### PR TITLE
Store program in cmj and generates JS from it

### DIFF
--- a/jscomp/core/js_cmj_format.ml
+++ b/jscomp/core/js_cmj_format.ml
@@ -44,14 +44,14 @@ type effect = string option
 let single_na = Single Lam_arity.na
 
 type keyed_cmj_value = { name : string ; arity : arity ; persistent_closed_lambda : Lam.t option}
-type keyed_cmj_values 
-  =   keyed_cmj_value array
+type keyed_cmj_values = keyed_cmj_value array
 
 type t = {
   values : keyed_cmj_values ;
-  pure : bool;
+  pure : bool ;
   package_spec : Js_packages_info.t ;
-  case : Ext_js_file_kind.case;  
+  case : Ext_js_file_kind.case ;
+  delayed_program : J.deps_program ;
 }
 
 let make 
@@ -59,6 +59,7 @@ let make
     ~effect 
     ~package_spec 
     ~case
+    ~delayed_program
      : t = 
   {
     values = Map_string.to_sorted_array_with_f values (fun k v -> {
@@ -68,7 +69,8 @@ let make
         }); 
     pure = effect = None ; 
     package_spec;
-    case
+    case ;
+    delayed_program
   }
 
 

--- a/jscomp/core/js_cmj_format.mli
+++ b/jscomp/core/js_cmj_format.mli
@@ -72,9 +72,10 @@ type keyed_cmj_value = {
 
 type t =  {
   values : keyed_cmj_value array ;
-  pure : bool;
+  pure : bool ;
   package_spec : Js_packages_info.t ;
-  case : Ext_js_file_kind.case;
+  case : Ext_js_file_kind.case ;
+  delayed_program : J.deps_program ;
 }
 
 
@@ -83,6 +84,7 @@ val make:
   effect: effect -> 
   package_spec: Js_packages_info.t ->
   case:Ext_js_file_kind.case ->
+  delayed_program: J.deps_program ->
   t
   
 

--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -212,12 +212,15 @@ let implementation_mlast ppf fname  setup =
   Binary_ast.read_ast_exn ~fname Ml  setup
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.implementation
   |> print_if_pipe ppf Clflags.dump_source Pprintast.structure
-  |> after_parsing_impl ppf  (Config_util.output_prefix fname )
+  |> after_parsing_impl ppf (Config_util.output_prefix fname )
 
-
-
-
-
+let implementation_cmj _ppf fname =
+  (* this is needed because the path is used to find other modules path *)
+  Res_compmisc.init_path ();
+  let cmj = Js_cmj_format.from_file fname in
+  Lam_compile_main.lambda_as_module
+    cmj.delayed_program
+    (Config_util.output_prefix fname )
 
 
 let make_structure_item ~ns cunit : Parsetree.structure_item =

--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -101,11 +101,7 @@ let after_parsing_sig ppf  outputprefix ast  =
 
 
 
-let interface ~parser ppf ?outputprefix fname  =
-  let outputprefix =
-    match outputprefix with
-    | None -> Config_util.output_prefix fname
-    | Some x -> x in
+let interface ~parser ppf fname  =
   Res_compmisc.init_path ();
   parser fname
   |> Ast_deriving_compat.signature
@@ -113,14 +109,14 @@ let interface ~parser ppf ?outputprefix fname  =
   |> Ppx_entry.rewrite_signature
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.interface
   |> print_if_pipe ppf Clflags.dump_source Pprintast.signature
-  |> after_parsing_sig ppf  outputprefix
+  |> after_parsing_sig ppf (Config_util.output_prefix fname)
 
 let interface_mliast ppf fname  setup =
   Res_compmisc.init_path ();
   Binary_ast.read_ast_exn ~fname Mli  setup
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.interface
   |> print_if_pipe ppf Clflags.dump_source Pprintast.signature
-  |> after_parsing_sig ppf  (Config_util.output_prefix fname)
+  |> after_parsing_sig ppf (Config_util.output_prefix fname)
 
 let all_module_alias (ast : Parsetree.structure)=
   Ext_list.for_all ast (fun {pstr_desc} ->
@@ -200,11 +196,7 @@ let after_parsing_impl ppf  outputprefix (ast : Parsetree.structure) =
       end;
       process_with_gentype (outputprefix ^ ".cmt")
     end
-let implementation ~parser ppf ?outputprefix fname   =
-  let outputprefix =
-      match outputprefix with
-      | None -> Config_util.output_prefix fname
-      | Some x -> x in
+let implementation ~parser ppf fname   =
   Res_compmisc.init_path ();
   parser fname
   |> Ast_deriving_compat.structure
@@ -212,7 +204,7 @@ let implementation ~parser ppf ?outputprefix fname   =
   |> Ppx_entry.rewrite_implementation
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.implementation
   |> print_if_pipe ppf Clflags.dump_source Pprintast.structure
-  |> after_parsing_impl ppf outputprefix
+  |> after_parsing_impl ppf (Config_util.output_prefix fname )
 
 let implementation_mlast ppf fname  setup =
 

--- a/jscomp/core/js_implementation.mli
+++ b/jscomp/core/js_implementation.mli
@@ -38,7 +38,6 @@
 val interface : 
   parser:(string -> Parsetree.signature) ->
   Format.formatter -> 
-  ?outputprefix:string -> 
   string -> 
   unit
 
@@ -63,7 +62,6 @@ val interface_mliast :
 val implementation : 
   parser:(string -> Parsetree.structure) ->
   Format.formatter -> 
-  ?outputprefix:string -> 
   string -> 
   unit
 (** [implementation ppf sourcefile outprefix] compiles to JS directly *) 

--- a/jscomp/core/js_implementation.mli
+++ b/jscomp/core/js_implementation.mli
@@ -72,5 +72,8 @@ val implementation_mlast :
   ([`ml | `rescript | `reason ]  -> unit) ->
   unit
 
+val implementation_cmj : Format.formatter -> string -> unit
+(** [implementation_cmj ppf cmj_file] compiles a cmj to JS *)
+
 val implementation_map : 
   Format.formatter -> string ->  unit

--- a/jscomp/core/lam_compile_main.ml
+++ b/jscomp/core/lam_compile_main.ml
@@ -309,7 +309,8 @@ let lambda_as_module
   | (true, _, Some _) ->
     (* TODO: try this on windows *)
     let basename = make_basename Js in
-    write_to_file NodeJS basename
+    let target_file = (Filename.dirname output_prefix) // basename in
+    write_to_file NodeJS target_file
   |  _ ->
     Js_packages_info.iter package_info (fun {module_system; path; suffix} ->
         let basename = make_basename suffix in

--- a/jscomp/core/lam_compile_main.ml
+++ b/jscomp/core/lam_compile_main.ml
@@ -264,18 +264,24 @@ js
     let effect =
       Lam_stats_export.get_dependent_module_effect
         maybe_pure external_module_ids in
-    let v : Js_cmj_format.t =
+    let delayed_program = {
+      J.program = program ;
+      side_effect = effect ;
+      modules = external_module_ids
+    } in
+    let cmj : Js_cmj_format.t =
       Lam_stats_export.export_to_cmj
         meta
         effect
         coerced_input.export_map
         (if Ext_char.is_lower_case (Filename.basename output_prefix).[0] then Little else Upper)
+        ~delayed_program
     in
     (if not !Clflags.dont_write_files then
        Js_cmj_format.to_file
          ~check_exists:(not !Js_config.force_cmj)
-         (output_prefix ^ Literals.suffix_cmj) v);
-    {J.program = program ; side_effect = effect ; modules = external_module_ids }
+         (output_prefix ^ Literals.suffix_cmj) cmj);
+    delayed_program
   )
 ;;
 

--- a/jscomp/core/lam_stats_export.ml
+++ b/jscomp/core/lam_stats_export.ml
@@ -144,12 +144,7 @@ let get_dependent_module_effect
    ]}
    TODO: check that we don't do this in browser environment
 *)
-let export_to_cmj
-    (meta : Lam_stats.t )
-    effect
-    export_map
-    case
-  : Js_cmj_format.t =
+let export_to_cmj meta effect export_map case =
   let values =  values_of_export meta export_map in
 
   Js_cmj_format.make

--- a/jscomp/core/lam_stats_export.mli
+++ b/jscomp/core/lam_stats_export.mli
@@ -35,5 +35,6 @@ val export_to_cmj :
   Js_cmj_format.effect ->
   Lam.t Map_ident.t ->
   Ext_js_file_kind.case ->
+  (* FIXME: this is a leaky abstraction *)
+  delayed_program:J.deps_program ->
   Js_cmj_format.t
-

--- a/jscomp/ext/ext_file_extensions.ml
+++ b/jscomp/ext/ext_file_extensions.ml
@@ -14,6 +14,7 @@ type valid_input =
   | Impl_ast
   | Mlmap
   | Cmi
+  | Cmj
   | Unknown
 
 
@@ -45,4 +46,6 @@ let classify_input ext =
     Res
   | _ when ext = Literals.suffix_resi ->
     Resi
+  | _ when ext =  Literals.suffix_cmj ->
+    Cmj
   | _ -> Unknown

--- a/jscomp/main/js_main.ml
+++ b/jscomp/main/js_main.ml
@@ -55,18 +55,16 @@ let process_file sourcefile
   match kind with
   | Re ->
     let sourcefile = set_abs_input_name  sourcefile in
-    let outputprefix = Config_util.output_prefix sourcefile in
     setup_error_printer `reason;
     Js_implementation.implementation
       ~parser:Ast_reason_pp.RE.parse_implementation
-      ppf sourcefile ~outputprefix
+      ppf sourcefile
   | Rei ->
     let sourcefile = set_abs_input_name  sourcefile in
-    let outputprefix = Config_util.output_prefix sourcefile in
     setup_error_printer `reason;
     Js_implementation.interface
       ~parser:Ast_reason_pp.RE.parse_interface
-      ppf sourcefile ~outputprefix
+      ppf sourcefile
   | Ml ->
     let sourcefile = set_abs_input_name  sourcefile in
     Js_implementation.implementation

--- a/jscomp/main/js_main.ml
+++ b/jscomp/main/js_main.ml
@@ -533,6 +533,8 @@ let buckle_script_flags : (string * Bsc_args.spec * string) array =
     "-make-runtime-test", unit_call Js_packages_state.make_runtime_test,
     "*internal* make runtime test library";
 
+    "-bs-stop-after-cmj", set Js_config.cmj_only,
+    "Stop after generating the cmj"
   |]
 
 

--- a/jscomp/main/js_main.ml
+++ b/jscomp/main/js_main.ml
@@ -104,6 +104,8 @@ let process_file sourcefile
     let cmi_sign = (Cmi_format.read_cmi sourcefile).cmi_sign in
     Printtyp.signature Format.std_formatter cmi_sign ;
     Format.pp_print_newline Format.std_formatter ()
+  | Cmj ->
+    Js_implementation.implementation_cmj ppf sourcefile
   | Unknown ->
     Bsc_args.bad_arg ("don't know what to do with " ^ sourcefile)
 let usage = "Usage: bsc <options> <files>\nOptions are:"


### PR DESCRIPTION
## Goal

This is a step on moving to support dune directly, by being able to generate JS from the cmj we achieve a flow quite similar to ocamlc + jsoo.

And this also aims to reduce duplicated work when the user has multiple targets, like CJS and ES6, which today runs the full pipeline twice.

ALSO, this allows to have relocatable builds even in the presence of absolute paths, because the stored program is not dependent on the path. And because JS is not platform dependent this is a safe operation.

## Cons

The cmj file will be considerable now, while before it was a dumb and helped with optimizations, now it carry the full JS AST.

If this starts to be a problem there is a couple of ways to mitigate it.

## Changes

- Add `J.deps_program` to the cmj
- Emits JS from the cmj
- Fix bug where `-o x/out.js -impl y/in` would put the JS file in the same place as the commands was executed instead of x/out.js

## Issues

- Closes #193
- Closes #195