### PR TITLE
Use reason on error messages

### DIFF
--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -108,6 +108,10 @@ let emit_module_build
       | Res, Reason -> { impl = res_suffixes.impl; intf = re_suffixes.intf }
       | Ml, Ml | Reason, Reason | Res, Res -> assert false
   in
+  let error_syntax_kind =
+    match module_info.syntax_kind with
+    | Same syntax_kind -> syntax_kind
+    | Different { impl } -> impl in
   let filename_sans_extension = module_info.name_sans_extension in
   let input_impl = Bsb_config.proj_rel (filename_sans_extension ^ config.impl ) in
   let input_intf = Bsb_config.proj_rel (filename_sans_extension ^ config.intf) in
@@ -146,7 +150,8 @@ let emit_module_build
       ~implicit_deps:((Option.value ~default:[] maybe_gentype_deps) @ ppx_deps)
       ~outputs:[output_ast]
       ~inputs:[basename input_impl]
-      ~rule:rules.build_ast;
+      ~rule:rules.build_ast
+      ~error_syntax_kind;
   end;
   let relative_ns_cmi =
    match namespace with
@@ -172,7 +177,8 @@ let emit_module_build
       ~outputs:[output_iast]
       ~implicit_deps:ppx_deps
       ~inputs:[basename input_intf]
-      ~rule:rules.build_ast;
+      ~rule:rules.build_ast
+      ~error_syntax_kind;
 
     Bsb_ninja_targets.output_build cur_dir buf
       ~implicit_deps:[ast_deps]
@@ -182,7 +188,7 @@ let emit_module_build
       ~rule:(if is_dev then rules.mi_dev else rules.mi)
       ~bs_dependencies
       ~rel_deps:(rel_bs_config_json :: relative_ns_cmi)
-    ;
+      ~error_syntax_kind;
   end;
 
   let rule =
@@ -207,7 +213,8 @@ let emit_module_build
       ~implicit_deps:(if has_intf_file then [output_cmi; ast_deps] else [ast_deps])
       ~bs_dependencies
       ~rel_deps:(rel_bs_config_json :: relative_ns_cmi)
-      ~rule;
+      ~rule
+      ~error_syntax_kind;
   end;
   if which <> `intf then output_js else []
 

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -37,30 +37,25 @@ end
 
 type t = {
   rule_name : string;
-  name : Buffer.t -> ?target:string -> string -> unit
+  name :
+    Buffer.t ->
+    ?error_syntax_kind:Bsb_db.syntax_kind ->
+    ?target:string -> 
+    string ->
+    unit
 }
 
-let output_rule (x : t) buf ?target cur_dir =
- let _name = x.name buf ?target cur_dir in
+let output_rule (x : t) buf ?error_syntax_kind ?target cur_dir =
+ let _name = x.name buf ?error_syntax_kind ?target cur_dir in
  ()
 
-let get_name (x : t) ?target cur_dir buf = x.name buf ?target cur_dir
-
-
 (** allocate an unique name for such rule*)
-let define ~command rule_name : t
-  =
-
+let define ~command rule_name : t =
   let self = {
     rule_name ;
-    name = fun buf ?target cur_dir ->
-         command buf ?target cur_dir
+    name = command
   } in
-
   self
-
-
-
 
 type command = string
 
@@ -110,7 +105,11 @@ let make_custom_rules
   let mk_ml_cmj_cmd
       ~(read_cmi : [`yes | `is_cmi | `no])
       ~is_dev
-      ~postbuild : Buffer.t -> ?target:string -> string -> unit = fun buf ?(target="%{targets}") cur_dir ->
+      ~postbuild
+      buf
+      ?error_syntax_kind
+      ?(target="%{targets}")
+      cur_dir =
     let rel_incls ?namespace dirs =
       Bsb_build_util.rel_include_dirs
         ~per_proj_dir:global_config.per_proj_dir
@@ -139,6 +138,8 @@ let make_custom_rules
         Buffer.add_string buf " ";
         Buffer.add_string buf dev_incls;
     end;
+    if error_syntax_kind = Some Bsb_db.Reason then
+      Buffer.add_string buf " -bs-re-out";
     Buffer.add_string buf " ";
     Buffer.add_string buf (rel_incls global_config.g_sourcedirs_incls);
     Buffer.add_string buf " ";
@@ -174,7 +175,7 @@ let make_custom_rules
       Buffer.add_string buf " $out_last"
     end ;
   in
