### PR TITLE
README: restore Acknowledgments section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
   ReScript on a regular basis.
 * Thanks to the [OCaml](https://ocaml.org) team, obviously, without such a
   beautiful yet practical language, this project would not exist.
-* Thanks to [ninja-build](https://ninja-build.org), used internally by Melange.
-  `ninja` is a truly [well-engineered](http://aosabook.org/en/posa/ninja.html)
-  scalable build tool.
 * Thanks to [Bloomberg](https://www.techatbloomberg.com) and
   [Facebook](https://github.com/facebook/). The ReScript project began at
   Bloomberg and was published in 2016; without the support of Bloomberg, it

--- a/README.md
+++ b/README.md
@@ -55,7 +55,24 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Acknowledgments
 
-See [Credits.md](./Credits.md).
+* Thanks to the [ReScript](https://github.com/rescript-lang/rescript-compiler)
+  project, its author and maintainer [@bobzhang](https://github.com/bobzhang),
+  and its many
+  [contributors](https://github.com/rescript-lang/rescript-compiler/graphs/contributors).
+  Melange is a fork of ReScript, and continues to incorporate patches to
+  ReScript on a regular basis.
+* Thanks to the [OCaml](https://ocaml.org) team, obviously, without such a
+  beautiful yet practical language, this project would not exist.
+* Thanks to [ninja-build](https://ninja-build.org), used internally by Melange.
+  `ninja` is a truly [well-engineered](http://aosabook.org/en/posa/ninja.html)
+  scalable build tool.
+* Thanks to [Bloomberg](https://www.techatbloomberg.com) and
+  [Facebook](https://github.com/facebook/). The ReScript project began at
+  Bloomberg and was published in 2016; without the support of Bloomberg, it
+  would not have happened. ReScript was funded by Facebook since July 2017.
+
+See also [Credits.md](./Credits.md) concerning some individual components of
+Melange.
 
 ## Licensing
 


### PR DESCRIPTION
In https://github.com/melange-re/melange/commit/e3d84e4e0011955ae620331ba9d0876b41938451#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17, Melange lost the content of the Acknowledgments section, and replaced it with only a link to [`Credits.md`](https://github.com/melange-re/melange/blob/a11ceb137489bb42c32cbe8c499220b5172060f5/Credits.md). This was a quite lossy change, as it lost:

- Explicit credit to the OCaml team.
- Credit to ninja (is Melange still using ninja internally?)
- Credit to Bloomberg and Facebook for supporting the BuckleScript project.

`Credits.md` does not have any of this. It is a list of sources for some of the components of ReScript (and Melange).

As far as I can tell, all of these should be acknowledged. In addition, the text [was already present](https://github.com/rescript-lang/rescript-compiler/tree/70bbeb858c9716dc69a3d99a42a3f0fc20d67dd1#acknowledgments) at the time Melange was forked. The link is to a commit from 2019.

This commit restores the lost content of the acknowledgments section. The text is based on the [current edit](https://github.com/rescript-lang/rescript-compiler/blob/023755a20d4afe65bb7f52c7f4cdcffa2ed84b3c/README.md#acknowledgments) of that section in ReScript, which has been edited slightly for grammar, punctuation, and the like, since the time Melange was forked. I adapted the text slightly to fit the Melange point of view.

Since Melange was forked (AFAICT), ReScript has also [added a History section](https://github.com/rescript-lang/rescript-compiler/pull/5046/files) and [moved it into the README](https://github.com/rescript-lang/rescript-compiler/commit/506c13a235654380ae3eca795e8fa04baad61910). I don't think it's necessary for Melange to copy that section verbatim. However, it seems quite important to clearly credit ReScript and @bobzhang in the Acknowledgmets section. The existing fragment in the README,

> This project is a fork of the ReScript compiler

does not seem adequate, as it is not clear whether Melange is a fork of a snapshot of ReScript (no), or whether it continues to incorporate work on ReScript on a regular basis (yes). I've prepended a point about that to the Acknowledgments in this PR.

I didn't include credit to specific major ReScript contributors listed in ReScript's new History section, as it is less common to credit contributors in a README, and the History section did not exist in ReScript either, until after the fork. It seems that can be based on discussion. I included a link to the contributor graph generated by GitHub. I picked the ReScript contributor graph, because for some reason ~~Melange's has only 12 contributors (ReScript has 271) &mdash; this makes me concerned and wanting to look into the metadata of Melange's commits and wherher it was correctly preserved, but I have not looked at this at all and maybe the reason is something else entirely~~ *Melange has all the contributors listed, GitHub just totals it as 12 in this repo*.

I think the wording and phrasing of Acknowledgments can, of course, be changed over time, but the overall meaning of the section should, IMO, be retained.
