### PR TITLE
enables bytecode mode on bsc for development

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -30,6 +30,9 @@
         "$cur__root/fix-install.sh"
       ]
     ],
+    "buildEnv": {
+      "CAML_LD_LIBRARY_PATH": "#{self.target_dir / 'default' / 'jscomp' / 'stubs' : $CAML_LD_LIBRARY_PATH }"
+    },
     "exportedEnv": {
       "BSLIB": {
         "val": "#{self.lib / 'melange'}",

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -1,7 +1,7 @@
 (executable
  (name js_main)
  (public_name bsc)
- (modes native)
+ (modes byte native)
  (flags :standard -open Melange_compiler_libs)
  (libraries
   js_parser


### PR DESCRIPTION
## Goal

Improve the development experience and enable easier debugging with ocamlearlybird.

## What this PR does

- Enable (modes byte) for `js_main`
- Adds the needed stubs to run `js_main.bc` on the `esy.json`.

## How to try

My current workflow is:

```sh
## keep this running on one terminal
dune build jscomp/main/js_main.bc -w --ignore-promoted-rules

## and in another one adds the alias and just do bsc stuff
alias bsc="$cur__target_dir/default/jscomp/main/js_main.bc"
bsc -version
```
