### PR TITLE
only use @bs.deriving, because of collisions with `ppxlib`

### DIFF
--- a/jscomp/frontend/ast_attributes.ml
+++ b/jscomp/frontend/ast_attributes.ml
@@ -170,7 +170,7 @@ let process_derive_type (attrs : t) : derive_attr * t =
   Ext_list.fold_left attrs ({bs_deriving = None }, [])
     (fun (st, acc) ({ attr_name = {txt ; loc}; attr_payload = payload}  as attr)  ->
        match   txt  with
-       |  "bs.deriving" | "deriving"
+       |  "bs.deriving"
          ->
          begin match st.bs_deriving with
            |  None ->

--- a/jscomp/frontend/ast_attributes.ml
+++ b/jscomp/frontend/ast_attributes.ml
@@ -170,7 +170,7 @@ let process_derive_type (attrs : t) : derive_attr * t =
   Ext_list.fold_left attrs ({bs_deriving = None }, [])
     (fun (st, acc) ({ attr_name = {txt ; loc}; attr_payload = payload}  as attr)  ->
        match   txt  with
-       |  "bs.deriving"
+       |  "bs.deriving" | "deriving"
          ->
          begin match st.bs_deriving with
            |  None ->

--- a/jscomp/napkin/res_printer.ml
+++ b/jscomp/napkin/res_printer.ml
@@ -22,7 +22,8 @@ type callbackStyle =
   https://github.com/rescript-lang/rescript-compiler/blob/29174de1a5fde3b16cf05d10f5ac109cfac5c4ca/jscomp/frontend/ast_external_process.ml#L291-L367 *)
 let convertBsExternalAttribute = function
   | "bs.as" -> "as"
-  | "bs.deriving" -> "deriving"
+  (* @deriving collides with ppxlib ppx's *)
+  | "bs.deriving" -> "bs.deriving"
   | "bs.get" -> "get"
   | "bs.get_index" -> "get_index"
   | "bs.ignore" -> "ignore"


### PR DESCRIPTION
Given the compatibility with OCaml it is probably also good to just keep `bs.deriving`.
