### PR TITLE
specify :standard for dune dirs

### DIFF
--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -242,7 +242,7 @@ let handle_files_per_dir
     Buffer.add_string buf rel_group_dir;
     Buffer.add_char buf '\n';
     if group.subdirs <> [] then begin
-      Buffer.add_string buf "(dirs";
+      Buffer.add_string buf "(dirs :standard";
       Ext_list.iter group.subdirs (fun subdir ->
         Buffer.add_char buf ' ';
         Buffer.add_string buf subdir);


### PR DESCRIPTION
If `"sources"` looks like:

```json
  "sources": [
    {
      "dir": "src",
      "subdirs": [ "a" ]
    },
    {
      "dir": "src/pages",
    }
  ]
```

we were effectively ignoring the `src/pages` directory. the `(dirs` stanza was added to fix #70 because Dune ignores directories starting with `_` by default, but including only the ones we know from `subdirs` is clearly not enough.