### PR TITLE
Run tests on CI with esy 

### DIFF
--- a/.github/workflows/esy-build.yml
+++ b/.github/workflows/esy-build.yml
@@ -30,3 +30,6 @@ jobs:
       - uses: esy/github-action@master
         with:
           cache-key: ${{ hashFiles('esy.lock/index.json') }}
+
+      - name: Run tests
+        run: esy test

--- a/.github/workflows/esy-build.yml
+++ b/.github/workflows/esy-build.yml
@@ -31,5 +31,6 @@ jobs:
         with:
           cache-key: ${{ hashFiles('esy.lock/index.json') }}
 
-      - name: Run tests
+      - name: Run tests.
+        if: ${{ matrix.system != 'windows' }}
         run: esy test

--- a/esy.json
+++ b/esy.json
@@ -16,18 +16,14 @@
     "@opam/ounit2": "*"
   },
   "scripts": {
+    "test": "esy b dune runtest --ignore-promoted-rules",
     "clean": "node ./scripts/ninja.js clean"
   },
   "esy": {
     "build": "dune build -p #{self.name}",
     "install": [
-      [
-        "esy-installer",
-        "$cur__target_dir/default/melange.install"
-      ],
-      [
-        "$cur__root/fix-install.sh"
-      ]
+      ["esy-installer", "$cur__target_dir/default/melange.install"],
+      ["$cur__root/fix-install.sh"]
     ],
     "exportedEnv": {
       "BSLIB": {
@@ -41,12 +37,7 @@
     "type": "git",
     "url": "git+https://github.com/melange-re/melange.git"
   },
-  "keywords": [
-    "ocaml",
-    "rescript",
-    "stdlib",
-    "functional programming"
-  ],
+  "keywords": ["ocaml", "rescript", "stdlib", "functional programming"],
   "author": {
     "name": "Hongbo Zhang"
   },


### PR DESCRIPTION
Turns out that the tests already run on esy if we ignore-promoted-rules like the ones that uses `web-tree-sitter` this will works.

In the future we may use different mechanism so that ignore-promoted-rules will not be needed.

## Related

#126 