### PR TITLE
README: Remove legacy and improve usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ to use it is via [Esy](https://esy.sh).
 }
 ```
 
-3. Reach out on the [ReasonML Discord](https://discord.gg/reasonml) if you
+3. Run `npm install` (or `yarn`) followed by just `esy` and after they finish installing and building, you should be able to use `bsb` commands via esy `esy bsb -make-world`
+
+4. Reach out on the [ReasonML Discord](https://discord.gg/reasonml) if you
    can't figure it out!
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 See [Credits.md](./Credits.md).
 
-## [Roadmap](https://github.com/rescript-lang/rescript-compiler/wiki)
-
 ## Licensing
 
 See [COPYING](./COPYING) and [COPYING.LESSER](./COPYING.LESSER)


### PR DESCRIPTION
This adds the extra steps that might not be immediately obvious to someone unused to using `esy` as well as remove the ROADMAP that was still pointing to rescript repo, we can add our ROADMAP later whenever we're ready with one