### PR TITLE
emit JS file when using -o with -impl

### DIFF
--- a/jscomp/core/lam_compile_main.ml
+++ b/jscomp/core/lam_compile_main.ml
@@ -296,8 +296,8 @@ let lambda_as_module
       (Filename.basename output_prefix)
       (Ext_js_suffix.to_string suffix) in
   let package_info = Js_packages_state.get_packages_info () in
-  let has_packages = Js_packages_info.is_empty package_info in
-  match (has_packages, !Js_config.js_stdout, !Clflags.output_name) with
+  let are_packages_empty = Js_packages_info.is_empty package_info in
+  match (are_packages_empty, !Js_config.js_stdout, !Clflags.output_name) with
   | (true, true, None) -> 
     Js_dump_program.dump_deps_program ~output_prefix NodeJS lambda_output stdout
   | (true, _, Some _) ->

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,7 +2,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/dedc6ef.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/58960d0.tar.gz;
 
 in
 import "${overlays}/sources.nix" {


### PR DESCRIPTION
This allows commands using -impl / -intf with -o, to work normally, dune emits this kind of commands. Currently this only generates the `.cmj`

## Example

```sh
bsc -I . -o a_something.cmj -impl a.ml
```

Will generate both the `a_something.cmj` and `a_something.js`