### PR TITLE
Format from / to all supported syntaxes

### DIFF
--- a/jscomp/common/js_config.ml
+++ b/jscomp/common/js_config.ml
@@ -38,7 +38,7 @@ let cross_module_inline = ref false
 
 
 let diagnose = ref false
-let get_diagnose () = 
+let get_diagnose () =
     !diagnose
 #if undefined BS_RELEASE_BUILD then
   || Sys.getenv_opt "RES_DEBUG_FILE" <> None
@@ -67,7 +67,7 @@ let binary_ast = ref false
 
 let debug = ref false
 
-let cmi_only = ref false  
+let cmi_only = ref false
 let cmj_only = ref false
 
 let force_cmi = ref false
@@ -86,10 +86,10 @@ let no_stdlib = ref false
 
 let no_export = ref false
 
-
+let format = ref None
 
 let as_ppx = ref false
 
 let mono_empty_array = ref true
 
-let customize_runtime = ref None 
+let customize_runtime = ref None

--- a/jscomp/common/js_config.mli
+++ b/jscomp/common/js_config.mli
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -31,32 +31,32 @@
 
 
 (** set/get header *)
-val no_version_header : bool ref 
+val no_version_header : bool ref
 
 
-(** return [package_name] and [path] 
-    when in script mode: 
+(** return [package_name] and [path]
+    when in script mode:
 *)
 
-(* val get_current_package_name_and_path : 
-  Js_packages_info.module_system -> 
+(* val get_current_package_name_and_path :
+  Js_packages_info.module_system ->
   Js_packages_info.info_query *)
 
 
-(* val set_package_name : string -> unit  
+(* val set_package_name : string -> unit
 val get_package_name : unit -> string option *)
 
 (** cross module inline option *)
 val cross_module_inline : bool ref
-  
+
 (** diagnose option *)
-val diagnose : bool ref 
-val get_diagnose : unit -> bool 
+val diagnose : bool ref
+val get_diagnose : unit -> bool
 (* val set_diagnose : bool -> unit  *)
 
 
 (** options for builtin ppx *)
-val no_builtin_ppx : bool ref 
+val no_builtin_ppx : bool ref
 
 
 
@@ -64,8 +64,8 @@ val no_builtin_ppx : bool ref
 
 
 (** check-div-by-zero option *)
-val check_div_by_zero : bool ref 
-val get_check_div_by_zero : unit -> bool 
+val check_div_by_zero : bool ref
+val get_check_div_by_zero : unit -> bool
 
 
 
@@ -81,23 +81,24 @@ val binary_ast : bool ref
 val debug : bool ref
 
 val cmi_only  : bool ref
-val cmj_only : bool ref 
+val cmj_only : bool ref
 (* stopped after generating cmj *)
-val force_cmi : bool ref 
+val force_cmi : bool ref
 val force_cmj : bool ref
 
 val jsx_version : int ref
 val refmt : string option ref
 
 
-val js_stdout : bool ref 
+val js_stdout : bool ref
 
-val all_module_aliases : bool ref 
+val all_module_aliases : bool ref
 
 val no_stdlib: bool ref
 val no_export: bool ref
 
-val as_ppx : bool ref 
+val format : Ext_file_extensions.syntax_kind option ref
+val as_ppx : bool ref
 
 val mono_empty_array : bool ref
-val customize_runtime : string option ref 
+val customize_runtime : string option ref

--- a/jscomp/ext/ext_file_extensions.ml
+++ b/jscomp/ext/ext_file_extensions.ml
@@ -1,5 +1,10 @@
-type valid_input = 
-  | Ml 
+type syntax_kind =
+  | Ml
+  | Reason
+  | Res
+
+type valid_input =
+  | Ml
   | Mli
   | Re
   | Rei
@@ -12,32 +17,32 @@ type valid_input =
   | Unknown
 
 
-(** This is per-file based, 
-    when [ocamlc] [-c -o another_dir/xx.cmi] 
+(** This is per-file based,
+    when [ocamlc] [-c -o another_dir/xx.cmi]
     it will return (another_dir/xx)
-*)    
+*)
 
-let classify_input ext = 
+let classify_input ext =
 
-  match () with 
-  | _ when ext = Literals.suffix_ml ->   
+  match () with
+  | _ when ext = Literals.suffix_ml ->
     Ml
   | _ when ext = Literals.suffix_re ->
     Re
   | _ when ext = !Config.interface_suffix ->
-    Mli  
+    Mli
   | _ when ext = Literals.suffix_rei ->
     Rei
   | _ when ext =  Literals.suffix_ast ->
-    Impl_ast 
+    Impl_ast
   | _ when ext = Literals.suffix_iast ->
     Intf_ast
   | _ when ext =  Literals.suffix_mlmap ->
-    Mlmap 
+    Mlmap
   | _ when ext =  Literals.suffix_cmi ->
     Cmi
-  | _ when ext = Literals.suffix_res -> 
+  | _ when ext = Literals.suffix_res ->
     Res
-  | _ when ext = Literals.suffix_resi -> 
-    Resi    
-  | _ -> Unknown  
+  | _ when ext = Literals.suffix_resi ->
+    Resi
+  | _ -> Unknown

--- a/jscomp/frontend/ast_reason_pp.ml
+++ b/jscomp/frontend/ast_reason_pp.ml
@@ -76,19 +76,13 @@ module Make(T: Reason_toolchain_conf.Toolchain) = struct
    in
    Reason_toolchain.To_current.copy_signature omp_ast, comments
 
- let format_implementation_with_comments ~comments ast =
-  let buf = Buffer.create 0x1000 in
-  let fmt = Format.formatter_of_buffer buf in
+ let format_implementation_with_comments fmt ~comments ast =
   let ast = Reason_toolchain.From_current.copy_structure ast in
-  T.print_implementation_with_comments fmt (ast, comments);
-  Buffer.contents buf
+  T.print_implementation_with_comments fmt (ast, comments)
 
- let format_interface_with_comments ~comments ast =
-  let buf = Buffer.create 0x1000 in
-  let fmt = Format.formatter_of_buffer buf in
+ let format_interface_with_comments fmt ~comments ast =
   let ast = Reason_toolchain.From_current.copy_signature ast in
-  T.print_interface_with_comments fmt (ast, comments);
-  Buffer.contents buf
+  T.print_interface_with_comments fmt (ast, comments)
 
  let format ~parser ~printer filename =
    let parse_result = setup_lexbuf ~parser filename in

--- a/jscomp/frontend/ast_reason_pp.mli
+++ b/jscomp/frontend/ast_reason_pp.mli
@@ -25,10 +25,27 @@
 
 exception Pp_error
 
-val parse_implementation : string -> Parsetree.structure
-val parse_interface : string -> Parsetree.signature
-val format_implementation : string -> string
-val format_interface : string -> string
+module ML : sig
+  val parse_implementation : string -> Parsetree.structure
+  val parse_interface : string -> Parsetree.signature
+  val parse_implementation_with_comments : string -> Parsetree.structure * Reason_comment.t list
+  val parse_interface_with_comments : string -> Parsetree.signature * Reason_comment.t list
+  val format_implementation_with_comments : comments:Reason_comment.t list -> Parsetree.structure -> string
+  val format_interface_with_comments : comments:Reason_comment.t list -> Parsetree.signature -> string
+  val format_implementation : string -> string
+  val format_interface : string -> string
+end
+
+module RE : sig
+  val parse_implementation : string -> Parsetree.structure
+  val parse_interface : string -> Parsetree.signature
+  val parse_implementation_with_comments : string -> Parsetree.structure * Reason_comment.t list
+  val parse_interface_with_comments : string -> Parsetree.signature * Reason_comment.t list
+  val format_implementation_with_comments : comments:Reason_comment.t list -> Parsetree.structure -> string
+  val format_interface_with_comments : comments:Reason_comment.t list -> Parsetree.signature -> string
+  val format_implementation : string -> string
+  val format_interface : string -> string
+end
 
 val clean:
   string ->

--- a/jscomp/frontend/ast_reason_pp.mli
+++ b/jscomp/frontend/ast_reason_pp.mli
@@ -30,8 +30,8 @@ module ML : sig
   val parse_interface : string -> Parsetree.signature
   val parse_implementation_with_comments : string -> Parsetree.structure * Reason_comment.t list
   val parse_interface_with_comments : string -> Parsetree.signature * Reason_comment.t list
-  val format_implementation_with_comments : comments:Reason_comment.t list -> Parsetree.structure -> string
-  val format_interface_with_comments : comments:Reason_comment.t list -> Parsetree.signature -> string
+  val format_implementation_with_comments : Format.formatter -> comments:Reason_comment.t list -> Parsetree.structure -> unit
+  val format_interface_with_comments : Format.formatter -> comments:Reason_comment.t list -> Parsetree.signature -> unit
   val format_implementation : string -> string
   val format_interface : string -> string
 end
@@ -41,8 +41,8 @@ module RE : sig
   val parse_interface : string -> Parsetree.signature
   val parse_implementation_with_comments : string -> Parsetree.structure * Reason_comment.t list
   val parse_interface_with_comments : string -> Parsetree.signature * Reason_comment.t list
-  val format_implementation_with_comments : comments:Reason_comment.t list -> Parsetree.structure -> string
-  val format_interface_with_comments : comments:Reason_comment.t list -> Parsetree.signature -> string
+  val format_implementation_with_comments : Format.formatter -> comments:Reason_comment.t list -> Parsetree.structure -> unit
+  val format_interface_with_comments : Format.formatter -> comments:Reason_comment.t list -> Parsetree.signature -> unit
   val format_implementation : string -> string
   val format_interface : string -> string
 end

--- a/jscomp/main/js_main.ml
+++ b/jscomp/main/js_main.ml
@@ -387,7 +387,17 @@ let buckle_script_flags : (string * Bsc_args.spec * string) array =
     "-dsource", set Clflags.dump_source,
     "*internal* print source";
 
-    "-format", string_call format_file,
+    "-format", string_call (fun ext ->
+      let syntax: Ext_file_extensions.syntax_kind = match Ext_string.trim ext with
+      | "re" -> Reason
+      | "res" -> Res
+      | "ml" -> Ml
+      | x ->
+        Location.raise_errorf
+          "invalid option `%s` passed to -format, expected `re`, `res` or `ml`"
+          x
+      in
+      Js_config.format := Some syntax),
     "Format as Res syntax";
 
     "-where", unit_call print_standard_library,

--- a/jscomp/main/js_main.ml
+++ b/jscomp/main/js_main.ml
@@ -135,79 +135,75 @@ let print_res_implementation ~comments ast =
 let format_file ~(kind: Ext_file_extensions.syntax_kind) input =
   let ext = Ext_file_extensions.classify_input (Ext_filename.get_extension_maybe input) in
   let impl_format_fn ~comments ast =
+    let std = Format.std_formatter in
     match kind, comments with
     | Ml, `Re comments ->
-      Ast_reason_pp.ML.format_implementation_with_comments ~comments ast
+      Ast_reason_pp.ML.format_implementation_with_comments std ~comments ast
     | Ml, `Res _ ->
-      Ast_reason_pp.ML.format_implementation_with_comments ~comments:[] ast
+      Ast_reason_pp.ML.format_implementation_with_comments std ~comments:[] ast
     | Res, `Res comments ->
       let ast = From_current.copy_structure ast in
-      print_res_implementation ~comments ast
+      output_string stdout (print_res_implementation ~comments ast)
     | Res, `Re _ ->
       let ast = From_current.copy_structure ast in
-      print_res_implementation ~comments:[] ast
+      output_string stdout (print_res_implementation ~comments:[] ast)
     | Reason, `Re comments ->
-      Ast_reason_pp.RE.format_implementation_with_comments ~comments ast
+      Ast_reason_pp.RE.format_implementation_with_comments std ~comments ast
     | Reason, `Res _ ->
-      Ast_reason_pp.RE.format_implementation_with_comments ~comments:[] ast
+      Ast_reason_pp.RE.format_implementation_with_comments std ~comments:[] ast
     | _ -> Bsc_args.bad_arg ("don't know what to do with " ^ input)
   in
   let intf_format_fn ~comments ast =
+    let std = Format.std_formatter in
     match kind, comments with
     | Ml, `Re comments ->
-      Ast_reason_pp.ML.format_interface_with_comments ~comments ast
+      Ast_reason_pp.ML.format_interface_with_comments std ~comments ast
     | Ml, `Res _ ->
-      Ast_reason_pp.ML.format_interface_with_comments ~comments:[] ast
+      Ast_reason_pp.ML.format_interface_with_comments std ~comments:[] ast
     | Res, `Res comments ->
       let ast = From_current.copy_signature ast in
-      print_res_interface ~comments ast
+      output_string stdout (print_res_interface ~comments ast)
     | Res, `Re _ ->
       let ast = From_current.copy_signature ast in
-      print_res_interface ~comments:[] ast
+      output_string stdout (print_res_interface ~comments:[] ast)
     | Reason, `Re comments ->
-      Ast_reason_pp.RE.format_interface_with_comments ~comments ast
+      Ast_reason_pp.RE.format_interface_with_comments std ~comments ast
     | Reason, `Res _ ->
-      Ast_reason_pp.RE.format_interface_with_comments ~comments:[] ast
+      Ast_reason_pp.RE.format_interface_with_comments std ~comments:[] ast
     | _ -> Bsc_args.bad_arg ("don't know what to do with " ^ input)
   in
-  match ext with
+  begin match ext with
   | Ml ->
     let ast, comments =
       Ast_reason_pp.ML.parse_implementation_with_comments input
     in
-    output_string stdout (impl_format_fn ~comments:(`Re comments) ast)
+    impl_format_fn ~comments:(`Re comments) ast
   | Mli ->
     let ast, comments = Ast_reason_pp.ML.parse_interface_with_comments input in
-    output_string stdout (intf_format_fn ~comments:(`Re comments) ast)
+    intf_format_fn ~comments:(`Re comments) ast
   | Res ->
     let parse_result =
       Res_driver.parsingEngine.parseImplementation ~forPrinter:true ~filename:input
     in
     handle_res_parse_result parse_result;
-    let s =
-      impl_format_fn
-        ~comments:(`Res parse_result.comments)
-        parse_result.parsetree
-    in
-    output_string stdout s
+    impl_format_fn
+      ~comments:(`Res parse_result.comments)
+      parse_result.parsetree
   | Resi ->
     let parse_result =
       Res_driver.parsingEngine.parseInterface ~forPrinter:true ~filename:input
     in
-    handle_res_parse_result parse_result;
-    let s =
-      intf_format_fn
-        ~comments:(`Res parse_result.comments)
-         parse_result.parsetree
-    in
-    output_string stdout s
+    intf_format_fn
+      ~comments:(`Res parse_result.comments)
+       parse_result.parsetree
   | Re ->
     let ast, comments = Ast_reason_pp.RE.parse_implementation_with_comments input in
-    output_string stdout (impl_format_fn ~comments:(`Re comments) ast)
+    impl_format_fn ~comments:(`Re comments) ast
   | Rei ->
     let ast, comments = Ast_reason_pp.RE.parse_interface_with_comments input in
-    output_string stdout (intf_format_fn ~comments:(`Re comments) ast)
+    intf_format_fn ~comments:(`Re comments) ast
   | _ -> Bsc_args.bad_arg ("don't know what to do with " ^ input)
+  end
 
 let anonymous ~(rev_args : string list) =
   if !Js_config.as_ppx then


### PR DESCRIPTION
- Adds support for parsing / printing from / to all supported syntaxes in `bsc`
  - caveat: res / reason don't interop so well. Right now comments aren't preserved when converting between these. It works OK for OCaml <-> Reason
- further work: if folks end up using this feature, we can write a res <-> reason comment converter in order to support comments from res <-> re