### PR TITLE
Support @new @variadic

### DIFF
--- a/jscomp/frontend/ast_external_process.ml
+++ b/jscomp/frontend/ast_external_process.ml
@@ -818,12 +818,12 @@ let external_desc_of_non_obj
      val_send_pipe = None;
      set_name = `Nm_na ;
      get_name = `Nm_na ;
-     splice = false;
+     splice;
      scopes;
      mk_obj = _ ;
      return_wrapper = _ ;
     }
-    -> Js_new {name; external_module_name;  scopes}
+    -> Js_new {name; external_module_name; splice; scopes}
   | {new_name = #bundle_source ; _ } ->
     Bs_syntaxerr.err loc (Conflict_ffi_attribute "Attribute found that conflicts with %@new")
   | {set_name = (`Nm_val lazy name | `Nm_external name | `Nm_payload name);

--- a/jscomp/frontend/external_ffi_types.ml
+++ b/jscomp/frontend/external_ffi_types.ml
@@ -73,6 +73,7 @@ type external_spec =
   | Js_new of {
       name : string ;
       external_module_name : external_module_name option;
+      splice : bool;
       scopes : string list;
     }
   | Js_set of

--- a/jscomp/frontend/external_ffi_types.mli
+++ b/jscomp/frontend/external_ffi_types.mli
@@ -63,6 +63,7 @@ type external_spec =
   | Js_new of {
       name : string;
       external_module_name : external_module_name option;
+      splice : bool;
       scopes : string list;
     }
   | Js_set of { js_set_name : string; js_set_scopes : string list }

--- a/jscomp/runtime/caml_splice_call.ml
+++ b/jscomp/runtime/caml_splice_call.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2019- Hongbo Zhang, Authors of ReScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -25,7 +25,7 @@
 type obj = Obj.t
 
 let spliceApply : obj -> obj -> obj = [%raw{|function(fn,args){
-  var i, argLen; 
+  var i, argLen;
   argLen = args.length
   var applied = []
   for(i = 0; i < argLen - 1; ++i){
@@ -36,10 +36,24 @@ let spliceApply : obj -> obj -> obj = [%raw{|function(fn,args){
     applied.push(lastOne[i])
   }
   return fn.apply(null,applied)
-}|}] 
+}|}]
+
+let spliceNewApply : obj -> obj -> obj = [%raw{|function (ctor,args){
+  var i, argLen;
+  argLen = args.length
+  var applied = []
+  for(i = 0; i < argLen - 1; ++i){
+    applied.push(args[i])
+  }
+  var lastOne = args[argLen - 1]
+  for(i = 0; i < lastOne.length; ++i ){
+    applied.push(lastOne[i])
+  }
+  return new ctor(...applied)
+}|}]
 
 let spliceObjApply : obj -> obj -> obj -> obj = [%raw{|function(obj,name,args){
-  var i, argLen; 
+  var i, argLen;
   argLen = args.length
   var applied = []
   for(i = 0; i < argLen - 1; ++i){

--- a/jscomp/runtime/caml_splice_call.mli
+++ b/jscomp/runtime/caml_splice_call.mli
@@ -1,5 +1,5 @@
 (* Copyright (C) 2019- Authors of ReScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -26,5 +26,7 @@
 type obj = Obj.t
 
 val spliceApply : obj -> obj -> obj
+
+val spliceNewApply : obj -> obj -> obj
 
 val spliceObjApply : obj -> obj -> obj -> obj

--- a/jscomp/test/splice_test.js
+++ b/jscomp/test/splice_test.js
@@ -64,11 +64,50 @@ dynamic([
       3
     ]);
 
-var a$1 = [];
+var a$1 = new Array(1, 2, 3, 4);
 
-a$1.push(1, 2, 3, 4);
+eq("File \"splice_test.ml\", line 49, characters 5-12", a$1, [
+      1,
+      2,
+      3,
+      4
+    ]);
 
-eq("File \"splice_test.ml\", line 51, characters 7-14", a$1, [
+function dynamicNew(arr) {
+  var a = Caml_splice_call.spliceNewApply(Array, [
+        1,
+        2,
+        arr
+      ]);
+  eq("File \"splice_test.ml\", line 53, characters 5-12", a, Caml_array.concat({
+            hd: [
+              1,
+              2
+            ],
+            tl: {
+              hd: arr,
+              tl: /* [] */0
+            }
+          }));
+}
+
+dynamicNew([
+      3,
+      4
+    ]);
+
+dynamicNew([]);
+
+dynamicNew([
+      1,
+      3
+    ]);
+
+var a$2 = [];
+
+a$2.push(1, 2, 3, 4);
+
+eq("File \"splice_test.ml\", line 70, characters 7-14", a$2, [
       1,
       2,
       3,
@@ -81,7 +120,7 @@ function dynamic$1(arr) {
         1,
         arr
       ]);
-  eq("File \"splice_test.ml\", line 56, characters 7-14", a, Caml_array.concat({
+  eq("File \"splice_test.ml\", line 75, characters 7-14", a, Caml_array.concat({
             hd: [1],
             tl: {
               hd: arr,
@@ -115,11 +154,11 @@ function f1(c) {
             ]);
 }
 
-eq("File \"splice_test.ml\", line 67, characters 6-13", Math.max(1, 2, 3), 3);
+eq("File \"splice_test.ml\", line 86, characters 6-13", Math.max(1, 2, 3), 3);
 
-eq("File \"splice_test.ml\", line 68, characters 6-13", Math.max(1), 1);
+eq("File \"splice_test.ml\", line 87, characters 6-13", Math.max(1), 1);
 
-eq("File \"splice_test.ml\", line 69, characters 6-13", Math.max(1, 1, 2, 3, 4, 5, 2, 3), 5);
+eq("File \"splice_test.ml\", line 88, characters 6-13", Math.max(1, 1, 2, 3, 4, 5, 2, 3), 5);
 
 Mt.from_pair_suites("splice_test.ml", suites.contents);
 
@@ -129,6 +168,7 @@ exports.eq = eq;
 exports.Caml_splice_call = Caml_splice_call$1;
 exports.f00 = f00;
 exports.dynamic = dynamic;
+exports.dynamicNew = dynamicNew;
 exports.Pipe = Pipe;
 exports.f1 = f1;
 /*  Not a pure module */

--- a/jscomp/test/splice_test.ml
+++ b/jscomp/test/splice_test.ml
@@ -1,70 +1,89 @@
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
-let eq loc x y = Mt.eq_suites ~test_id ~suites loc x y 
+let eq loc x y = Mt.eq_suites ~test_id ~suites loc x y
 
 
-module Caml_splice_call = struct 
-end 
-external f : int -> int array -> int = "Math.max" 
+module Caml_splice_call = struct
+end
+external f : int -> int array -> int = "Math.max"
   [@@bs.splice] [@@bs.val]
 
 ;; f 1 [||] |. ignore
 
-external send : int -> int array -> int = "send" 
+external send : int -> int array -> int = "send"
   [@@bs.splice] [@@bs.send]
 
-let f00 a b =   
+let f00 a b =
   a |. send [|b|]
 
-external push : int array -> int -> int array -> unit = 
+external push : int array -> int -> int array -> unit =
   "push" [@@bs.send] [@@bs.splice]
 
 (* This is only test, the binding maybe wrong
   since in OCaml array'length is not mutable
 *)
-let () =   
-  let a = [||] in 
+let () =
+  let a = [||] in
   a |. push 1 [|2;3;4|];
 
   eq __LOC__ a [|1;2;3;4|]
 
-let dynamic arr =   
-  let a = [||] in 
+let dynamic arr =
+  let a = [||] in
   a |. push 1 arr ;
   eq __LOC__ a (Array.concat [[|1|]; arr])
 
-;; dynamic [|2;3;4|]  
+;; dynamic [|2;3;4|]
 ;; dynamic [||]
 ;; dynamic [|1;1;3|]
 
+(* Array constructor with a single parameter `x`
+   just makes an array with its length set to `x`,
+   so at least two parameters are needed
+*)
+external newArr : int -> int -> int array -> int array = "Array"
+  [@@bs.splice] [@@bs.new]
+
+let () =
+  let a = newArr 1 2 [|3;4|] in
+  eq __LOC__ a [|1;2;3;4|]
+
+let dynamicNew arr =
+  let a = newArr 1 2 arr in
+  eq __LOC__ a (Array.concat [[|1; 2|]; arr])
+
+;; dynamicNew [|3;4|]
+;; dynamicNew [||]
+;; dynamicNew [|1;3|]
+
 module Pipe = struct
-  external push :  int -> int array -> unit = 
-    "push" [@@bs.send.pipe: int array ] [@@bs.splice] 
+  external push :  int -> int array -> unit =
+    "push" [@@bs.send.pipe: int array ] [@@bs.splice]
 
   (* This is only test, the binding maybe wrong
      since in OCaml array'length is not mutable
   *)
-  let () =   
-    let a = [||] in 
+  let () =
+    let a = [||] in
     a |> push 1 [|2;3;4|];
 
     eq __LOC__ a [|1;2;3;4|]
 
-  let dynamic arr =   
-    let a = [||] in 
+  let dynamic arr =
+    let a = [||] in
     a |> push 1 arr ;
     eq __LOC__ a (Array.concat [[|1|]; arr])
 
-  ;; dynamic [|2;3;4|]  
+  ;; dynamic [|2;3;4|]
   ;; dynamic [||]
   ;; dynamic [|1;1;3|]
 
-end 
+end
 
 #if 1 then
-let f1 (c : int array) =  f 1 c 
+let f1 (c : int array) =  f 1 c
 
-;; eq __LOC__ (f1  [|2;3|] ) 3 
+;; eq __LOC__ (f1  [|2;3|] ) 3
 ;; eq __LOC__ (f1  [||] ) 1
 ;; eq __LOC__ (f1 [|1;2;3;4;5;2;3|]) 5
 #end


### PR DESCRIPTION
This PR allows `@new` and `@variadic` to be used simultaneously.

```js
'use strict';
class Foo {
    constructor(...names) {
        this.names = names;
    }
}
let foo = new Foo("bar", "baz");
console.log(foo.names);
```

```rescript
type foo
@get external names: foo => array<string> = "names"
@new @variadic external makeFoo : array<string> => foo = "Foo"
let foo = makeFoo(["bar", "baz"])
Js.log(foo->names)
```