### PR TITLE
simplify esy-build CI

### DIFF
--- a/.github/workflows/esy-build.yml
+++ b/.github/workflows/esy-build.yml
@@ -28,11 +28,5 @@ jobs:
         run: npm install -g esy
 
       - uses: esy/github-action@master
-        if: ${{ matrix.system != 'macos-arm64' }}
-        with:
-          cache-key: ${{ hashFiles('esy.lock/index.json') }}
-
-      - uses: EduardoRFS/github-action@0e5336e318d2f648cf881ab85ece10f51e369b17
-        if: ${{ matrix.system == 'macos-arm64' }}
         with:
           cache-key: ${{ hashFiles('esy.lock/index.json') }}


### PR DESCRIPTION
The fork of the esy action was adding `arch -arm64` on every esy call, this is not needed anymore as I recently moved the wrapper from the action to the CI machine itself as it is more reliable and the machine can then be shared with other repositories.
