### PR TITLE
Fix relative path calculation in the presence of `.`

### DIFF
--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -25,6 +25,12 @@
 let basename = Filename.basename
 let (//) = Ext_path.combine
 
+let rel_dependencies_alias ~proj_dir ~cur_dir deps =
+  Ext_list.map deps (fun dir ->
+   let rel_dir =
+     Ext_path.rel_normalized_absolute_path ~from:(proj_dir // cur_dir) dir
+   in
+   rel_dir // Literals.bsb_world)
 
 
 let handle_generators buf
@@ -152,13 +158,11 @@ let emit_module_build
       (ns ^ Literals.suffix_cmi) ]
    | None -> []
    in
-  let bs_dependencies = Ext_list.map bs_dependencies (fun dir ->
-     (Ext_path.rel_normalized_absolute_path ~from:(per_proj_dir // cur_dir) dir) // Literals.bsb_world)
-  in
   let rel_bs_config_json = rel_proj_dir // Literals.bsconfig_json in
+  let bs_dependencies = rel_dependencies_alias ~proj_dir:per_proj_dir ~cur_dir bs_dependencies in
   let bs_dependencies = if is_dev then
-    let dev_dependencies = Ext_list.map bs_dev_dependencies (fun dir ->
-      (Ext_path.rel_normalized_absolute_path ~from:(per_proj_dir // cur_dir) dir) // Literals.bsb_world)
+    let dev_dependencies =
+      rel_dependencies_alias ~proj_dir:per_proj_dir ~cur_dir bs_dev_dependencies
     in
     dev_dependencies @ bs_dependencies
   else

--- a/jscomp/ext/ext_path.ml
+++ b/jscomp/ext/ext_path.ml
@@ -192,6 +192,12 @@ let split_aux p =
    [amdjs-global] format and tailored for `rollup`
 *)
 let rel_normalized_absolute_path ~from to_ =
+  let merge_parent_segment acc segment =
+    if segment = Filename.current_dir_name then
+      acc
+    else
+      acc // Ext_string.parent_dir_lit
+  in
   let root1, paths1 = split_aux from in
   let root2, paths2 = split_aux to_ in
   if root1 <> root2 then root2
@@ -204,18 +210,14 @@ let rel_normalized_absolute_path ~from to_ =
         else if y = Filename.current_dir_name then go xss ys
         else
           let start =
-            Ext_list.fold_left xs Ext_string.parent_dir_lit (fun acc  _  -> acc // Ext_string.parent_dir_lit )
+            Ext_list.fold_left xs Ext_string.parent_dir_lit merge_parent_segment
           in
           Ext_list.fold_left yss start (fun acc v -> acc // v)
       | [], [] -> Ext_string.empty
       | [], y::ys -> Ext_list.fold_left ys y (fun acc x -> acc // x)
       | x::xs, [] ->
         let start = if x = Filename.current_dir_name then "" else Ext_string.parent_dir_lit in
-        Ext_list.fold_left xs start (fun acc segment ->
-          if segment = Filename.current_dir_name then
-            acc
-          else
-            acc // Ext_string.parent_dir_lit )
+        Ext_list.fold_left xs start merge_parent_segment
      in
     let v =  go paths1 paths2  in
 

--- a/jscomp/ounit_tests/ounit_path_tests.ml
+++ b/jscomp/ounit_tests/ounit_path_tests.ml
@@ -3,17 +3,17 @@ let ((>::),
 
 
 let normalize = Ext_path.normalize_absolute_path
-let (=~) x y = 
-  OUnit.assert_equal 
+let (=~) x y =
+  OUnit.assert_equal
   ~printer:(fun x -> x)
   ~cmp:(fun x y ->   Ext_string.equal x y ) x y
 
-let suites = 
-  __FILE__ 
+let suites =
+  __FILE__
   >:::
   [
-    "linux path tests" >:: begin fun _ -> 
-      let norm = 
+    "linux path tests" >:: begin fun _ ->
+      let norm =
         Array.map normalize
           [|
             "/gsho/./..";
@@ -26,8 +26,8 @@ let suites =
             "/a";
             "/a.txt/";
             "/a.txt"
-          |] in 
-      OUnit.assert_equal norm 
+          |] in
+      OUnit.assert_equal norm
         [|
           "/";
           "/a/c../d/e/f";
@@ -44,18 +44,18 @@ let suites =
     __LOC__ >:: begin fun _ ->
       normalize "/./a/.////////j/k//../////..///././b/./c/d/./." =~ "/a/b/c/d"
     end;
-    __LOC__ >:: begin fun _ -> 
+    __LOC__ >:: begin fun _ ->
       normalize "/./a/.////////j/k//../////..///././b/./c/d/././../" =~ "/a/b/c"
     end;
 
-    __LOC__ >:: begin fun _ -> 
-      let aux a b result = 
+    __LOC__ >:: begin fun _ ->
+      let aux a b result =
 
         Ext_path.rel_normalized_absolute_path
-          ~from:a b =~ result ; 
+          ~from:a b =~ result ;
 
         Ext_path.rel_normalized_absolute_path
-          ~from:(String.sub a 0 (String.length a - 1)) 
+          ~from:(String.sub a 0 (String.length a - 1))
           b  =~ result ;
 
         Ext_path.rel_normalized_absolute_path
@@ -67,8 +67,8 @@ let suites =
         Ext_path.rel_normalized_absolute_path
           ~from:(String.sub a 0 (String.length a - 1 ))
           (String.sub b 0 (String.length b - 1))
-        =~ result  
-      in   
+        =~ result
+      in
       aux
         "/a/b/c/"
         "/a/b/c/d/"  "./d";
@@ -80,27 +80,35 @@ let suites =
         "/a/b/c/"  ".."  ;
       aux
         "/a/b/c/d/"
-        "/a/b/"  "../.."  ;  
+        "/a/b/"  "../.."  ;
       aux
         "/a/b/c/d/"
-        "/a/"  "../../.."  ;  
+        "/a/"  "../../.."  ;
       aux
         "/a/b/c/d/"
-        "//"  "../../../.."  ;  
-
+        "//"  "../../../.."  ;
 
     end;
-    (* This is still correct just not optimal depends 
+    (* This is still correct just not optimal depends
        on user's perspective *)
-    __LOC__ >:: begin fun _ -> 
-      Ext_path.rel_normalized_absolute_path 
+    __LOC__ >:: begin fun _ ->
+      Ext_path.rel_normalized_absolute_path
         ~from:"/a/b/c/d"
-        "/x/y" =~ "../../../../x/y"  
+        "/x/y" =~ "../../../../x/y";
 
+      Ext_path.rel_normalized_absolute_path
+             ~from:"/a/b/c/d/e/./src/bindings/Navigation"
+             "/a/b/c/d/e" =~ "../../..";
+
+      Ext_path.rel_normalized_absolute_path
+        ~from:"/a/b/c/./d" "/a/b/c" =~ ".." ;
+
+      Ext_path.rel_normalized_absolute_path
+        ~from:"/a/b/c/./src" "/a/b/d/./src" =~ "../../d/src" ;
     end;
 
-    (* used in module system: [es6-global] and [amdjs-global] *)    
-    __LOC__ >:: begin fun _ -> 
+    (* used in module system: [es6-global] and [amdjs-global] *)
+    __LOC__ >:: begin fun _ ->
       Ext_path.rel_normalized_absolute_path
         ~from:"/usr/local/lib/node_modules/"
         "//" =~ "../../../..";
@@ -112,16 +120,16 @@ let suites =
         "./node_modules/xx/./xx.js" =~ "./node_modules/xx/xx.js";
       Ext_path.rel_normalized_absolute_path
         ~from:"././"
-        "./node_modules/xx/./xx.js" =~ "./node_modules/xx/xx.js"        
+        "./node_modules/xx/./xx.js" =~ "./node_modules/xx/xx.js"
     end;
 
-     __LOC__ >:: begin fun _ -> 
+     __LOC__ >:: begin fun _ ->
       Ext_path.node_rebase_file
         ~to_:( "lib/js/src/a")
         ~from:( "lib/js/src") "b" =~ "./a/b" ;
       Ext_path.node_rebase_file
         ~to_:( "lib/js/src/")
-        ~from:( "lib/js/src") "b" =~ "./b" ;          
+        ~from:( "lib/js/src") "b" =~ "./b" ;
       Ext_path.node_rebase_file
         ~to_:( "lib/js/src")
         ~from:("lib/js/src/a") "b" =~ "../b";
@@ -129,7 +137,7 @@ let suites =
         ~to_:( "lib/js/src/a")
         ~from:("lib/js/") "b" =~ "./src/a/b" ;
       Ext_path.node_rebase_file
-        ~to_:("lib/js/./src/a") 
+        ~to_:("lib/js/./src/a")
         ~from:("lib/js/src/a/") "b"
         =~ "./b";
 
@@ -141,5 +149,5 @@ let suites =
         ~to_:"lib/js/src/a/"
         ~from:"lib/js/src/a/" "b"
       =~ "./b"
-    end     
+    end
   ]


### PR DESCRIPTION
This is the same bug that I fixed in #60, but in another branch of the same function.

I made sure to add tests for the fix in #60 and for the case we found today.