### PR TITLE
Compatibility with ppxlib derivers

### DIFF
--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -108,6 +108,7 @@ let interface ~parser ppf ?outputprefix fname  =
     | Some x -> x in
   Res_compmisc.init_path ();
   parser fname
+  |> Ast_deriving_compat.mapper.signature Ast_deriving_compat.mapper
   |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name Mli
   |> Ppx_entry.rewrite_signature
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.interface
@@ -206,6 +207,7 @@ let implementation ~parser ppf ?outputprefix fname   =
       | Some x -> x in
   Res_compmisc.init_path ();
   parser fname
+  |> Ast_deriving_compat.mapper.structure Ast_deriving_compat.mapper
   |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name Ml
   |> Ppx_entry.rewrite_implementation
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.implementation

--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -108,7 +108,7 @@ let interface ~parser ppf ?outputprefix fname  =
     | Some x -> x in
   Res_compmisc.init_path ();
   parser fname
-  |> Ast_deriving_compat.mapper.signature Ast_deriving_compat.mapper
+  |> Ast_deriving_compat.signature
   |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name Mli
   |> Ppx_entry.rewrite_signature
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.interface
@@ -207,7 +207,7 @@ let implementation ~parser ppf ?outputprefix fname   =
       | Some x -> x in
   Res_compmisc.init_path ();
   parser fname
-  |> Ast_deriving_compat.mapper.structure Ast_deriving_compat.mapper
+  |> Ast_deriving_compat.structure
   |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name Ml
   |> Ppx_entry.rewrite_implementation
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.implementation

--- a/jscomp/frontend/ast_derive.ml
+++ b/jscomp/frontend/ast_derive.ml
@@ -40,6 +40,11 @@ type derive_table  =
 
 let derive_table : derive_table ref = ref Map_string.empty
 
+let is_builtin_deriver key =
+  Map_string.mem !derive_table key ||
+  (* abstract is treated specially *)
+  key = "abstract"
+
 let register key value =
   derive_table := Map_string.add !derive_table key value
 

--- a/jscomp/frontend/ast_deriving_compat.ml
+++ b/jscomp/frontend/ast_deriving_compat.ml
@@ -47,6 +47,7 @@ let type_declaration_mapper (_self : mapper) (tdcl : Parsetree.type_declaration)
                  )
              | Some _ -> []
            end
