### PR TITLE
use ocaml-lsp-server from opam

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -10,7 +10,7 @@
     "@opam/melange-compiler-libs": "melange-re/melange-compiler-libs:melange-compiler-libs.opam#c787d2f98a"
   },
   "devDependencies": {
-    "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam",
+    "@opam/ocaml-lsp-server": "*",
     "web-tree-sitter": "0.18.0",
     "@opam/merlin": "*",
     "@opam/ounit2": "*"

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "897cd5083657286f6f6e94e63d933c53",
+  "checksum": "a21081929ddb4054bf12d01c449a607c",
   "root": "melange@link-dev:./esy.json",
   "node": {
     "web-tree-sitter@0.18.0@d41d8cd9": {
@@ -46,8 +46,8 @@
       "devDependencies": [
         "web-tree-sitter@0.18.0@d41d8cd9",
         "@opam/ounit2@opam:2.2.4@1877225e",
-        "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#b6fd82a8c0cf11b2a1c3370bc7a61622409b14d5@d41d8cd9",
-        "@opam/merlin@opam:4.2-412@6d72a362"
+        "@opam/ocaml-lsp-server@opam:1.5.0@a7ce3ad8",
+        "@opam/merlin@opam:4.2-412@845ccff0"
       ],
       "installConfig": { "pnp": false }
     },
@@ -272,21 +272,26 @@
       ],
       "devDependencies": [ "ocaml@4.12.0@d41d8cd9" ]
     },
-    "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#b6fd82a8c0cf11b2a1c3370bc7a61622409b14d5@d41d8cd9": {
-      "id":
-        "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#b6fd82a8c0cf11b2a1c3370bc7a61622409b14d5@d41d8cd9",
+    "@opam/ocaml-lsp-server@opam:1.5.0@a7ce3ad8": {
+      "id": "@opam/ocaml-lsp-server@opam:1.5.0@a7ce3ad8",
       "name": "@opam/ocaml-lsp-server",
-      "version":
-        "github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#b6fd82a8c0cf11b2a1c3370bc7a61622409b14d5",
+      "version": "opam:1.5.0",
       "source": {
         "type": "install",
         "source": [
-          "github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#b6fd82a8c0cf11b2a1c3370bc7a61622409b14d5"
-        ]
+          "archive:https://opam.ocaml.org/cache/md5/2c/2c19731536a4f62923554c1947c39211#md5:2c19731536a4f62923554c1947c39211",
+          "archive:https://github.com/ocaml/ocaml-lsp/releases/download/1.5.0/jsonrpc-1.5.0.tbz#md5:2c19731536a4f62923554c1947c39211"
+        ],
+        "opam": {
+          "name": "ocaml-lsp-server",
+          "version": "1.5.0",
+          "path": "esy.lock/opam/ocaml-lsp-server.1.5.0"
+        }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "@opam/stdlib-shims@opam:0.3.0@0d088929",
         "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
@@ -297,6 +302,7 @@
       ],
       "devDependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "@opam/stdlib-shims@opam:0.3.0@0d088929",
         "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
@@ -331,8 +337,8 @@
         "ocaml@4.12.0@d41d8cd9", "@opam/dune@opam:2.8.5@83fb0224"
       ]
     },
-    "@opam/merlin@opam:4.2-412@6d72a362": {
-      "id": "@opam/merlin@opam:4.2-412@6d72a362",
+    "@opam/merlin@opam:4.2-412@845ccff0": {
+      "id": "@opam/merlin@opam:4.2-412@845ccff0",
       "name": "@opam/merlin",
       "version": "opam:4.2-412",
       "source": {

--- a/esy.lock/opam/merlin.4.2-412/opam
+++ b/esy.lock/opam/merlin.4.2-412/opam
@@ -65,6 +65,11 @@ should take care of basic setup.
 See https://github.com/OCamlPro/opam-user-setup
 "
   {success & !user-setup:installed}
+"Since version 4.2, Merlin integration with completion packages company
+and auto-complete has moved to separate modules. Make sure to add
+`(require 'merlin-company)` or `(require 'merlin-ac)` to your emacs
+configuration if you were using one of these."
+  {success}
 ]
 x-commit-hash: "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c"
 url {

--- a/esy.lock/opam/ocaml-lsp-server.1.5.0/opam
+++ b/esy.lock/opam/ocaml-lsp-server.1.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinerg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "yojson"
+  "stdlib-shims"
+  "ppx_yojson_conv_lib"
+  "dune-build-info"
+  "dot-merlin-reader"
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "ocamlformat" {with-test}
+  "ocamlfind" {>= "1.5.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12" & < "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-j" jobs "ocaml-lsp-server.install" "--release"]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.5.0/jsonrpc-1.5.0.tbz"
+  checksum: [
+    "md5=2c19731536a4f62923554c1947c39211"
+    "sha512=9bc252e2564fe6c9017b5ee1b2c4ddebf73c4be4b2a3d48f1d61b6ec1910a2cb9f4fa4952a7a6d89482c28ddbad8e0d9c34c206a1b2fe42bb2c3a7156aa953e9"
+  ]
+}


### PR DESCRIPTION
As `ocaml-lsp-server` was already released for 4.12 we don't need to keep using it like this, and also some weird bugs was happening on the master version.

Something like `unit_of_yojson` then the LSP crashes, maybe @rgrinberg is interested on it?