### PR TITLE
RFC: run the Melange builtin PPX before applying other PPX transforms

### DIFF
--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -108,8 +108,8 @@ let interface ~parser ppf ?outputprefix fname  =
     | Some x -> x in
   Res_compmisc.init_path ();
   parser fname
-  |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name Mli
   |> Ppx_entry.rewrite_signature
+  |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name Mli
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.interface
   |> print_if_pipe ppf Clflags.dump_source Pprintast.signature
   |> after_parsing_sig ppf  outputprefix
@@ -206,8 +206,8 @@ let implementation ~parser ppf ?outputprefix fname   =
       | Some x -> x in
   Res_compmisc.init_path ();
   parser fname
-  |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name Ml
   |> Ppx_entry.rewrite_implementation
+  |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name Ml
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.implementation
   |> print_if_pipe ppf Clflags.dump_source Pprintast.structure
   |> after_parsing_impl ppf outputprefix


### PR DESCRIPTION
This implements the proposal outlined in https://github.com/melange-re/melange/pull/90#issuecomment-809714966.

It runs the Melange builtin PPX (which removes Melange-specific `[@deriving]` attributes ) before applying external PPX transformations.


I'm not immediately sure what the implications of this are, so it would be great to do some extensive testing on a few codebases to make sure everything is working as before.

If it all works as expected, this could be a nice solution to https://github.com/rescript-lang/rescript-compiler/issues/5036
