### PR TITLE
Pass dune arguments (after `--`) to `dune clean`

### DIFF
--- a/jscomp/bsb/bsb_clean.ml
+++ b/jscomp/bsb/bsb_clean.ml
@@ -30,12 +30,7 @@ let dune_clean ~dune_args proj_dir =
   try
     let cmd = Literals.dune in
     let common_args = [|cmd; "clean"|] in
-    let args =
-      if Array.length dune_args = 0 then
-        common_args
-      else
-        Array.append common_args dune_args
-    in
+    let args = Array.append common_args dune_args in
     let eid =
       Bsb_unix.run_command_execvp {cmd ; args; cwd = proj_dir}
     in

--- a/jscomp/bsb/bsb_clean.ml
+++ b/jscomp/bsb/bsb_clean.ml
@@ -26,11 +26,18 @@
 let (//) = Ext_path.combine
 
 
-let dune_clean  proj_dir =
+let dune_clean ~dune_args proj_dir =
   try
     let cmd = Literals.dune in
+    let common_args = [|cmd; "clean"|] in
+    let args =
+      if Array.length dune_args = 0 then
+        common_args
+      else
+        Array.append common_args dune_args
+    in
     let eid =
-      Bsb_unix.run_command_execvp {cmd ; args = [|cmd; "clean"|] ; cwd = proj_dir}
+      Bsb_unix.run_command_execvp {cmd ; args; cwd = proj_dir}
     in
     if eid <> 0 then
       Bsb_log.warn "@{<warning>dune clean failed@}@."
@@ -60,18 +67,15 @@ let clean_bs_garbage proj_dir =
     Bsb_log.warn "@{<warning>Failed@} to clean due to %s" (Printexc.to_string e)
 
 
-let clean_bs_deps  proj_dir =
-  dune_clean  proj_dir ;
+let clean_self ~dune_args proj_dir =
+    dune_clean ~dune_args proj_dir ;
+    clean_bs_garbage  proj_dir
+
+let clean ~dune_args proj_dir =
+  clean_self ~dune_args proj_dir;
   let queue = Bsb_build_util.walk_all_deps  proj_dir in
   Queue.iter (fun (pkg_cxt : Bsb_build_util.package_context )->
       (* whether top or not always do the cleaning *)
       clean_bs_garbage  pkg_cxt.proj_dir
     ) queue
 
-let clean_self  proj_dir =
-    dune_clean  proj_dir ;
-    clean_bs_garbage  proj_dir
-
-let clean proj_dir =
-  clean_bs_deps proj_dir;
-  clean_self proj_dir;

--- a/jscomp/bsb/bsb_clean.mli
+++ b/jscomp/bsb/bsb_clean.mli
@@ -26,4 +26,4 @@
   TODO: clean staled in source js artifacts
 *)
 
-val clean : string -> unit
+val clean : dune_args:string array -> string -> unit

--- a/jscomp/main/bsb_main.ml
+++ b/jscomp/main/bsb_main.ml
@@ -76,11 +76,7 @@ let output_dune_file buf =
 
 let dune_command_exit dune_args =
   let common_args = [|Literals.dune; "build"; ("@" ^ Literals.bsb_world)|] in
-  let args =
-    if Array.length dune_args = 0 then
-      common_args
-    else
-      Array.append common_args dune_args
+  let args = Array.append common_args dune_args
   in
   Bsb_log.info "@{<info>Running:@} %s@." (String.concat " " (Array.to_list args));
   Unix.execvp Literals.dune args

--- a/jscomp/main/bsb_main.ml
+++ b/jscomp/main/bsb_main.ml
@@ -100,16 +100,17 @@ let build_whole_project () =
   config :: dep_configs
 
 let print_init_theme_notice () =
-  print_endline
+  prerr_endline
     "The subcommands -init, -theme and -themes are deprecated now. Use the template at \
-     https://github.com/melange-re/melange-basic-template to start a new project."
+     https://github.com/melange-re/melange-basic-template to start a new project.";
+  flush stderr
 
-let run_bsb ({ make_world; install; watch_mode; _ } as options) =
+let run_bsb ({ make_world; install; watch_mode; dune_args; _ } as options) =
   let cwd = Bsb_global_paths.cwd in
   try begin
     if options.print_version then print_version_string ();
     if options.verbose then Bsb_log.verbose ();
-    if options.clean then Bsb_clean.clean cwd; (* TODO: take dune args *)
+    if options.clean then Bsb_clean.clean ~dune_args cwd;
     if options.print_bsb_location then print_endline (Filename.dirname Sys.executable_name);
     match options.init_path, options.list_themes with
     | Some _, _ | _, true -> print_init_theme_notice ()
@@ -121,7 +122,7 @@ let run_bsb ({ make_world; install; watch_mode; _ } as options) =
           let configs = build_whole_project () in
           Bsb_world.install_targets Bsb_global_paths.cwd configs
         end;
-        if watch_mode then exit 0 else if make_world then dune_command_exit options.dune_args
+        if watch_mode then exit 0 else if make_world then dune_command_exit dune_args
       end
   end
   with

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,7 +2,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/6f0c2da.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/5acabdcb.tar.gz;
 
 in
 import "${overlays}/boot.nix" {

--- a/shell.nix
+++ b/shell.nix
@@ -10,5 +10,6 @@ mkShell {
   buildInputs = [
     nodejs-14_x
     yarn
+    python3
   ] ++ (with ocamlPackages; [ merlin utop ounit2 ]);
 }


### PR DESCRIPTION
- When developing a project of mine inside a monorepo, I need to pass `--root=.` to `dune clean`
- This was planned but I never got around to implementing it