### PR TITLE
Make `bsb` generated rules available for the 4.12.0+BS version only

### DIFF
--- a/jscomp/bsb/bsb_ninja_targets.ml
+++ b/jscomp/bsb/bsb_ninja_targets.ml
@@ -151,6 +151,7 @@ let output_alias ?action buf ~name ~deps =
        Buffer.add_string buf (Filename.basename x));
    Buffer.add_string buf ")"
   end;
+ Buffer.add_string buf (Format.asprintf "\n(enabled_if (= %%{ocaml_version} %S))" Sys.ocaml_version) ;
  Buffer.add_string buf ")"
 
 let output_build
@@ -207,6 +208,7 @@ let output_build
     rule
     buf
     cur_dir;
+  Buffer.add_string buf (Format.asprintf "\n(enabled_if (= %%{ocaml_version} %S))" Sys.ocaml_version) ;
   Buffer.add_string buf " )\n "
 
 

--- a/jscomp/bsb/bsb_ninja_targets.ml
+++ b/jscomp/bsb/bsb_ninja_targets.ml
@@ -22,6 +22,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+let enabled_if =
+  Format.asprintf "(enabled_if (= %%{ocaml_version} %S))" Sys.ocaml_version
 
 let oc_list xs  oc =
   Ext_list.iter xs (fun s -> output_string oc Ext_string.single_space ; output_string oc s)
@@ -151,7 +153,8 @@ let output_alias ?action buf ~name ~deps =
        Buffer.add_string buf (Filename.basename x));
    Buffer.add_string buf ")"
   end;
- Buffer.add_string buf (Format.asprintf "\n(enabled_if (= %%{ocaml_version} %S))" Sys.ocaml_version) ;
+ Buffer.add_char buf '\n';
+ Buffer.add_string buf enabled_if ;
  Buffer.add_string buf ")"
 
 let output_build
@@ -208,7 +211,8 @@ let output_build
     rule
     buf
     cur_dir;
-  Buffer.add_string buf (Format.asprintf "\n(enabled_if (= %%{ocaml_version} %S))" Sys.ocaml_version) ;
+  Buffer.add_char buf '\n';
+  Buffer.add_string buf enabled_if;
   Buffer.add_string buf " )\n "
 
 


### PR DESCRIPTION
This one is straightforward:
- Add an `(enabled_if (= %{ocaml_version} "4.12.0+BS"))` stanza to every generated rule

This effectively makes `bsb` generated rules invisible to native projects.

fixes #64 