### PR TITLE
If project has a gentype config, depend on sourcedirs.json meta

### DIFF
--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -93,11 +93,12 @@ let emit_module_build
   in
   let output_cmi =  output_filename_sans_extension ^ Literals.suffix_cmi in
   let output_cmj =  output_filename_sans_extension ^ Literals.suffix_cmj in
+  let rel_proj_dir = Ext_path.rel_normalized_absolute_path
+     ~from:(Ext_path.combine per_proj_dir module_info.dir)
+     per_proj_dir
+  in
   let maybe_gentype_deps = Option.map (fun _ ->
-    let rel_sourcedirs_dir = Ext_path.rel_normalized_absolute_path
-         ~from:(per_proj_dir // module_info.dir)
-         (per_proj_dir // Bsb_config.lib_bs // Literals.sourcedirs_meta) in
-    [rel_sourcedirs_dir]) gentype_config
+    [rel_proj_dir // Bsb_config.lib_bs // Literals.sourcedirs_meta ]) gentype_config
   in
   let output_js =
     Bsb_package_specs.get_list_of_output_js package_specs output_filename_sans_extension in
@@ -126,13 +127,7 @@ let emit_module_build
      (Ext_path.rel_normalized_absolute_path ~from:(per_proj_dir // cur_dir) dir) // Literals.bsb_world
   )
   in
-  let rel_bs_config_json =
-   Ext_path.combine
-    (Ext_path.rel_normalized_absolute_path
-       ~from:(Ext_path.combine per_proj_dir module_info.dir)
-       per_proj_dir)
-    Literals.bsconfig_json
-  in
+  let rel_bs_config_json = rel_proj_dir // Literals.bsconfig_json in
   let bs_dependencies = if is_dev then
     let dev_dependencies = Ext_list.map bs_dev_dependencies (fun dir ->
       (Ext_path.rel_normalized_absolute_path ~from:(per_proj_dir // cur_dir) dir) // Literals.bsb_world

--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -65,6 +65,7 @@ let emit_module_build
     (package_specs : Bsb_package_specs.t)
     (is_dev : bool)
     buf
+    ?gentype_config
     ~per_proj_dir
     ~bs_dependencies
     ~bs_dev_dependencies
@@ -92,9 +93,16 @@ let emit_module_build
   in
   let output_cmi =  output_filename_sans_extension ^ Literals.suffix_cmi in
   let output_cmj =  output_filename_sans_extension ^ Literals.suffix_cmj in
+  let maybe_gentype_deps = Option.map (fun _ ->
+    let rel_sourcedirs_dir = Ext_path.rel_normalized_absolute_path
+         ~from:(per_proj_dir // module_info.dir)
+         (per_proj_dir // Bsb_config.lib_bs // Literals.sourcedirs_meta) in
+    [rel_sourcedirs_dir]) gentype_config
+  in
   let output_js =
     Bsb_package_specs.get_list_of_output_js package_specs output_filename_sans_extension in
   Bsb_ninja_targets.output_build cur_dir buf
+    ~implicit_deps:(Option.value ~default:[] maybe_gentype_deps)
     ~outputs:[output_ast]
     ~inputs:[basename input_impl]
     ~rule:ast_rule;
@@ -216,6 +224,7 @@ let handle_files_per_dir
           ~per_proj_dir
           ~bs_dependencies
           ~bs_dev_dependencies
+          ?gentype_config:global_config.gentypeconfig
           js_post_build_cmd
           global_config.namespace module_info
         in

--- a/jscomp/main/bsb_main.ml
+++ b/jscomp/main/bsb_main.ml
@@ -193,7 +193,7 @@ let () =
             (if !watch_mode then
                 program_exit ()) (* bsb -verbose hit here *)
           else begin
-            (if make_world then
+            (if !generate_dune_bsb then
               config := Some (build_whole_project ~buf));
              if !watch_mode then begin
                program_exit ()
@@ -202,10 +202,12 @@ let () =
                   [bsb -clean-world]
                   [bsb -regen ]
                *)
-             end else if make_world then begin
-               ninja_command_exit [||]
-             end else if do_install then begin
-               install_target (maybe_generate_config !config)
+             end else begin
+               if do_install then
+                 install_target (maybe_generate_config !config);
+               if make_world then begin
+                 ninja_command_exit [||]
+               end
              end
           end
       end


### PR DESCRIPTION
- Right now it's assumed that the sourcedirs meta was generated in the first place. Therefore you have to run bsb with `bsb -install -make-world`. 
- I think we can always generate the `sourcedirs.json`, so I'll lift this restriction in a separate PR. 