### PR TITLE
revert patch that transforms let into match

### DIFF
--- a/jscomp/frontend/bs_builtin_ppx.ml
+++ b/jscomp/frontend/bs_builtin_ppx.ml
@@ -150,37 +150,6 @@ let expr_mapper (self : mapper) (e : Parsetree.expression) =
         ] ) ->
       default_expr_mapper self
         { e with pexp_desc = Pexp_ifthenelse (b, t_exp, Some f_exp) }
-  | Pexp_let
-      ( Nonrecursive,
-        [
-          {
-            pvb_pat =
-              ( { ppat_desc = Ppat_record _ }
-              | { ppat_desc = Ppat_alias ({ ppat_desc = Ppat_record _ }, _) } )
-              as p;
-            pvb_expr;
-            pvb_attributes;
-            pvb_loc = _;
-          };
-        ],
-        body ) -> (
-      match pvb_expr.pexp_desc with
-      | Pexp_pack _ -> default_expr_mapper self e
-      | _ ->
-          default_expr_mapper self
-            {
-              e with
-              pexp_desc =
-                Pexp_match
-                  (pvb_expr, [ { pc_lhs = p; pc_guard = None; pc_rhs = body } ]);
-              pexp_attributes = e.pexp_attributes @ pvb_attributes;
-            })
-  (* let [@warning "a"] {a;b} = c in body
-     The attribute is attached to value binding,
-     after the transformation value binding does not exist so we attach
-     the attribute to the whole expression, in general, when shuffuling the ast
-     it is very hard to place attributes correctly
-  *)
   | _ -> default_expr_mapper self e
 
 let typ_mapper (self : mapper) (typ : Parsetree.core_type) =

--- a/jscomp/test/gh_161.js
+++ b/jscomp/test/gh_161.js
@@ -1,0 +1,12 @@
+'use strict';
+
+
+var X = {};
+
+function builds_in_melange(param) {
+  return 0;
+}
+
+exports.X = X;
+exports.builds_in_melange = builds_in_melange;
+/* No side effect */

--- a/jscomp/test/gh_161.res
+++ b/jscomp/test/gh_161.res
@@ -1,0 +1,9 @@
+module X = {
+  type t = { id : int }
+}
+
+// https://github.com/melange-re/melange/pull/161
+let builds_in_melange = () => {
+  let { id } = { X.id: 0 }
+  id
+}

--- a/jscomp/test/gh_161_ml.js
+++ b/jscomp/test/gh_161_ml.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+var X = {};
+
+var fails_in_melange = 0;
+
+exports.X = X;
+exports.fails_in_melange = fails_in_melange;
+/* No side effect */

--- a/jscomp/test/gh_161_ml.ml
+++ b/jscomp/test/gh_161_ml.ml
@@ -1,0 +1,8 @@
+module X = struct
+  type t = { id : int }
+end
+
+(* builds in ocamlc *)
+let fails_in_melange =
+  let { X.id } = { id = 0 } in
+  id

--- a/jscomp/test/ocaml_typedtree_test.js
+++ b/jscomp/test/ocaml_typedtree_test.js
@@ -52440,12 +52440,12 @@ function is_runtime_component(param) {
         } else {
           return false;
         }
-    case /* Sig_typext */2 :
-    case /* Sig_module */3 :
-    case /* Sig_class */5 :
-        return true;
+    case /* Sig_type */1 :
+    case /* Sig_modtype */4 :
+    case /* Sig_class_type */6 :
+        return false;
     default:
-      return false;
+      return true;
   }
 }
 


### PR DESCRIPTION
**breaking change**

Melange inherited from ReScript a transformation that changes `let` with a pattern matching in records to `match`. This improves some common cases of type inference in OCaml, but is actually a breaking change.

This happens because let does type checking of the pattern then the value, while match does the opposite, and in OCaml this matters.

## Examples

The following code shows the difference in behavior between `bsc` and `ocamlc`.

```ocaml
module X = struct
  type t = { id: int }
end

(* fails in ocamlc *)
let builds_in_melange =
  let { id = id } = X.{ id = 0 } in
  id
(* builds in ocamlc *)
let fails_in_melange =
  let { X.id = id } = { id = 0 } in
  id
```
Thanks @Octachron for pointing this out to me.