### PR TITLE
bsb: declare add an empty `bsb_world` alias to avoid hard failure

### DIFF
--- a/jscomp/main/bsb_main.ml
+++ b/jscomp/main/bsb_main.ml
@@ -61,7 +61,11 @@ let output_dune_project_if_does_not_exist proj_dir =
 let output_dune_file buf =
   let proj_dir =  Bsb_global_paths.cwd in
   let dune_bsb = proj_dir // Literals.dune_bsb in
-  Buffer.add_string buf "\n(data_only_dirs node_modules)";
+  Buffer.add_string buf "\n(data_only_dirs node_modules)\n";
+  (* for the edge case of empty sources (either in user config or because a
+     source dir is empty), we emit an empty `bsb_world` alias. This avoids
+     showing the user an error when they haven't done anything. *)
+  Buffer.add_string buf "\n(alias (name bsb_world))\n";
   Bsb_ninja_targets.revise_dune dune_bsb buf;
   let dune = proj_dir // Literals.dune in
   let buf = Buffer.create 256 in


### PR DESCRIPTION
Reproducing the comment I added:

> for the edge case of empty sources (either in user config or because a
     source dir is empty), we emit an empty `bsb_world` alias. This avoids
     showing the user an error when they haven't done anything. 