-  let mk_ast buf ?target:_ cur_dir : unit =
+  let mk_ast buf ?error_syntax_kind:_ ?target:_ cur_dir : unit =
     let rel_proj_dir = Ext_path.rel_normalized_absolute_path
       ~from:(global_config.per_proj_dir // cur_dir)
       global_config.per_proj_dir
@@ -209,9 +210,9 @@ let make_custom_rules
       ~command:mk_ast
       "ast" in
 
-  let aux ~name ~read_cmi  ~postbuild =
-    define ~command:(mk_ml_cmj_cmd ~read_cmi  ~is_dev:false ~postbuild) name,
-    define ~command:(mk_ml_cmj_cmd ~read_cmi  ~is_dev:true ~postbuild) (name ^ "_dev")
+  let aux ~name ~read_cmi ~postbuild =
+    define ~command:(mk_ml_cmj_cmd ~read_cmi ~is_dev:false ~postbuild) name,
+    define ~command:(mk_ml_cmj_cmd ~read_cmi ~is_dev:true ~postbuild) (name ^ "_dev")
   in
 
   let mj, mj_dev =
@@ -226,7 +227,7 @@ let make_custom_rules
       ~name:"mi" in
   let build_package =
     define
-      ~command:(fun buf ?target:_ _cur_dir ->
+      ~command:(fun buf ?error_syntax_kind:_ ?target:_ _cur_dir ->
          let s = global_config.bsc ^ " -w -49 -color always -no-alias-deps %{inputs}" in
         Buffer.add_string buf "(action (run ";
         Buffer.add_string buf s;
@@ -246,7 +247,7 @@ let make_custom_rules
     build_package ;
     customs =
       Map_string.mapi custom_rules begin fun name command ->
-        define ~command:(fun buf ?target:_ _cur_dir ->
+        define ~command:(fun buf ?error_syntax_kind:_ ?target:_ _cur_dir ->
           let actual_command =
             Str.global_substitute Generators.regexp (fun match_ ->
               match Generators.(maybe_match ~group:1 match_, maybe_match ~group:2 match_) with

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -29,9 +29,13 @@
 *)
 type t
 
-val output_rule : t -> Buffer.t -> ?target:string -> string -> unit
-
-val get_name : t -> ?target:string -> string  -> Buffer.t -> unit
+val output_rule :
+  t ->
+  Buffer.t ->
+  ?error_syntax_kind:Bsb_db.syntax_kind ->
+  ?target:string ->
+  string ->
+  unit
 
 (***********************************************************)
 (** A list of existing rules *)

--- a/jscomp/bsb/bsb_ninja_targets.ml
+++ b/jscomp/bsb/bsb_ninja_targets.ml
@@ -93,6 +93,7 @@ let output_build
     ?(bs_dependencies=[])
     ?(implicit_outputs=[])
     ?(js_outputs=[])
+    ?error_syntax_kind
     ~outputs
     ~inputs
     ~rule
@@ -138,6 +139,7 @@ let output_build
   Buffer.add_string buf "\n";
   Bsb_ninja_rule.output_rule
     ~target:(String.concat Ext_string.single_space (Ext_list.map outputs Filename.basename))
+    ?error_syntax_kind
     rule
     buf
     cur_dir;

--- a/jscomp/bsb/bsb_ninja_targets.mli
+++ b/jscomp/bsb/bsb_ninja_targets.mli
@@ -39,6 +39,7 @@ val output_build :
   ?bs_dependencies:string list ->
   ?implicit_outputs: string list ->
   ?js_outputs: (string * bool) list ->
+  ?error_syntax_kind:Bsb_db.syntax_kind ->
   outputs:string list ->
   inputs:string list ->
   rule:Bsb_ninja_rule.t ->

--- a/jscomp/outcome_printer/dune
+++ b/jscomp/outcome_printer/dune
@@ -1,3 +1,5 @@
 (library
  (name outcome_printer)
- (libraries ext reason))
+ (libraries melange-compiler-libs ext reason)
+ (flags
+  (:standard -open Melange_compiler_libs)))


### PR DESCRIPTION
This makes that error messages uses reason when it's a reason file

```shell
File "/home/eduardo/reason/gh-feed-reader/_build/default/src/App.re", line 6, characters 11-23:
6 | type x = t(list(string), string);
               ^^^^^^^^^^^^
Error: This type list(string) should be an instance of type option('a)
```

## Implementation

As the hooks were already in place and this feature was possible in the past, I figured it out that it was actually just enabling it on dune.

It was partially broken because the migration to melange-compiler-libs tho.

## Related

Implements #166
