### PR TITLE
Introduce a ReScript compatibility layer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1653467129,
-        "narHash": "sha256-YRUXvBNyEFoEcn/6TlDCr5PTuZvadmCRqTP68bcRghQ=",
+        "lastModified": 1653809686,
+        "narHash": "sha256-otqdK4BMB00Q1kf5bBcIoU2bIwMkIQXdnYJBrIwYFzQ=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "64846b202d7f6c5bb1b61b1ce2feaf7b8af08be4",
+        "rev": "f195f017473a2ef56da1ef7f6a705f4227bd3330",
         "type": "github"
       },
       "original": {
@@ -38,17 +38,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1653315696,
-        "narHash": "sha256-7tLCnzCz/fq86NEoF9+g/NkQRA2J+nkgytc7l2HuWnY=",
+        "lastModified": 1653663379,
+        "narHash": "sha256-xzE3+LY0NHk1G7jvJvR6gDu4iNtwpRmHLCiJVVyXUHg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c11d9597c1b3cdc4fb44cbab48deec2cfbaa5281",
+        "rev": "60a08714866da907bc9e63e49a157c8d20893520",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c11d9597c1b3cdc4fb44cbab48deec2cfbaa5281",
+        "rev": "60a08714866da907bc9e63e49a157c8d20893520",
         "type": "github"
       }
     },

--- a/jscomp/core/dune
+++ b/jscomp/core/dune
@@ -14,6 +14,7 @@
   melange-compiler-libs
   outcome_printer
   js_parser
+  ppx_rescript_compat
   napkin))
 
 (rule

--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -99,14 +99,9 @@ let after_parsing_sig ppf outputprefix ast =
         initial_env sg;
       process_with_gentype (outputprefix ^ ".cmti"))
 
-let interface ~parser ~lang ppf fname =
+let interface ~parser ~lang:_ ppf fname =
   Res_compmisc.init_path ();
   let sig_ = parser fname |> Ast_deriving_compat.signature in
-  let sig_ =
-    match lang with
-    | `rescript -> Ppx_rescript_compat.signature sig_
-    | _ -> sig_
-  in
   sig_
   |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name
        Mli

--- a/jscomp/core/js_implementation.mli
+++ b/jscomp/core/js_implementation.mli
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -25,9 +25,13 @@
 (** High level compilation module *)
 
 val interface :
-  parser:(string -> Parsetree.signature) -> Format.formatter -> string -> unit
+  parser:(string -> Parsetree.signature) ->
+  lang:[ `ml | `rescript | `reason ] ->
+  Format.formatter ->
+  string ->
+  unit
 (** This module defines a function to compile the program directly into [js]
-    given [filename] and [outputprefix], 
+    given [filename] and [outputprefix],
     it will be useful if we don't care about bytecode output(generating js only).
  *)
 
@@ -45,7 +49,11 @@ val interface_mliast :
 *)
 
 val implementation :
