### PR TITLE
Fix stdlib module shadowing

### DIFF
--- a/jscomp/core/bs_conditional_initial.ml
+++ b/jscomp/core/bs_conditional_initial.ml
@@ -79,10 +79,6 @@ let setup_env () =
       !Clflags.include_dirs);
 #endif
 
-#ifdef BS_RELEASE_BUILD
-    Clflags.include_dirs := (Lazy.force Js_config.stdlib_path) :: !Clflags.include_dirs;
-#endif
-
   Lexer.replace_directive_bool "BS" true;
   Lexer.replace_directive_bool "JS" true;
   Lexer.replace_directive_string "BS_VERSION"  Bs_version.version

--- a/jscomp/core/res_compmisc.ml
+++ b/jscomp/core/res_compmisc.ml
@@ -27,7 +27,7 @@ let init_path () =
   let exp_dirs =
     List.map (Misc.expand_directory Config.standard_library) dirs in
     Load_path.reset ();
-    List.iter Load_path.add_dir (List.rev_append exp_dirs (Clflags.std_include_dir ()));
+    List.iter Load_path.add_dir (List.rev ((Lazy.force Js_config.stdlib_path) :: exp_dirs));
   Env.reset_cache ()
 
 (* Return the initial environment in which compilation proceeds. *)


### PR DESCRIPTION
fixes #173 

We need to add the stdlib include dir at the end of the includes so that it doesn't shadow modules with the same name in a project.