### PR TITLE
docs: Update README to use new esy workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,8 @@ to use it is via [Esy](https://esy.sh).
 {
   "dependencies": {
     "ocaml": "4.12.x",
-    "melange": "*"
-  },
-  "resolutions": {
-    "melange": "melange-re/melange#HASH_HERE", <- or grab the latest commit in this repo
+    "melange": "melange-re/melange",
+    "@opam/ocaml-lsp-server": "*"
   },
   "esy": {
     "buildsInSource": "unsafe",

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ to use it is via [Esy](https://esy.sh).
 
 ```json
 {
+  "name": "melange-project",
   "dependencies": {
     "ocaml": "4.12.x",
     "melange": "melange-re/melange",
@@ -26,9 +27,7 @@ to use it is via [Esy](https://esy.sh).
   },
   "esy": {
     "buildsInSource": "unsafe",
-    "build": [
-      "ln -sfn #{melange.install} node_modules/bs-platform"
-    ]
+    "build": ["ln -sfn #{melange.install} node_modules/bs-platform"]
   },
   "installConfig": {
     "pnp": false
@@ -45,13 +44,13 @@ to use it is via [Esy](https://esy.sh).
 
 ### How does this project relate to other tools?
 
-| Name  | Purpose  | Dependencies  |  Notes |
-|---|---|---|---|
-| [Esy](https://esy.sh)  | Package manager |  Installed with NPM |  Obtaining dependencies (e.g. `dune` or `reason`)  |
-| [Dune](https://dune.build/)  | Build tool  | Installed with `esy` | Well-known OCaml build tool; supports custom rules that can be composed to build _anything_ |
-|  [Reason](https://reasonml.github.io/) | Syntax  |  Installed with `esy` | a library that implements an alternative syntax to OCaml  |
-|  [Melange](https://melange.re) | Compiler that emits JavaScript  |  Esy (to install), Dune (to build), Reason (used as a library) |  Supports OCaml, Reason and ReScript syntaxes; derived from ReScript, focused on compatibility with the wider OCaml ecosystem |
-|  [ReScript](https://rescript-lang.org/) | The brand around a syntax and a compiler that emits JavaScript  | None | Distributed via NPM as prebuilt binaries; previously called BuckleScript |
+| Name                                   | Purpose                                                        | Dependencies                                                  | Notes                                                                                                                        |
+| -------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [Esy](https://esy.sh)                  | Package manager                                                | Installed with NPM                                            | Obtaining dependencies (e.g. `dune` or `reason`)                                                                             |
+| [Dune](https://dune.build/)            | Build tool                                                     | Installed with `esy`                                          | Well-known OCaml build tool; supports custom rules that can be composed to build _anything_                                  |
+| [Reason](https://reasonml.github.io/)  | Syntax                                                         | Installed with `esy`                                          | a library that implements an alternative syntax to OCaml                                                                     |
+| [Melange](https://melange.re)          | Compiler that emits JavaScript                                 | Esy (to install), Dune (to build), Reason (used as a library) | Supports OCaml, Reason and ReScript syntaxes; derived from ReScript, focused on compatibility with the wider OCaml ecosystem |
+| [ReScript](https://rescript-lang.org/) | The brand around a syntax and a compiler that emits JavaScript | None                                                          | Distributed via NPM as prebuilt binaries; previously called BuckleScript                                                     |
 
 ### Can I use ReScript syntax?
 


### PR DESCRIPTION
Because we don't use resolutions anymore there is no need to add resolutions, also ocaml-lsp for 4.12 was released.

This is finally starting to look like a nice workflow.