+         (* [@@deriving abstract] *)
          | PStr [ {pstr_desc = Pstr_eval ({
                     pexp_desc =
                       Pexp_ident ({txt = Lident txt; _});

--- a/jscomp/frontend/ast_deriving_compat.ml
+++ b/jscomp/frontend/ast_deriving_compat.ml
@@ -67,21 +67,7 @@ let type_declaration_mapper (_self : mapper) (tdcl : Parsetree.type_declaration)
 let  mapper : mapper =
   { default_mapper with type_declaration = type_declaration_mapper; }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+let structure ast =
+  mapper.structure mapper ast
+let signature ast =
+  mapper.signature mapper ast

--- a/jscomp/frontend/ast_deriving_compat.ml
+++ b/jscomp/frontend/ast_deriving_compat.ml
@@ -33,6 +33,7 @@ let type_declaration_mapper (_self : mapper) (tdcl : Parsetree.type_declaration)
        let txt' = match txt with
        | "deriving" ->
          let deriver = begin match payload with
+         (* [@@deriving {abstract = light}] *)
          | PStr [ {pstr_desc = Pstr_eval ({pexp_desc = Pexp_record (label_exprs, with_obj)}, _); _ }] ->
            begin match with_obj with
              | None ->

--- a/jscomp/frontend/ast_deriving_compat.ml
+++ b/jscomp/frontend/ast_deriving_compat.ml
@@ -1,0 +1,87 @@
+(* Copyright (C) 2021- Authors of Melange
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+type mapper = Bs_ast_mapper.mapper
+let default_mapper = Bs_ast_mapper.default_mapper
+
+let type_declaration_mapper (_self : mapper) (tdcl : Parsetree.type_declaration) =
+  let attributes = Ext_list.map tdcl.ptype_attributes
+    (fun ({ attr_name = {txt ; loc}; attr_payload = payload}  as attr)  ->
+       let txt' = match txt with
+       | "deriving" ->
+         let deriver = begin match payload with
+         | PStr [ {pstr_desc = Pstr_eval ({pexp_desc = Pexp_record (label_exprs, with_obj)}, _); _ }] ->
+           begin match with_obj with
+             | None ->
+               Ext_list.filter_map label_exprs
+                 (fun u  ->
+                    match u with
+                    | ({txt = Lident name; _}) ,
+                      ({Parsetree.pexp_desc = Pexp_ident{txt = Lident name2}} )
+                      when name2 = name -> Some name
+                    | ({txt = Lident name; _}), _ -> Some name
+                    | _ -> None
+                 )
+             | Some _ -> []
+           end
+         | PStr [ {pstr_desc = Pstr_eval ({
+                    pexp_desc =
+                      Pexp_ident ({txt = Lident txt; _});
+                  }, _) } ] -> [ txt ]
+         | _ -> []
+       end in
+       if Ext_list.exists deriver Ast_derive.is_builtin_deriver then
+         "bs.deriving"
+       else
+         "deriving"
+      | x -> x
+      in
+      { attr with attr_name = {txt=txt' ; loc}})
+  in
+  { tdcl with ptype_attributes = attributes }
+
+
+let  mapper : mapper =
+  { default_mapper with type_declaration = type_declaration_mapper; }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/jscomp/frontend/ast_deriving_compat.mli
+++ b/jscomp/frontend/ast_deriving_compat.mli
@@ -24,4 +24,6 @@
 
 
 
-val mapper: Bs_ast_mapper.mapper
+val structure: Parsetree.structure -> Parsetree.structure
+val signature: Parsetree.signature -> Parsetree.signature
+

--- a/jscomp/frontend/ast_deriving_compat.mli
+++ b/jscomp/frontend/ast_deriving_compat.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+(* Copyright (C) 2021- Authors of Melange
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,41 +22,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type tdcls = Parsetree.type_declaration list
-
-type gen = {
-  structure_gen : tdcls -> Asttypes.rec_flag -> Ast_structure.t ;
-  signature_gen : tdcls -> Asttypes.rec_flag -> Ast_signature.t ;
-  expression_gen : (Parsetree.core_type -> Parsetree.expression) option ;
-}
-
-val is_builtin_deriver: string -> bool
-(**
-   [register name cb]
-   example: [register "accessors" cb]
-*)
-val register :
-  string ->
-  (Parsetree.expression option -> gen) ->
-  unit
-
-(* val gen_structure:
-  tdcls  ->
-  Ast_payload.action list ->
-  bool ->
-  Ast_structure.t *)
-
-val gen_signature:
-  tdcls ->
-  Ast_payload.action list ->
-  Asttypes.rec_flag ->
-  Ast_signature.t
 
 
-
-val gen_structure_signature :
-  Location.t ->
-  Parsetree.type_declaration list ->
-  Ast_payload.action ->
-  Asttypes.rec_flag ->
-  Parsetree.structure_item option
+val mapper: Bs_ast_mapper.mapper


### PR DESCRIPTION
This change implements @mathspy's suggestion from https://github.com/melange-re/melange/pull/93#issuecomment-809909358.

To avoid ppxlib failing when it doesn't recognize a Melange / ReScript deriver (e.g. `accessors`, `abstract`, `jsConverter`), we convert those from `[@"deriving" ...]` to `[@bs.deriving ...]` before applying the PPX pass.

This is a compatibility-focused fix for https://github.com/rescript-lang/rescript-compiler/issues/5036