### PR TITLE
Add -stdin flag to bsb to read source from standard input

### DIFF
--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -42,7 +42,7 @@
  (public_name bsb)
  (modes native)
  (modules bsb_main)
- (libraries bs_hash_stubs ext common bsb cmdliner))
+ (libraries bs_hash_stubs ext common bsb cmdliner core))
 
 (executable
  (name cmjdump_main)


### PR DESCRIPTION
🚧  For now this is barely a quick prototype. 🚧 

Goal: see if the same setup used in the browser playground (`jsoo_main.ml`) could be used to read from stdin. 

Why: the original use case is to read OCaml snippets from markdown files with something like [soupault](https://github.com/dmbaturin/soupault), which would then call `bsb -stdin` and pass the string, so that the js output can be automatically injected in the soon-to-be created Melange documentation site in a postprocessing step.

```bash
$ echo "let t = 1" | esy x bsb -stdin
// Generated by Melange
'use strict';


var t = 1;

exports.t = t;
/* No side effect */
```

### todo
- discuss if this makes sense
- error handling (I don't know how to do it 😅 )
- maybe put it in bsc instead of bsb
- I had to remove the open of `Stdlib`, is that ok?