-  parser:(string -> Parsetree.structure) -> Format.formatter -> string -> unit
+  parser:(string -> Parsetree.structure) ->
+  lang:[ `ml | `rescript | `reason ] ->
+  Format.formatter ->
+  string ->
+  unit
 (** [implementation ppf sourcefile outprefix] compiles to JS directly *)
 
 val implementation_mlast :

--- a/jscomp/main/melc.ml
+++ b/jscomp/main/melc.ml
@@ -58,34 +58,40 @@ let process_file sourcefile
     setup_error_printer `reason;
     Js_implementation.implementation
       ~parser:Ast_reason_pp.RE.parse_implementation
+      ~lang:`reason
       ppf sourcefile
   | Rei ->
     let sourcefile = set_abs_input_name  sourcefile in
     setup_error_printer `reason;
     Js_implementation.interface
       ~parser:Ast_reason_pp.RE.parse_interface
+      ~lang:`reason
       ppf sourcefile
   | Ml ->
     let sourcefile = set_abs_input_name  sourcefile in
     Js_implementation.implementation
       ~parser:Pparse_driver.parse_implementation
+      ~lang:`ml
       ppf sourcefile
   | Mli  ->
     let sourcefile = set_abs_input_name  sourcefile in
     Js_implementation.interface
       ~parser:Pparse_driver.parse_interface
+      ~lang:`ml
       ppf sourcefile
   | Res ->
     let sourcefile = set_abs_input_name  sourcefile in
     setup_error_printer `rescript;
     Js_implementation.implementation
       ~parser:Napkin.Res_driver.parse_implementation
+      ~lang:`rescript
       ppf sourcefile
   | Resi ->
     let sourcefile = set_abs_input_name  sourcefile in
     setup_error_printer `rescript;
     Js_implementation.interface
       ~parser:Napkin.Res_driver.parse_interface
+      ~lang:`rescript
       ppf sourcefile
   | Intf_ast
     ->

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   src = lib.filterGitSource {
     src = ./..;
-    dirs = [ "jscomp" "lib" "scripts" ];
+    dirs = [ "jscomp" "lib" "ppx_rescript_compat" "scripts" ];
     files = [
       "dune-project"
       "dune"

--- a/ppx_rescript_compat/dune
+++ b/ppx_rescript_compat/dune
@@ -1,0 +1,3 @@
+(library
+ (name ppx_rescript_compat)
+ (libraries frontend))

--- a/ppx_rescript_compat/ppx_rescript_compat.ml
+++ b/ppx_rescript_compat/ppx_rescript_compat.ml
@@ -38,7 +38,7 @@ let expr_mapper (self : mapper) (expr : Parsetree.expression) =
   match expr.pexp_desc with
   | Pexp_send (({ pexp_desc = Pexp_ident _; _ } as ident), { txt = name; loc })
     ->
-      (* ReScript removed them OCaml object system and abuses `Pexp_send` for
+      (* ReScript removed the OCaml object system and abuses `Pexp_send` for
          `obj##property`. Here, we make that conversion. *)
       { expr with pexp_desc = Ast_util.js_property loc ident name }
   | _ -> default_mapper.expr self expr

--- a/ppx_rescript_compat/ppx_rescript_compat.ml
+++ b/ppx_rescript_compat/ppx_rescript_compat.ml
@@ -1,0 +1,48 @@
+(* Copyright (C) 2022- Authors of Melange
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+(*
+ * This PPX runs during the compilation of ReScript files. It's meant to
+ * contain a translation layer, where possible, from ReScript features to
+ * Melange features. Currently, we perform the following transforms:
+ *
+ *  - `obj["prop"]` -> `obj##prop`
+ *)
+
+type mapper = Bs_ast_mapper.mapper
+
+let default_mapper = Bs_ast_mapper.default_mapper
+
+let expr_mapper (self : mapper) (expr : Parsetree.expression) =
+  match expr.pexp_desc with
+  | Pexp_send (({ pexp_desc = Pexp_ident _; _ } as ident), { txt = name; loc })
+    ->
+      (* ReScript removed them OCaml object system and abuses `Pexp_send` for
+         `obj##property`. Here, we make that conversion. *)
+      { expr with pexp_desc = Ast_util.js_property loc ident name }
+  | _ -> default_mapper.expr self expr
+
+let mapper : mapper = { default_mapper with expr = expr_mapper }
+let structure ast = mapper.structure mapper ast
+let signature ast = mapper.signature mapper ast

--- a/ppx_rescript_compat/ppx_rescript_compat.mli
+++ b/ppx_rescript_compat/ppx_rescript_compat.mli
@@ -1,0 +1,26 @@
+(* Copyright (C) 2021- Authors of Melange
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+val structure : Parsetree.structure -> Parsetree.structure
+val signature : Parsetree.signature -> Parsetree.signature


### PR DESCRIPTION
This PR introduces a ReScript compatibility layer that aims to run on ReScript files and translate some of the Melange-incompatible transforms to compatible AST nodes.

This allows applications that use ReScript features to work within Melange codebases.

Right now, the only transform the PPX performs is `obj["prop"]` -> `obj##prop`.