### PR TITLE
Fixes for dev-time Merlin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1653809686,
-        "narHash": "sha256-otqdK4BMB00Q1kf5bBcIoU2bIwMkIQXdnYJBrIwYFzQ=",
+        "lastModified": 1653867233,
+        "narHash": "sha256-M5dr7ZT1AbURGixK9fLWnZLD4F9O5cY9mHnJtfk5oTI=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "f195f017473a2ef56da1ef7f6a705f4227bd3330",
+        "rev": "a1d46c5c2c9b23f43ebb21fadbe5c7e9a95e9cd1",
         "type": "github"
       },
       "original": {
@@ -38,17 +38,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1653663379,
-        "narHash": "sha256-xzE3+LY0NHk1G7jvJvR6gDu4iNtwpRmHLCiJVVyXUHg=",
+        "lastModified": 1653750779,
+        "narHash": "sha256-yQ5bsgAnUMS/MB2uRi+RANcXtlNENYp5+CZNvDVGxFo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60a08714866da907bc9e63e49a157c8d20893520",
+        "rev": "fa66e6d444f37c80d973d75fd3e0d28e286d8ea4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60a08714866da907bc9e63e49a157c8d20893520",
+        "rev": "fa66e6d444f37c80d973d75fd3e0d28e286d8ea4",
         "type": "github"
       }
     },

--- a/jscomp/common/js_config.cppo.ml
+++ b/jscomp/common/js_config.cppo.ml
@@ -22,9 +22,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-
-
 let (//) = Ext_path.combine
+
+#ifndef BS_RELEASE_BUILD
+let executable_name =
+  lazy (Unix.realpath (Ext_path.normalize_absolute_path Sys.executable_name))
+#endif
 
 let install_dir = lazy (
 #ifdef BS_RELEASE_BUILD
@@ -33,7 +36,7 @@ let install_dir = lazy (
   Filename.(dirname (dirname Sys.executable_name))
 #else
   (* <root>/jscomp/main/bsc.exe -> <root> *)
-  Filename.(dirname (dirname (Ext_path.normalize_absolute_path Sys.executable_name)))
+  Filename.(dirname (dirname (Lazy.force executable_name)))
 #endif
 )
 
@@ -48,7 +51,7 @@ let include_dirs =
   let jscomp =
     (* jscomp/main/bsc.exe -> jscomp *)
     Filename.dirname
-      (Filename.dirname (Ext_path.real_path Sys.executable_name))
+      (Filename.dirname (Lazy.force executable_name))
   in
   [ (jscomp//"others")
   ; (jscomp//"stdlib-412/stdlib_modules")

--- a/jscomp/others/dune.gen
+++ b/jscomp/others/dune.gen
@@ -360,7 +360,7 @@
 
 
   (rule
-    (targets js_OO.cmi js_OO.cmj )
+    (targets js_OO.cmi js_OO.cmj js_OO.cmt )
     (deps (:inputs js_OO.ml) (alias ../runtime/runtime))
 
     (action
@@ -368,7 +368,7 @@
 
 
   (rule
-    (targets js_array.cmi js_array.cmj )
+    (targets js_array.cmi js_array.cmj js_array.cmt )
     (deps (:inputs js_array.ml) (alias ../runtime/runtime) js_array2.cmj)
 
     (action
@@ -376,7 +376,7 @@
 
 
   (rule
-    (targets js_array2.cmi js_array2.cmj )
+    (targets js_array2.cmi js_array2.cmj js_array2.cmt )
     (deps (:inputs js_array2.ml) (alias ../runtime/runtime))
 
     (action
@@ -384,7 +384,7 @@
 
 
   (rule
-    (targets js_cast.cmj )
+    (targets js_cast.cmj js_cast.cmt )
     (deps (:inputs js_cast.ml) (alias ../runtime/runtime) js_cast.cmi)
 
     (action
@@ -392,7 +392,7 @@
 
 
   (rule
-    (targets js_cast.cmi )
+    (targets js_cast.cmi js_cast.cmti )
     (deps (:inputs js_cast.mli) (alias ../runtime/runtime))
 
     (action
@@ -400,7 +400,7 @@
 
 
   (rule
-    (targets js_console.cmi js_console.cmj )
+    (targets js_console.cmi js_console.cmj js_console.cmt )
     (deps (:inputs js_console.ml) (alias ../runtime/runtime))
 
     (action
@@ -408,7 +408,7 @@
 
 
   (rule
-    (targets js_date.cmi js_date.cmj )
+    (targets js_date.cmi js_date.cmj js_date.cmt )
     (deps (:inputs js_date.ml) (alias ../runtime/runtime))
 
     (action
@@ -416,7 +416,7 @@
 
 
   (rule
-    (targets js_dict.cmj )
+    (targets js_dict.cmj js_dict.cmt )
     (deps (:inputs js_dict.ml) (alias ../runtime/runtime) js_array2.cmj js_dict.cmi)
 
     (action
@@ -424,7 +424,7 @@
 
 
   (rule
-    (targets js_dict.cmi )
+    (targets js_dict.cmi js_dict.cmti )
     (deps (:inputs js_dict.mli) (alias ../runtime/runtime))
 
     (action
@@ -432,7 +432,7 @@
 
 
   (rule
-    (targets js_exn.cmj )
+    (targets js_exn.cmj js_exn.cmt )
     (deps (:inputs js_exn.ml) (alias ../runtime/runtime) js_exn.cmi)
 
     (action
@@ -440,7 +440,7 @@
 
 
   (rule
-    (targets js_exn.cmi )
+    (targets js_exn.cmi js_exn.cmti )
     (deps (:inputs js_exn.mli) (alias ../runtime/runtime))
 
     (action
@@ -448,7 +448,7 @@
 
 
   (rule
-    (targets js_float.cmi js_float.cmj )
+    (targets js_float.cmi js_float.cmj js_float.cmt )
     (deps (:inputs js_float.ml) (alias ../runtime/runtime))
 
     (action
@@ -456,7 +456,7 @@
 
 
   (rule
-    (targets js_global.cmi js_global.cmj )
+    (targets js_global.cmi js_global.cmj js_global.cmt )
     (deps (:inputs js_global.ml) (alias ../runtime/runtime))
 
     (action
@@ -464,7 +464,7 @@
 
 
   (rule
-    (targets js_int.cmi js_int.cmj )
+    (targets js_int.cmi js_int.cmj js_int.cmt )
     (deps (:inputs js_int.ml) (alias ../runtime/runtime))
 
     (action
@@ -472,7 +472,7 @@
 
 
   (rule
-    (targets js_json.cmj )
+    (targets js_json.cmj js_json.cmt )
     (deps (:inputs js_json.ml) (alias ../runtime/runtime) js_array2.cmj js_dict.cmj js_json.cmi js_string.cmj js_types.cmj)
 
     (action
@@ -480,7 +480,7 @@
 
 
   (rule
-    (targets js_json.cmi )
+    (targets js_json.cmi js_json.cmti )
     (deps (:inputs js_json.mli) (alias ../runtime/runtime) js_dict.cmi js_null.cmi js_string.cmj js_types.cmi)
 
     (action
@@ -488,7 +488,7 @@
 
 
   (rule
-    (targets js_list.cmj )
+    (targets js_list.cmj js_list.cmt )
     (deps (:inputs js_list.ml) (alias ../runtime/runtime) js_array2.cmj js_list.cmi js_vector.cmj)
 
     (action
@@ -496,7 +496,7 @@
 
 
   (rule
-    (targets js_list.cmi )
+    (targets js_list.cmi js_list.cmti )
     (deps (:inputs js_list.mli) (alias ../runtime/runtime))
 
     (action
@@ -504,7 +504,7 @@
 
 
   (rule
-    (targets js_mapperRt.cmj )
+    (targets js_mapperRt.cmj js_mapperRt.cmt )
     (deps (:inputs js_mapperRt.ml) (alias ../runtime/runtime) js_mapperRt.cmi)
 
     (action
@@ -512,7 +512,7 @@
 
 
   (rule
-    (targets js_mapperRt.cmi )
+    (targets js_mapperRt.cmi js_mapperRt.cmti )
     (deps (:inputs js_mapperRt.mli) (alias ../runtime/runtime))
 
     (action
@@ -520,7 +520,7 @@
 
 
   (rule
-    (targets js_math.cmi js_math.cmj )
+    (targets js_math.cmi js_math.cmj js_math.cmt )
     (deps (:inputs js_math.ml) (alias ../runtime/runtime) js_int.cmj)
 
     (action
@@ -528,7 +528,7 @@
 
 
   (rule
-    (targets js_null.cmj )
+    (targets js_null.cmj js_null.cmt )
     (deps (:inputs js_null.ml) (alias ../runtime/runtime) js_exn.cmj js_null.cmi)
 
     (action
@@ -536,7 +536,7 @@
 
 
   (rule
-    (targets js_null.cmi )
+    (targets js_null.cmi js_null.cmti )
     (deps (:inputs js_null.mli) (alias ../runtime/runtime))
 
     (action
@@ -544,7 +544,7 @@
 
 
   (rule
-    (targets js_null_undefined.cmj )
+    (targets js_null_undefined.cmj js_null_undefined.cmt )
     (deps (:inputs js_null_undefined.ml) (alias ../runtime/runtime) js_null_undefined.cmi)
 
     (action
@@ -552,7 +552,7 @@
 
 
   (rule
-    (targets js_null_undefined.cmi )
+    (targets js_null_undefined.cmi js_null_undefined.cmti )
     (deps (:inputs js_null_undefined.mli) (alias ../runtime/runtime))
 
     (action
@@ -560,7 +560,7 @@
 
 
   (rule
-    (targets js_obj.cmi js_obj.cmj )
+    (targets js_obj.cmi js_obj.cmj js_obj.cmt )
     (deps (:inputs js_obj.ml) (alias ../runtime/runtime))
 
     (action
@@ -568,7 +568,7 @@
 
 
   (rule
-    (targets js_option.cmj )
+    (targets js_option.cmj js_option.cmt )
     (deps (:inputs js_option.ml) (alias ../runtime/runtime) js_exn.cmj js_option.cmi)
 
     (action
@@ -576,7 +576,7 @@
 
 
   (rule
-    (targets js_option.cmi )
+    (targets js_option.cmi js_option.cmti )
     (deps (:inputs js_option.mli) (alias ../runtime/runtime))
 
     (action
@@ -584,7 +584,7 @@
 
 
   (rule
-    (targets js_promise.cmi js_promise.cmj )
+    (targets js_promise.cmi js_promise.cmj js_promise.cmt )
     (deps (:inputs js_promise.ml) (alias ../runtime/runtime))
 
     (action
@@ -592,7 +592,7 @@
 
 
   (rule
-    (targets js_re.cmi js_re.cmj )
+    (targets js_re.cmi js_re.cmj js_re.cmt )
     (deps (:inputs js_re.ml) (alias ../runtime/runtime))
 
     (action
@@ -600,7 +600,7 @@
 
 
   (rule
-    (targets js_result.cmj )
+    (targets js_result.cmj js_result.cmt )
     (deps (:inputs js_result.ml) (alias ../runtime/runtime) js_result.cmi)
 
     (action
@@ -608,7 +608,7 @@
 
 
   (rule
-    (targets js_result.cmi )
+    (targets js_result.cmi js_result.cmti )
     (deps (:inputs js_result.mli) (alias ../runtime/runtime))
 
     (action
@@ -616,7 +616,7 @@
 
 
   (rule
-    (targets js_string.cmi js_string.cmj )
+    (targets js_string.cmi js_string.cmj js_string.cmt )
     (deps (:inputs js_string.ml) (alias ../runtime/runtime) js_array2.cmj js_re.cmj)
 
     (action
@@ -624,7 +624,7 @@
 
 
   (rule
-    (targets js_string2.cmi js_string2.cmj )
+    (targets js_string2.cmi js_string2.cmj js_string2.cmt )
     (deps (:inputs js_string2.ml) (alias ../runtime/runtime) js_array2.cmj js_re.cmj)
 
     (action
@@ -632,7 +632,7 @@
 
 
   (rule
-    (targets js_types.cmj )
+    (targets js_types.cmj js_types.cmt )
     (deps (:inputs js_types.ml) (alias ../runtime/runtime) js_null.cmj js_types.cmi)
 
     (action
@@ -640,7 +640,7 @@
 
 
   (rule
-    (targets js_types.cmi )
+    (targets js_types.cmi js_types.cmti )
     (deps (:inputs js_types.mli) (alias ../runtime/runtime))
 
     (action
@@ -648,7 +648,7 @@
 
 
   (rule
-    (targets js_undefined.cmj )
+    (targets js_undefined.cmj js_undefined.cmt )
     (deps (:inputs js_undefined.ml) (alias ../runtime/runtime) js_exn.cmj js_undefined.cmi)
 
     (action
@@ -656,7 +656,7 @@
 
 
   (rule
-    (targets js_undefined.cmi )
+    (targets js_undefined.cmi js_undefined.cmti )
     (deps (:inputs js_undefined.mli) (alias ../runtime/runtime))
 
     (action
@@ -664,7 +664,7 @@
 
 
   (rule
-    (targets js_vector.cmj )
+    (targets js_vector.cmj js_vector.cmt )
     (deps (:inputs js_vector.ml) (alias ../runtime/runtime) js_array2.cmj js_vector.cmi)
 
     (action
@@ -672,7 +672,7 @@
 
 
   (rule
-    (targets js_vector.cmi )
+    (targets js_vector.cmi js_vector.cmti )
     (deps (:inputs js_vector.mli) (alias ../runtime/runtime))
 
     (action
@@ -685,7 +685,7 @@
   
 
   (rule
-    (targets belt_Array.cmj )
+    (targets belt_Array.cmj belt_Array.cmt )
     (deps (:inputs belt_Array.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmi js_math.cmj)
 
     (action
@@ -693,7 +693,7 @@
 
 
   (rule
-    (targets belt_Array.cmi )
+    (targets belt_Array.cmi belt_Array.cmti )
     (deps (:inputs belt_Array.mli) (alias ../runtime/runtime))
 
     (action
@@ -701,7 +701,7 @@
 
 
   (rule
-    (targets belt_Float.cmj )
+    (targets belt_Float.cmj belt_Float.cmt )
     (deps (:inputs belt_Float.ml) (alias ../runtime/runtime) belt.cmi belt_Float.cmi)
 
     (action
@@ -709,7 +709,7 @@
 
 
   (rule
-    (targets belt_Float.cmi )
+    (targets belt_Float.cmi belt_Float.cmti )
     (deps (:inputs belt_Float.mli) (alias ../runtime/runtime))
 
     (action
@@ -717,7 +717,7 @@
 
 
   (rule
-    (targets belt_HashMap.cmj )
+    (targets belt_HashMap.cmj belt_HashMap.cmt )
     (deps (:inputs belt_HashMap.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_HashMap.cmi belt_HashMapInt.cmi belt_HashMapInt.cmj belt_HashMapString.cmi belt_HashMapString.cmj belt_Id.cmj belt_internalBuckets.cmj belt_internalBucketsType.cmj)
 
     (action
@@ -725,7 +725,7 @@
 
 
   (rule
-    (targets belt_HashMap.cmi )
+    (targets belt_HashMap.cmi belt_HashMap.cmti )
     (deps (:inputs belt_HashMap.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_HashMapInt.cmi belt_HashMapInt.cmj belt_HashMapString.cmi belt_HashMapString.cmj belt_Id.cmi)
 
     (action
@@ -733,7 +733,7 @@
 
 
   (rule
-    (targets belt_HashMapInt.cmj )
+    (targets belt_HashMapInt.cmj belt_HashMapInt.cmt )
     (deps (:inputs belt_HashMapInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_HashMapInt.cmi belt_internalBuckets.cmi belt_internalBuckets.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj)
 
     (action
@@ -741,7 +741,7 @@
 
 
   (rule
-    (targets belt_HashMapInt.cmi )
+    (targets belt_HashMapInt.cmi belt_HashMapInt.cmti )
     (deps (:inputs belt_HashMapInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalBuckets.cmi belt_internalBuckets.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj)
 
     (action
@@ -749,7 +749,7 @@
 
 
   (rule
-    (targets belt_HashMapString.cmj )
+    (targets belt_HashMapString.cmj belt_HashMapString.cmt )
     (deps (:inputs belt_HashMapString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_HashMapString.cmi belt_internalBuckets.cmi belt_internalBuckets.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj)
 
     (action
@@ -757,7 +757,7 @@
 
 
   (rule
-    (targets belt_HashMapString.cmi )
+    (targets belt_HashMapString.cmi belt_HashMapString.cmti )
     (deps (:inputs belt_HashMapString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalBuckets.cmi belt_internalBuckets.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj)
 
     (action
@@ -765,7 +765,7 @@
 
 
   (rule
-    (targets belt_HashSet.cmj )
+    (targets belt_HashSet.cmj belt_HashSet.cmt )
     (deps (:inputs belt_HashSet.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_HashSet.cmi belt_HashSetInt.cmi belt_HashSetInt.cmj belt_HashSetString.cmi belt_HashSetString.cmj belt_Id.cmj belt_internalBucketsType.cmj belt_internalSetBuckets.cmj)
 
     (action
@@ -773,7 +773,7 @@
 
 
   (rule
-    (targets belt_HashSet.cmi )
+    (targets belt_HashSet.cmi belt_HashSet.cmti )
     (deps (:inputs belt_HashSet.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_HashSetInt.cmi belt_HashSetInt.cmj belt_HashSetString.cmi belt_HashSetString.cmj belt_Id.cmi)
 
     (action
@@ -781,7 +781,7 @@
 
 
   (rule
-    (targets belt_HashSetInt.cmj )
+    (targets belt_HashSetInt.cmj belt_HashSetInt.cmt )
     (deps (:inputs belt_HashSetInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_HashSetInt.cmi belt_internalBucketsType.cmi belt_internalBucketsType.cmj belt_internalSetBuckets.cmi belt_internalSetBuckets.cmj)
 
     (action
@@ -789,7 +789,7 @@
 
 
   (rule
-    (targets belt_HashSetInt.cmi )
+    (targets belt_HashSetInt.cmi belt_HashSetInt.cmti )
     (deps (:inputs belt_HashSetInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj belt_internalSetBuckets.cmi belt_internalSetBuckets.cmj)
 
     (action
@@ -797,7 +797,7 @@
 
 
   (rule
-    (targets belt_HashSetString.cmj )
+    (targets belt_HashSetString.cmj belt_HashSetString.cmt )
     (deps (:inputs belt_HashSetString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_HashSetString.cmi belt_internalBucketsType.cmi belt_internalBucketsType.cmj belt_internalSetBuckets.cmi belt_internalSetBuckets.cmj)
 
     (action
@@ -805,7 +805,7 @@
 
 
   (rule
-    (targets belt_HashSetString.cmi )
+    (targets belt_HashSetString.cmi belt_HashSetString.cmti )
     (deps (:inputs belt_HashSetString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalBucketsType.cmi belt_internalBucketsType.cmj belt_internalSetBuckets.cmi belt_internalSetBuckets.cmj)
 
     (action
@@ -813,7 +813,7 @@
 
 
   (rule
-    (targets belt_Id.cmj )
+    (targets belt_Id.cmj belt_Id.cmt )
     (deps (:inputs belt_Id.ml) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
 
     (action
@@ -821,7 +821,7 @@
 
 
   (rule
-    (targets belt_Id.cmi )
+    (targets belt_Id.cmi belt_Id.cmti )
     (deps (:inputs belt_Id.mli) (alias ../runtime/runtime))
 
     (action
@@ -829,7 +829,7 @@
 
 
   (rule
-    (targets belt_Int.cmj )
+    (targets belt_Int.cmj belt_Int.cmt )
     (deps (:inputs belt_Int.ml) (alias ../runtime/runtime) belt.cmi belt_Int.cmi)
 
     (action
@@ -837,7 +837,7 @@
 
 
   (rule
-    (targets belt_Int.cmi )
+    (targets belt_Int.cmi belt_Int.cmti )
     (deps (:inputs belt_Int.mli) (alias ../runtime/runtime))
 
     (action
@@ -845,7 +845,7 @@
 
 
   (rule
-    (targets belt_List.cmj )
+    (targets belt_List.cmj belt_List.cmt )
     (deps (:inputs belt_List.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_List.cmi belt_SortArray.cmj)
 
     (action
@@ -853,7 +853,7 @@
 
 
   (rule
-    (targets belt_List.cmi )
+    (targets belt_List.cmi belt_List.cmti )
     (deps (:inputs belt_List.mli) (alias ../runtime/runtime))
 
     (action
@@ -861,7 +861,7 @@
 
 
   (rule
-    (targets belt_Map.cmj )
+    (targets belt_Map.cmj belt_Map.cmt )
     (deps (:inputs belt_Map.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmj belt_Map.cmi belt_MapDict.cmj belt_MapInt.cmi belt_MapInt.cmj belt_MapString.cmi belt_MapString.cmj)
 
     (action
@@ -869,7 +869,7 @@
 
 
   (rule
-    (targets belt_Map.cmi )
+    (targets belt_Map.cmi belt_Map.cmti )
     (deps (:inputs belt_Map.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmi belt_MapDict.cmi belt_MapInt.cmi belt_MapInt.cmj belt_MapString.cmi belt_MapString.cmj)
 
     (action
@@ -877,7 +877,7 @@
 
 
   (rule
-    (targets belt_MapDict.cmj )
+    (targets belt_MapDict.cmj belt_MapDict.cmt )
     (deps (:inputs belt_MapDict.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_Id.cmj belt_MapDict.cmi belt_internalAVLtree.cmj)
 
     (action
@@ -885,7 +885,7 @@
 
 
   (rule
-    (targets belt_MapDict.cmi )
+    (targets belt_MapDict.cmi belt_MapDict.cmti )
     (deps (:inputs belt_MapDict.mli) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
 
     (action
@@ -893,7 +893,7 @@
 
 
   (rule
-    (targets belt_MapInt.cmj )
+    (targets belt_MapInt.cmj belt_MapInt.cmt )
     (deps (:inputs belt_MapInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MapInt.cmi belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapInt.cmi belt_internalMapInt.cmj)
 
     (action
@@ -901,7 +901,7 @@
 
 
   (rule
-    (targets belt_MapInt.cmi )
+    (targets belt_MapInt.cmi belt_MapInt.cmti )
     (deps (:inputs belt_MapInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapInt.cmi belt_internalMapInt.cmj)
 
     (action
@@ -909,7 +909,7 @@
 
 
   (rule
-    (targets belt_MapString.cmj )
+    (targets belt_MapString.cmj belt_MapString.cmt )
     (deps (:inputs belt_MapString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MapString.cmi belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapString.cmi belt_internalMapString.cmj)
 
     (action
@@ -917,7 +917,7 @@
 
 
   (rule
-    (targets belt_MapString.cmi )
+    (targets belt_MapString.cmi belt_MapString.cmti )
     (deps (:inputs belt_MapString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapString.cmi belt_internalMapString.cmj)
 
     (action
@@ -925,7 +925,7 @@
 
 
   (rule
-    (targets belt_MutableMap.cmj )
+    (targets belt_MutableMap.cmj belt_MutableMap.cmt )
     (deps (:inputs belt_MutableMap.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_Id.cmj belt_MutableMap.cmi belt_MutableMapInt.cmi belt_MutableMapInt.cmj belt_MutableMapString.cmi belt_MutableMapString.cmj belt_internalAVLtree.cmj)
 
     (action
@@ -933,7 +933,7 @@
 
 
   (rule
-    (targets belt_MutableMap.cmi )
+    (targets belt_MutableMap.cmi belt_MutableMap.cmti )
     (deps (:inputs belt_MutableMap.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmi belt_MutableMapInt.cmi belt_MutableMapInt.cmj belt_MutableMapString.cmi belt_MutableMapString.cmj)
 
     (action
@@ -941,7 +941,7 @@
 
 
   (rule
-    (targets belt_MutableMapInt.cmj )
+    (targets belt_MutableMapInt.cmj belt_MutableMapInt.cmt )
     (deps (:inputs belt_MutableMapInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MutableMapInt.cmi belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapInt.cmi belt_internalMapInt.cmj)
 
     (action
@@ -949,7 +949,7 @@
 
 
   (rule
-    (targets belt_MutableMapInt.cmi )
+    (targets belt_MutableMapInt.cmi belt_MutableMapInt.cmti )
     (deps (:inputs belt_MutableMapInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapInt.cmi belt_internalMapInt.cmj)
 
     (action
@@ -957,7 +957,7 @@
 
 
   (rule
-    (targets belt_MutableMapString.cmj )
+    (targets belt_MutableMapString.cmj belt_MutableMapString.cmt )
     (deps (:inputs belt_MutableMapString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MutableMapString.cmi belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapString.cmi belt_internalMapString.cmj)
 
     (action
@@ -965,7 +965,7 @@
 
 
   (rule
-    (targets belt_MutableMapString.cmi )
+    (targets belt_MutableMapString.cmi belt_MutableMapString.cmti )
     (deps (:inputs belt_MutableMapString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj belt_internalMapString.cmi belt_internalMapString.cmj)
 
     (action
@@ -973,7 +973,7 @@
 
 
   (rule
-    (targets belt_MutableQueue.cmj )
+    (targets belt_MutableQueue.cmj belt_MutableQueue.cmt )
     (deps (:inputs belt_MutableQueue.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_MutableQueue.cmi)
 
     (action
@@ -981,7 +981,7 @@
 
 
   (rule
-    (targets belt_MutableQueue.cmi )
+    (targets belt_MutableQueue.cmi belt_MutableQueue.cmti )
     (deps (:inputs belt_MutableQueue.mli) (alias ../runtime/runtime))
 
     (action
@@ -989,7 +989,7 @@
 
 
   (rule
-    (targets belt_MutableSet.cmj )
+    (targets belt_MutableSet.cmj belt_MutableSet.cmt )
     (deps (:inputs belt_MutableSet.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_Id.cmj belt_MutableSet.cmi belt_MutableSetInt.cmi belt_MutableSetInt.cmj belt_MutableSetString.cmi belt_MutableSetString.cmj belt_SortArray.cmj belt_internalAVLset.cmj)
 
     (action
@@ -997,7 +997,7 @@
 
 
   (rule
-    (targets belt_MutableSet.cmi )
+    (targets belt_MutableSet.cmi belt_MutableSet.cmti )
     (deps (:inputs belt_MutableSet.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmi belt_MutableSetInt.cmi belt_MutableSetInt.cmj belt_MutableSetString.cmi belt_MutableSetString.cmj)
 
     (action
@@ -1005,7 +1005,7 @@
 
 
   (rule
-    (targets belt_MutableSetInt.cmj )
+    (targets belt_MutableSetInt.cmj belt_MutableSetInt.cmt )
     (deps (:inputs belt_MutableSetInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MutableSetInt.cmi belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetInt.cmi belt_internalSetInt.cmj)
 
     (action
@@ -1013,7 +1013,7 @@
 
 
   (rule
-    (targets belt_MutableSetInt.cmi )
+    (targets belt_MutableSetInt.cmi belt_MutableSetInt.cmti )
     (deps (:inputs belt_MutableSetInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetInt.cmi belt_internalSetInt.cmj)
 
     (action
@@ -1021,7 +1021,7 @@
 
 
   (rule
-    (targets belt_MutableSetString.cmj )
+    (targets belt_MutableSetString.cmj belt_MutableSetString.cmt )
     (deps (:inputs belt_MutableSetString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_MutableSetString.cmi belt_SortArrayString.cmi belt_SortArrayString.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetString.cmi belt_internalSetString.cmj)
 
     (action
@@ -1029,7 +1029,7 @@
 
 
   (rule
-    (targets belt_MutableSetString.cmi )
+    (targets belt_MutableSetString.cmi belt_MutableSetString.cmti )
     (deps (:inputs belt_MutableSetString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_SortArrayString.cmi belt_SortArrayString.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetString.cmi belt_internalSetString.cmj)
 
     (action
@@ -1037,7 +1037,7 @@
 
 
   (rule
-    (targets belt_MutableStack.cmj )
+    (targets belt_MutableStack.cmj belt_MutableStack.cmt )
     (deps (:inputs belt_MutableStack.ml) (alias ../runtime/runtime) belt.cmi belt_MutableStack.cmi)
 
     (action
@@ -1045,7 +1045,7 @@
 
 
   (rule
-    (targets belt_MutableStack.cmi )
+    (targets belt_MutableStack.cmi belt_MutableStack.cmti )
     (deps (:inputs belt_MutableStack.mli) (alias ../runtime/runtime))
 
     (action
@@ -1053,7 +1053,7 @@
 
 
   (rule
-    (targets belt_Option.cmj )
+    (targets belt_Option.cmj belt_Option.cmt )
     (deps (:inputs belt_Option.ml) (alias ../runtime/runtime) belt.cmi belt_Option.cmi)
 
     (action
@@ -1061,7 +1061,7 @@
 
 
   (rule
-    (targets belt_Option.cmi )
+    (targets belt_Option.cmi belt_Option.cmti )
     (deps (:inputs belt_Option.mli) (alias ../runtime/runtime))
 
     (action
@@ -1069,7 +1069,7 @@
 
 
   (rule
-    (targets belt_Range.cmj )
+    (targets belt_Range.cmj belt_Range.cmt )
     (deps (:inputs belt_Range.ml) (alias ../runtime/runtime) belt.cmi belt_Range.cmi)
 
     (action
@@ -1077,7 +1077,7 @@
 
 
   (rule
-    (targets belt_Range.cmi )
+    (targets belt_Range.cmi belt_Range.cmti )
     (deps (:inputs belt_Range.mli) (alias ../runtime/runtime))
 
     (action
@@ -1085,7 +1085,7 @@
 
 
   (rule
-    (targets belt_Result.cmj )
+    (targets belt_Result.cmj belt_Result.cmt )
     (deps (:inputs belt_Result.ml) (alias ../runtime/runtime) belt.cmi belt_Result.cmi)
 
     (action
@@ -1093,7 +1093,7 @@
 
 
   (rule
-    (targets belt_Result.cmi )
+    (targets belt_Result.cmi belt_Result.cmti )
     (deps (:inputs belt_Result.mli) (alias ../runtime/runtime))
 
     (action
@@ -1101,7 +1101,7 @@
 
 
   (rule
-    (targets belt_Set.cmj )
+    (targets belt_Set.cmj belt_Set.cmt )
     (deps (:inputs belt_Set.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmj belt_Set.cmi belt_SetDict.cmj belt_SetInt.cmi belt_SetInt.cmj belt_SetString.cmi belt_SetString.cmj)
 
     (action
@@ -1109,7 +1109,7 @@
 
 
   (rule
-    (targets belt_Set.cmi )
+    (targets belt_Set.cmi belt_Set.cmti )
     (deps (:inputs belt_Set.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Id.cmi belt_SetDict.cmi belt_SetInt.cmi belt_SetInt.cmj belt_SetString.cmi belt_SetString.cmj)
 
     (action
@@ -1117,7 +1117,7 @@
 
 
   (rule
-    (targets belt_SetDict.cmj )
+    (targets belt_SetDict.cmj belt_SetDict.cmt )
     (deps (:inputs belt_SetDict.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_Id.cmj belt_SetDict.cmi belt_internalAVLset.cmj)
 
     (action
@@ -1125,7 +1125,7 @@
 
 
   (rule
-    (targets belt_SetDict.cmi )
+    (targets belt_SetDict.cmi belt_SetDict.cmti )
     (deps (:inputs belt_SetDict.mli) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
 
     (action
@@ -1133,7 +1133,7 @@
 
 
   (rule
-    (targets belt_SetInt.cmj )
+    (targets belt_SetInt.cmj belt_SetInt.cmt )
     (deps (:inputs belt_SetInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SetInt.cmi belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetInt.cmi belt_internalSetInt.cmj)
 
     (action
@@ -1141,7 +1141,7 @@
 
 
   (rule
-    (targets belt_SetInt.cmi )
+    (targets belt_SetInt.cmi belt_SetInt.cmti )
     (deps (:inputs belt_SetInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetInt.cmi belt_internalSetInt.cmj)
 
     (action
@@ -1149,7 +1149,7 @@
 
 
   (rule
-    (targets belt_SetString.cmj )
+    (targets belt_SetString.cmj belt_SetString.cmt )
     (deps (:inputs belt_SetString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SetString.cmi belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetString.cmi belt_internalSetString.cmj)
 
     (action
@@ -1157,7 +1157,7 @@
 
 
   (rule
-    (targets belt_SetString.cmi )
+    (targets belt_SetString.cmi belt_SetString.cmti )
     (deps (:inputs belt_SetString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj belt_internalSetString.cmi belt_internalSetString.cmj)
 
     (action
@@ -1165,7 +1165,7 @@
 
 
   (rule
-    (targets belt_SortArray.cmj )
+    (targets belt_SortArray.cmj belt_SortArray.cmt )
     (deps (:inputs belt_SortArray.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmj belt_SortArray.cmi belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_SortArrayString.cmi belt_SortArrayString.cmj)
 
     (action
@@ -1173,7 +1173,7 @@
 
 
   (rule
-    (targets belt_SortArray.cmi )
+    (targets belt_SortArray.cmi belt_SortArray.cmti )
     (deps (:inputs belt_SortArray.mli) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_SortArrayString.cmi belt_SortArrayString.cmj)
 
     (action
@@ -1181,7 +1181,7 @@
 
 
   (rule
-    (targets belt_SortArrayInt.cmj )
+    (targets belt_SortArrayInt.cmj belt_SortArrayInt.cmt )
     (deps (:inputs belt_SortArrayInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArrayInt.cmi)
 
     (action
@@ -1189,7 +1189,7 @@
 
 
   (rule
-    (targets belt_SortArrayInt.cmi )
+    (targets belt_SortArrayInt.cmi belt_SortArrayInt.cmti )
     (deps (:inputs belt_SortArrayInt.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj)
 
     (action
@@ -1197,7 +1197,7 @@
 
 
   (rule
-    (targets belt_SortArrayString.cmj )
+    (targets belt_SortArrayString.cmj belt_SortArrayString.cmt )
     (deps (:inputs belt_SortArrayString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArrayString.cmi)
 
     (action
@@ -1205,7 +1205,7 @@
 
 
   (rule
-    (targets belt_SortArrayString.cmi )
+    (targets belt_SortArrayString.cmi belt_SortArrayString.cmti )
     (deps (:inputs belt_SortArrayString.mli) (alias ../runtime/runtime) (alias js_pkg) belt_Array.cmi belt_Array.cmj)
 
     (action
@@ -1213,7 +1213,7 @@
 
 
   (rule
-    (targets belt_internalAVLset.cmj )
+    (targets belt_internalAVLset.cmj belt_internalAVLset.cmt )
     (deps (:inputs belt_internalAVLset.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_Id.cmj belt_SortArray.cmj belt_internalAVLset.cmi)
 
     (action
@@ -1221,7 +1221,7 @@
 
 
   (rule
-    (targets belt_internalAVLset.cmi )
+    (targets belt_internalAVLset.cmi belt_internalAVLset.cmti )
     (deps (:inputs belt_internalAVLset.mli) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
 
     (action
@@ -1229,7 +1229,7 @@
 
 
   (rule
-    (targets belt_internalAVLtree.cmj )
+    (targets belt_internalAVLtree.cmj belt_internalAVLtree.cmt )
     (deps (:inputs belt_internalAVLtree.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_Id.cmj belt_SortArray.cmj belt_internalAVLtree.cmi)
 
     (action
@@ -1237,7 +1237,7 @@
 
 
   (rule
-    (targets belt_internalAVLtree.cmi )
+    (targets belt_internalAVLtree.cmi belt_internalAVLtree.cmti )
     (deps (:inputs belt_internalAVLtree.mli) (alias ../runtime/runtime) belt.cmi belt_Id.cmi)
 
     (action
@@ -1245,7 +1245,7 @@
 
 
   (rule
-    (targets belt_internalBuckets.cmj )
+    (targets belt_internalBuckets.cmj belt_internalBuckets.cmt )
     (deps (:inputs belt_internalBuckets.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_internalBuckets.cmi belt_internalBucketsType.cmj)
 
     (action
@@ -1253,7 +1253,7 @@
 
 
   (rule
-    (targets belt_internalBuckets.cmi )
+    (targets belt_internalBuckets.cmi belt_internalBuckets.cmti )
     (deps (:inputs belt_internalBuckets.mli) (alias ../runtime/runtime) belt.cmi belt_internalBucketsType.cmi)
 
     (action
@@ -1261,7 +1261,7 @@
 
 
   (rule
-    (targets belt_internalBucketsType.cmj )
+    (targets belt_internalBucketsType.cmj belt_internalBucketsType.cmt )
     (deps (:inputs belt_internalBucketsType.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_internalBucketsType.cmi)
 
     (action
@@ -1269,7 +1269,7 @@
 
 
   (rule
-    (targets belt_internalBucketsType.cmi )
+    (targets belt_internalBucketsType.cmi belt_internalBucketsType.cmti )
     (deps (:inputs belt_internalBucketsType.mli) (alias ../runtime/runtime))
 
     (action
@@ -1277,7 +1277,7 @@
 
 
   (rule
-    (targets belt_internalMapInt.cmi belt_internalMapInt.cmj )
+    (targets belt_internalMapInt.cmi belt_internalMapInt.cmj belt_internalMapInt.cmt )
     (deps (:inputs belt_internalMapInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArray.cmi belt_SortArray.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj)
 
     (action
@@ -1285,7 +1285,7 @@
 
 
   (rule
-    (targets belt_internalMapString.cmi belt_internalMapString.cmj )
+    (targets belt_internalMapString.cmi belt_internalMapString.cmj belt_internalMapString.cmt )
     (deps (:inputs belt_internalMapString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArray.cmi belt_SortArray.cmj belt_internalAVLtree.cmi belt_internalAVLtree.cmj)
 
     (action
@@ -1293,7 +1293,7 @@
 
 
   (rule
-    (targets belt_internalSetBuckets.cmj )
+    (targets belt_internalSetBuckets.cmj belt_internalSetBuckets.cmt )
     (deps (:inputs belt_internalSetBuckets.ml) (alias ../runtime/runtime) belt.cmi belt_Array.cmj belt_internalBucketsType.cmj belt_internalSetBuckets.cmi)
 
     (action
@@ -1301,7 +1301,7 @@
 
 
   (rule
-    (targets belt_internalSetBuckets.cmi )
+    (targets belt_internalSetBuckets.cmi belt_internalSetBuckets.cmti )
     (deps (:inputs belt_internalSetBuckets.mli) (alias ../runtime/runtime) belt.cmi belt_internalBucketsType.cmi)
 
     (action
@@ -1309,7 +1309,7 @@
 
 
   (rule
-    (targets belt_internalSetInt.cmi belt_internalSetInt.cmj )
+    (targets belt_internalSetInt.cmi belt_internalSetInt.cmj belt_internalSetInt.cmt )
     (deps (:inputs belt_internalSetInt.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArrayInt.cmi belt_SortArrayInt.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj)
 
     (action
@@ -1317,7 +1317,7 @@
 
 
   (rule
-    (targets belt_internalSetString.cmi belt_internalSetString.cmj )
+    (targets belt_internalSetString.cmi belt_internalSetString.cmj belt_internalSetString.cmt )
     (deps (:inputs belt_internalSetString.ml) (alias ../runtime/runtime) (alias js_pkg) belt.cmi belt_Array.cmi belt_Array.cmj belt_SortArrayString.cmi belt_SortArrayString.cmj belt_internalAVLset.cmi belt_internalAVLset.cmj)
 
     (action
@@ -1325,7 +1325,7 @@
 
 
   (rule
-    (targets dom.cmi dom.cmj )
+    (targets dom.cmi dom.cmj dom.cmt )
     (deps (:inputs dom.ml) (alias ../runtime/runtime) dom_storage.cmj dom_storage2.cmj)
 
     (action
@@ -1333,7 +1333,7 @@
 
 
   (rule
-    (targets dom_storage.cmi dom_storage.cmj )
+    (targets dom_storage.cmi dom_storage.cmj dom_storage.cmt )
     (deps (:inputs dom_storage.ml) (alias ../runtime/runtime) dom_storage2.cmj)
 
     (action
@@ -1341,7 +1341,7 @@
 
 
   (rule
-    (targets dom_storage2.cmi dom_storage2.cmj )
+    (targets dom_storage2.cmi dom_storage2.cmj dom_storage2.cmt )
     (deps (:inputs dom_storage2.ml) (alias ../runtime/runtime))
 
     (action
@@ -1349,7 +1349,7 @@
 
 
   (rule
-    (targets node_buffer.cmi node_buffer.cmj )
+    (targets node_buffer.cmi node_buffer.cmj node_buffer.cmt )
     (deps (:inputs node_buffer.ml) (alias ../runtime/runtime) node.cmi node.cmj)
 
     (action
@@ -1357,7 +1357,7 @@
 
 
   (rule
-    (targets node_child_process.cmi node_child_process.cmj )
+    (targets node_child_process.cmi node_child_process.cmj node_child_process.cmt )
     (deps (:inputs node_child_process.ml) (alias ../runtime/runtime) node.cmi node.cmj)
 
     (action
@@ -1365,7 +1365,7 @@
 
 
   (rule
-    (targets node_fs.cmi node_fs.cmj )
+    (targets node_fs.cmi node_fs.cmj node_fs.cmt )
     (deps (:inputs node_fs.ml) (alias ../runtime/runtime) js_string.cmj node.cmi node.cmj)
 
     (action
@@ -1373,7 +1373,7 @@
 
 
   (rule
-    (targets node_module.cmi node_module.cmj )
+    (targets node_module.cmi node_module.cmj node_module.cmt )
     (deps (:inputs node_module.ml) (alias ../runtime/runtime) js_dict.cmj node.cmi node.cmj)
 
     (action
@@ -1381,7 +1381,7 @@
 
 
   (rule
-    (targets node_path.cmi node_path.cmj )
+    (targets node_path.cmi node_path.cmj node_path.cmt )
     (deps (:inputs node_path.ml) (alias ../runtime/runtime))
 
     (action
@@ -1389,7 +1389,7 @@
 
 
   (rule
-    (targets node_process.cmj )
+    (targets node_process.cmj node_process.cmt )
     (deps (:inputs node_process.ml) (alias ../runtime/runtime) js_dict.cmj node.cmi node_process.cmi)
 
     (action
@@ -1397,7 +1397,7 @@
 
 
   (rule
-    (targets node_process.cmi )
+    (targets node_process.cmi node_process.cmti )
     (deps (:inputs node_process.mli) (alias ../runtime/runtime) js_dict.cmi node.cmi)
 
     (action
@@ -1405,7 +1405,7 @@
 
 
   (rule
-    (targets js_typed_array.cmi js_typed_array.cmj )
+    (targets js_typed_array.cmi js_typed_array.cmj js_typed_array.cmt )
     (deps (:inputs js_typed_array.ml) (alias ../runtime/runtime) (alias js_pkg) js_typed_array2.cmi js_typed_array2.cmj)
 
     (action
@@ -1413,7 +1413,7 @@
 
 
   (rule
-    (targets js_typed_array2.cmi js_typed_array2.cmj )
+    (targets js_typed_array2.cmi js_typed_array2.cmj js_typed_array2.cmt )
     (deps (:inputs js_typed_array2.ml) (alias ../runtime/runtime))
 
     (action

--- a/jscomp/runtime/dune.gen
+++ b/jscomp/runtime/dune.gen
@@ -18,7 +18,7 @@
 
 
   (rule
-    (targets caml.cmj )
+    (targets caml.cmj caml.cmt )
     (deps (:inputs caml.ml) caml.cmi caml_int64_extern.cmj)
 
     (action
@@ -26,7 +26,7 @@
 
 
   (rule
-    (targets caml.cmi )
+    (targets caml.cmi caml.cmti )
     (deps (:inputs caml.mli) bs_stdlib_mini.cmi caml_int64_extern.cmj js.cmi js.cmj)
 
     (action
@@ -34,7 +34,7 @@
 
 
   (rule
-    (targets caml_array.cmj )
+    (targets caml_array.cmj caml_array.cmt )
     (deps (:inputs caml_array.ml) caml_array.cmi caml_array_extern.cmj)
 
     (action
@@ -42,7 +42,7 @@
 
 
   (rule
-    (targets caml_array.cmi )
+    (targets caml_array.cmi caml_array.cmti )
     (deps (:inputs caml_array.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -50,7 +50,7 @@
 
 
   (rule
-    (targets caml_bytes.cmj )
+    (targets caml_bytes.cmj caml_bytes.cmt )
     (deps (:inputs caml_bytes.ml) caml_bytes.cmi caml_string_extern.cmj)
 
     (action
@@ -58,7 +58,7 @@
 
 
   (rule
-    (targets caml_bytes.cmi )
+    (targets caml_bytes.cmi caml_bytes.cmti )
     (deps (:inputs caml_bytes.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -66,7 +66,7 @@
 
 
   (rule
-    (targets caml_float.cmj )
+    (targets caml_float.cmj caml_float.cmt )
     (deps (:inputs caml_float.ml) caml_float.cmi caml_float_extern.cmj)
 
     (action
@@ -74,7 +74,7 @@
 
 
   (rule
-    (targets caml_float.cmi )
+    (targets caml_float.cmi caml_float.cmti )
     (deps (:inputs caml_float.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -82,7 +82,7 @@
 
 
   (rule
-    (targets caml_format.cmj )
+    (targets caml_format.cmj caml_format.cmt )
     (deps (:inputs caml_format.ml) caml_float.cmj caml_float_extern.cmj caml_format.cmi caml_int64.cmj caml_int64_extern.cmj caml_nativeint_extern.cmj caml_string_extern.cmj)
 
     (action
@@ -90,7 +90,7 @@
 
 
   (rule
-    (targets caml_format.cmi )
+    (targets caml_format.cmi caml_format.cmti )
     (deps (:inputs caml_format.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -98,7 +98,7 @@
 
 
   (rule
-    (targets caml_gc.cmj )
+    (targets caml_gc.cmj caml_gc.cmt )
     (deps (:inputs caml_gc.ml) caml_gc.cmi)
 
     (action
@@ -106,7 +106,7 @@
 
 
   (rule
-    (targets caml_gc.cmi )
+    (targets caml_gc.cmi caml_gc.cmti )
     (deps (:inputs caml_gc.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -114,7 +114,7 @@
 
 
   (rule
-    (targets caml_hash.cmj )
+    (targets caml_hash.cmj caml_hash.cmt )
     (deps (:inputs caml_hash.ml) caml_hash.cmi caml_hash_primitive.cmj caml_nativeint_extern.cmj js.cmj)
 
     (action
@@ -122,7 +122,7 @@
 
 
   (rule
-    (targets caml_hash.cmi )
+    (targets caml_hash.cmi caml_hash.cmti )
     (deps (:inputs caml_hash.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -130,7 +130,7 @@
 
 
   (rule
-    (targets caml_hash_primitive.cmj )
+    (targets caml_hash_primitive.cmj caml_hash_primitive.cmt )
     (deps (:inputs caml_hash_primitive.ml) caml_hash_primitive.cmi caml_string_extern.cmj)
 
     (action
@@ -138,7 +138,7 @@
 
 
   (rule
-    (targets caml_hash_primitive.cmi )
+    (targets caml_hash_primitive.cmi caml_hash_primitive.cmti )
     (deps (:inputs caml_hash_primitive.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -146,7 +146,7 @@
 
 
   (rule
-    (targets caml_int32.cmj )
+    (targets caml_int32.cmj caml_int32.cmt )
     (deps (:inputs caml_int32.ml) caml_int32.cmi caml_nativeint_extern.cmj)
 
     (action
@@ -154,7 +154,7 @@
 
 
   (rule
-    (targets caml_int32.cmi )
+    (targets caml_int32.cmi caml_int32.cmti )
     (deps (:inputs caml_int32.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -162,7 +162,7 @@
 
 
   (rule
-    (targets caml_int64.cmj )
+    (targets caml_int64.cmj caml_int64.cmt )
     (deps (:inputs caml_int64.ml) caml.cmj caml_float.cmj caml_float_extern.cmj caml_int64.cmi caml_int64_extern.cmj caml_nativeint_extern.cmj caml_string_extern.cmj js.cmj)
 
     (action
@@ -170,7 +170,7 @@
 
 
   (rule
-    (targets caml_int64.cmi )
+    (targets caml_int64.cmi caml_int64.cmti )
     (deps (:inputs caml_int64.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -178,7 +178,7 @@
 
 
   (rule
-    (targets caml_io.cmj )
+    (targets caml_io.cmj caml_io.cmt )
     (deps (:inputs caml_io.ml) caml_io.cmi caml_string_extern.cmj caml_undefined_extern.cmj js.cmj)
 
     (action
@@ -186,7 +186,7 @@
 
 
   (rule
-    (targets caml_io.cmi )
+    (targets caml_io.cmi caml_io.cmti )
     (deps (:inputs caml_io.mli) bs_stdlib_mini.cmi caml_undefined_extern.cmj js.cmi js.cmj)
 
     (action
@@ -194,7 +194,7 @@
 
 
   (rule
-    (targets caml_lexer.cmj )
+    (targets caml_lexer.cmj caml_lexer.cmt )
     (deps (:inputs caml_lexer.ml) caml_lexer.cmi)
 
     (action
@@ -202,7 +202,7 @@
 
 
   (rule
-    (targets caml_lexer.cmi )
+    (targets caml_lexer.cmi caml_lexer.cmti )
     (deps (:inputs caml_lexer.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -210,7 +210,7 @@
 
 
   (rule
-    (targets caml_md5.cmj )
+    (targets caml_md5.cmj caml_md5.cmt )
     (deps (:inputs caml_md5.ml) caml_array_extern.cmj caml_int32_extern.cmj caml_md5.cmi caml_string_extern.cmj)
 
     (action
@@ -218,7 +218,7 @@
 
 
   (rule
-    (targets caml_md5.cmi )
+    (targets caml_md5.cmi caml_md5.cmti )
     (deps (:inputs caml_md5.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -226,7 +226,7 @@
 
 
   (rule
-    (targets caml_module.cmj )
+    (targets caml_module.cmj caml_module.cmt )
     (deps (:inputs caml_module.ml) caml_array_extern.cmj caml_module.cmi caml_obj.cmj)
 
     (action
@@ -234,7 +234,7 @@
 
 
   (rule
-    (targets caml_module.cmi )
+    (targets caml_module.cmi caml_module.cmti )
     (deps (:inputs caml_module.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -242,7 +242,7 @@
 
 
   (rule
-    (targets caml_obj.cmj )
+    (targets caml_obj.cmj caml_obj.cmt )
     (deps (:inputs caml_obj.ml) caml_array_extern.cmj caml_obj.cmi caml_option.cmj js.cmj)
 
     (action
@@ -250,7 +250,7 @@
 
 
   (rule
-    (targets caml_obj.cmi )
+    (targets caml_obj.cmi caml_obj.cmti )
     (deps (:inputs caml_obj.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -258,7 +258,7 @@
 
 
   (rule
-    (targets caml_oo.cmj )
+    (targets caml_oo.cmj caml_oo.cmt )
     (deps (:inputs caml_oo.ml) caml_array_extern.cmj caml_exceptions.cmj caml_oo.cmi)
 
     (action
@@ -266,7 +266,7 @@
 
 
   (rule
-    (targets caml_oo.cmi )
+    (targets caml_oo.cmi caml_oo.cmti )
     (deps (:inputs caml_oo.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -274,7 +274,7 @@
 
 
   (rule
-    (targets caml_option.cmj )
+    (targets caml_option.cmj caml_option.cmt )
     (deps (:inputs caml_option.ml) caml_option.cmi caml_undefined_extern.cmj js.cmj)
 
     (action
@@ -282,7 +282,7 @@
 
 
   (rule
-    (targets caml_option.cmi )
+    (targets caml_option.cmi caml_option.cmti )
     (deps (:inputs caml_option.mli) bs_stdlib_mini.cmi caml_undefined_extern.cmj js.cmi js.cmj)
 
     (action
@@ -290,7 +290,7 @@
 
 
   (rule
-    (targets caml_parser.cmj )
+    (targets caml_parser.cmj caml_parser.cmt )
     (deps (:inputs caml_parser.ml) caml_parser.cmi)
 
     (action
@@ -298,7 +298,7 @@
 
 
   (rule
-    (targets caml_parser.cmi )
+    (targets caml_parser.cmi caml_parser.cmti )
     (deps (:inputs caml_parser.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -306,7 +306,7 @@
 
 
   (rule
-    (targets caml_splice_call.cmj )
+    (targets caml_splice_call.cmj caml_splice_call.cmt )
     (deps (:inputs caml_splice_call.ml) caml_splice_call.cmi)
 
     (action
@@ -314,7 +314,7 @@
 
 
   (rule
-    (targets caml_splice_call.cmi )
+    (targets caml_splice_call.cmi caml_splice_call.cmti )
     (deps (:inputs caml_splice_call.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -322,7 +322,7 @@
 
 
   (rule
-    (targets caml_string.cmj )
+    (targets caml_string.cmj caml_string.cmt )
     (deps (:inputs caml_string.ml) caml_string.cmi caml_string_extern.cmj)
 
     (action
@@ -330,7 +330,7 @@
 
 
   (rule
-    (targets caml_string.cmi )
+    (targets caml_string.cmi caml_string.cmti )
     (deps (:inputs caml_string.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -338,7 +338,7 @@
 
 
   (rule
-    (targets caml_sys.cmj )
+    (targets caml_sys.cmj caml_sys.cmt )
     (deps (:inputs caml_sys.ml) caml_array_extern.cmj caml_sys.cmi caml_undefined_extern.cmj js.cmj)
 
     (action
@@ -346,7 +346,7 @@
 
 
   (rule
-    (targets caml_sys.cmi )
+    (targets caml_sys.cmi caml_sys.cmti )
     (deps (:inputs caml_sys.mli) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -354,7 +354,7 @@
 
 
   (rule
-    (targets caml_array_extern.cmi caml_array_extern.cmj )
+    (targets caml_array_extern.cmi caml_array_extern.cmj caml_array_extern.cmt )
     (deps (:inputs caml_array_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -362,7 +362,7 @@
 
 
   (rule
-    (targets caml_exceptions.cmi caml_exceptions.cmj )
+    (targets caml_exceptions.cmi caml_exceptions.cmj caml_exceptions.cmt )
     (deps (:inputs caml_exceptions.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -370,7 +370,7 @@
 
 
   (rule
-    (targets caml_external_polyfill.cmi caml_external_polyfill.cmj )
+    (targets caml_external_polyfill.cmi caml_external_polyfill.cmj caml_external_polyfill.cmt )
     (deps (:inputs caml_external_polyfill.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -378,7 +378,7 @@
 
 
   (rule
-    (targets caml_float_extern.cmi caml_float_extern.cmj )
+    (targets caml_float_extern.cmi caml_float_extern.cmj caml_float_extern.cmt )
     (deps (:inputs caml_float_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -386,7 +386,7 @@
 
 
   (rule
-    (targets caml_int32_extern.cmi caml_int32_extern.cmj )
+    (targets caml_int32_extern.cmi caml_int32_extern.cmj caml_int32_extern.cmt )
     (deps (:inputs caml_int32_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -394,7 +394,7 @@
 
 
   (rule
-    (targets caml_int64_extern.cmi caml_int64_extern.cmj )
+    (targets caml_int64_extern.cmi caml_int64_extern.cmj caml_int64_extern.cmt )
     (deps (:inputs caml_int64_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -402,7 +402,7 @@
 
 
   (rule
-    (targets caml_js_exceptions.cmi caml_js_exceptions.cmj )
+    (targets caml_js_exceptions.cmi caml_js_exceptions.cmj caml_js_exceptions.cmt )
     (deps (:inputs caml_js_exceptions.ml) bs_stdlib_mini.cmi caml_exceptions.cmj js.cmi js.cmj)
 
     (action
@@ -410,7 +410,7 @@
 
 
   (rule
-    (targets caml_nativeint_extern.cmi caml_nativeint_extern.cmj )
+    (targets caml_nativeint_extern.cmi caml_nativeint_extern.cmj caml_nativeint_extern.cmt )
     (deps (:inputs caml_nativeint_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -418,7 +418,7 @@
 
 
   (rule
-    (targets caml_oo_curry.cmi caml_oo_curry.cmj )
+    (targets caml_oo_curry.cmi caml_oo_curry.cmj caml_oo_curry.cmt )
     (deps (:inputs caml_oo_curry.ml) bs_stdlib_mini.cmi caml_oo.cmj curry.cmj js.cmi js.cmj)
 
     (action
@@ -426,7 +426,7 @@
 
 
   (rule
-    (targets caml_string_extern.cmi caml_string_extern.cmj )
+    (targets caml_string_extern.cmi caml_string_extern.cmj caml_string_extern.cmt )
     (deps (:inputs caml_string_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -434,7 +434,7 @@
 
 
   (rule
-    (targets caml_undefined_extern.cmi caml_undefined_extern.cmj )
+    (targets caml_undefined_extern.cmi caml_undefined_extern.cmj caml_undefined_extern.cmt )
     (deps (:inputs caml_undefined_extern.ml) bs_stdlib_mini.cmi js.cmi js.cmj)
 
     (action
@@ -442,7 +442,7 @@
 
 
   (rule
-    (targets curry.cmi curry.cmj )
+    (targets curry.cmi curry.cmj curry.cmt )
     (deps (:inputs curry.ml) bs_stdlib_mini.cmi caml_array.cmi caml_array_extern.cmj js.cmi js.cmj)
 
     (action

--- a/jscomp/stdlib-412/stdlib_modules/dune.gen
+++ b/jscomp/stdlib-412/stdlib_modules/dune.gen
@@ -49,7 +49,7 @@
 
 
   (rule
-    (targets arg.cmj )
+    (targets arg.cmj arg.cmt )
     (deps (:inputs arg.ml) (alias ../../others/others) arg.cmi array.cmj buffer.cmj int.cmj list.cmj printf.cmj string.cmj sys.cmj)
 
     (action
@@ -57,7 +57,7 @@
 
 
   (rule
-    (targets arg.cmi )
+    (targets arg.cmi arg.cmti )
     (deps (:inputs arg.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -65,7 +65,7 @@
 
 
   (rule
-    (targets array.cmj )
+    (targets array.cmj array.cmt )
     (deps (:inputs array.ml) (alias ../../others/others) array.cmi seq.cmj)
 
     (action
@@ -73,7 +73,7 @@
 
 
   (rule
-    (targets array.cmi )
+    (targets array.cmi array.cmti )
     (deps (:inputs array.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -81,7 +81,7 @@
 
 
   (rule
-    (targets arrayLabels.cmj )
+    (targets arrayLabels.cmj arrayLabels.cmt )
     (deps (:inputs arrayLabels.ml) (alias ../../others/others) array.cmj arrayLabels.cmi)
 
     (action
@@ -89,7 +89,7 @@
 
 
   (rule
-    (targets arrayLabels.cmi )
+    (targets arrayLabels.cmi arrayLabels.cmti )
     (deps (:inputs arrayLabels.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -97,7 +97,7 @@
 
 
   (rule
-    (targets atomic.cmj )
+    (targets atomic.cmj atomic.cmt )
     (deps (:inputs atomic.ml) (alias ../../others/others) atomic.cmi camlinternalAtomic.cmj)
 
     (action
@@ -105,7 +105,7 @@
 
 
   (rule
-    (targets atomic.cmi )
+    (targets atomic.cmi atomic.cmti )
     (deps (:inputs atomic.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -113,7 +113,7 @@
 
 
   (rule
-    (targets bool.cmj )
+    (targets bool.cmj bool.cmt )
     (deps (:inputs bool.ml) (alias ../../others/others) bool.cmi)
 
     (action
@@ -121,7 +121,7 @@
 
 
   (rule
-    (targets bool.cmi )
+    (targets bool.cmi bool.cmti )
     (deps (:inputs bool.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -129,7 +129,7 @@
 
 
   (rule
-    (targets buffer.cmj )
+    (targets buffer.cmj buffer.cmt )
     (deps (:inputs buffer.ml) (alias ../../others/others) buffer.cmi bytes.cmj seq.cmj string.cmj sys.cmj)
 
     (action
@@ -137,7 +137,7 @@
 
 
   (rule
-    (targets buffer.cmi )
+    (targets buffer.cmi buffer.cmti )
     (deps (:inputs buffer.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj uchar.cmi)
 
     (action
@@ -145,7 +145,7 @@
 
 
   (rule
-    (targets bytes.cmj )
+    (targets bytes.cmj bytes.cmt )
     (deps (:inputs bytes.ml) (alias ../../others/others) bytes.cmi char.cmj int.cmj seq.cmj sys.cmj uchar.cmj)
 
     (action
@@ -153,7 +153,7 @@
 
 
   (rule
-    (targets bytes.cmi )
+    (targets bytes.cmi bytes.cmti )
     (deps (:inputs bytes.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj uchar.cmi)
 
     (action
@@ -161,7 +161,7 @@
 
 
   (rule
-    (targets bytesLabels.cmj )
+    (targets bytesLabels.cmj bytesLabels.cmt )
     (deps (:inputs bytesLabels.ml) (alias ../../others/others) bytes.cmj bytesLabels.cmi)
 
     (action
@@ -169,7 +169,7 @@
 
 
   (rule
-    (targets bytesLabels.cmi )
+    (targets bytesLabels.cmi bytesLabels.cmti )
     (deps (:inputs bytesLabels.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj uchar.cmi)
 
     (action
@@ -177,7 +177,7 @@
 
 
   (rule
-    (targets callback.cmj )
+    (targets callback.cmj callback.cmt )
     (deps (:inputs callback.ml) (alias ../../others/others) callback.cmi obj.cmj)
 
     (action
@@ -185,7 +185,7 @@
 
 
   (rule
-    (targets callback.cmi )
+    (targets callback.cmi callback.cmti )
     (deps (:inputs callback.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -193,7 +193,7 @@
 
 
   (rule
-    (targets camlinternalFormat.cmj )
+    (targets camlinternalFormat.cmj camlinternalFormat.cmt )
     (deps (:inputs camlinternalFormat.ml) (alias ../../others/others) bool.cmj buffer.cmj bytes.cmj camlinternalFormat.cmi camlinternalFormatBasics.cmj char.cmj float.cmj int.cmj int32.cmj int64.cmj string.cmj sys.cmj)
 
     (action
@@ -201,7 +201,7 @@
 
 
   (rule
-    (targets camlinternalFormat.cmi )
+    (targets camlinternalFormat.cmi camlinternalFormat.cmti )
     (deps (:inputs camlinternalFormat.mli) (alias ../../others/others) buffer.cmi camlinternalFormatBasics.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -209,7 +209,7 @@
 
 
   (rule
-    (targets camlinternalLazy.cmj )
+    (targets camlinternalLazy.cmj camlinternalLazy.cmt )
     (deps (:inputs camlinternalLazy.ml) (alias ../../others/others) camlinternalLazy.cmi sys.cmj)
 
     (action
@@ -217,7 +217,7 @@
 
 
   (rule
-    (targets camlinternalLazy.cmi )
+    (targets camlinternalLazy.cmi camlinternalLazy.cmti )
     (deps (:inputs camlinternalLazy.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -225,7 +225,7 @@
 
 
   (rule
-    (targets camlinternalMod.cmj )
+    (targets camlinternalMod.cmj camlinternalMod.cmt )
     (deps (:inputs camlinternalMod.ml) (alias ../../others/others) array.cmj camlinternalMod.cmi camlinternalOO.cmj lazy.cmj obj.cmj)
 
     (action
@@ -233,7 +233,7 @@
 
 
   (rule
-    (targets camlinternalMod.cmi )
+    (targets camlinternalMod.cmi camlinternalMod.cmti )
     (deps (:inputs camlinternalMod.mli) (alias ../../others/others) lazy.cmi obj.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -241,7 +241,7 @@
 
 
   (rule
-    (targets camlinternalOO.cmj )
+    (targets camlinternalOO.cmj camlinternalOO.cmt )
     (deps (:inputs camlinternalOO.ml) (alias ../../others/others) array.cmj camlinternalOO.cmi char.cmj list.cmj map.cmj obj.cmj string.cmj sys.cmj)
 
     (action
@@ -249,7 +249,7 @@
 
 
   (rule
-    (targets camlinternalOO.cmi )
+    (targets camlinternalOO.cmi camlinternalOO.cmti )
     (deps (:inputs camlinternalOO.mli) (alias ../../others/others) obj.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -257,7 +257,7 @@
 
 
   (rule
-    (targets char.cmj )
+    (targets char.cmj char.cmt )
     (deps (:inputs char.ml) (alias ../../others/others) char.cmi)
 
     (action
@@ -265,7 +265,7 @@
 
 
   (rule
-    (targets char.cmi )
+    (targets char.cmi char.cmti )
     (deps (:inputs char.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -273,7 +273,7 @@
 
 
   (rule
-    (targets complex.cmj )
+    (targets complex.cmj complex.cmt )
     (deps (:inputs complex.ml) (alias ../../others/others) complex.cmi)
 
     (action
@@ -281,7 +281,7 @@
 
 
   (rule
-    (targets complex.cmi )
+    (targets complex.cmi complex.cmti )
     (deps (:inputs complex.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -289,7 +289,7 @@
 
 
   (rule
-    (targets digest.cmj )
+    (targets digest.cmj digest.cmt )
     (deps (:inputs digest.ml) (alias ../../others/others) bytes.cmj char.cmj digest.cmi string.cmj)
 
     (action
@@ -297,7 +297,7 @@
 
 
   (rule
-    (targets digest.cmi )
+    (targets digest.cmi digest.cmti )
     (deps (:inputs digest.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -305,7 +305,7 @@
 
 
   (rule
-    (targets either.cmj )
+    (targets either.cmj either.cmt )
     (deps (:inputs either.ml) (alias ../../others/others) either.cmi)
 
     (action
@@ -313,7 +313,7 @@
 
 
   (rule
-    (targets either.cmi )
+    (targets either.cmi either.cmti )
     (deps (:inputs either.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -321,7 +321,7 @@
 
 
   (rule
-    (targets ephemeron.cmj )
+    (targets ephemeron.cmj ephemeron.cmt )
     (deps (:inputs ephemeron.ml) (alias ../../others/others) array.cmj ephemeron.cmi hashtbl.cmj int.cmj lazy.cmj list.cmj obj.cmj random.cmj seq.cmj sys.cmj)
 
     (action
@@ -329,7 +329,7 @@
 
 
   (rule
-    (targets ephemeron.cmi )
+    (targets ephemeron.cmi ephemeron.cmti )
     (deps (:inputs ephemeron.mli) (alias ../../others/others) hashtbl.cmi seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -337,7 +337,7 @@
 
 
   (rule
-    (targets filename.cmj )
+    (targets filename.cmj filename.cmt )
     (deps (:inputs filename.ml) (alias ../../others/others) buffer.cmj filename.cmi lazy.cmj list.cmj printf.cmj random.cmj string.cmj sys.cmj)
 
     (action
@@ -345,7 +345,7 @@
 
 
   (rule
-    (targets filename.cmi )
+    (targets filename.cmi filename.cmti )
     (deps (:inputs filename.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -353,7 +353,7 @@
 
 
   (rule
-    (targets float.cmj )
+    (targets float.cmj float.cmt )
     (deps (:inputs float.ml) (alias ../../others/others) array.cmj arrayLabels.cmj float.cmi list.cmj seq.cmj)
 
     (action
@@ -361,7 +361,7 @@
 
 
   (rule
-    (targets float.cmi )
+    (targets float.cmi float.cmti )
     (deps (:inputs float.mli) (alias ../../others/others) array.cmi arrayLabels.cmi seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -369,7 +369,7 @@
 
 
   (rule
-    (targets format.cmj )
+    (targets format.cmj format.cmt )
     (deps (:inputs format.ml) (alias ../../others/others) buffer.cmj bytes.cmj camlinternalFormat.cmj camlinternalFormatBasics.cmj either.cmj format.cmi int.cmj list.cmj queue.cmj seq.cmj stack.cmj string.cmj)
 
     (action
@@ -377,7 +377,7 @@
 
 
   (rule
-    (targets format.cmi )
+    (targets format.cmi format.cmti )
     (deps (:inputs format.mli) (alias ../../others/others) buffer.cmi either.cmi seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -385,7 +385,7 @@
 
 
   (rule
-    (targets fun.cmj )
+    (targets fun.cmj fun.cmt )
     (deps (:inputs fun.ml) (alias ../../others/others) fun.cmi printexc.cmj)
 
     (action
@@ -393,7 +393,7 @@
 
 
   (rule
-    (targets fun.cmi )
+    (targets fun.cmi fun.cmti )
     (deps (:inputs fun.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -401,7 +401,7 @@
 
 
   (rule
-    (targets gc.cmj )
+    (targets gc.cmj gc.cmt )
     (deps (:inputs gc.ml) (alias ../../others/others) gc.cmi printexc.cmj printf.cmj string.cmj sys.cmj)
 
     (action
@@ -409,7 +409,7 @@
 
 
   (rule
-    (targets gc.cmi )
+    (targets gc.cmi gc.cmti )
     (deps (:inputs gc.mli) (alias ../../others/others) printexc.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -417,7 +417,7 @@
 
 
   (rule
-    (targets genlex.cmj )
+    (targets genlex.cmj genlex.cmt )
     (deps (:inputs genlex.ml) (alias ../../others/others) bytes.cmj char.cmj genlex.cmi hashtbl.cmj list.cmj stream.cmj string.cmj)
 
     (action
@@ -425,7 +425,7 @@
 
 
   (rule
-    (targets genlex.cmi )
+    (targets genlex.cmi genlex.cmti )
     (deps (:inputs genlex.mli) (alias ../../others/others) stdlib__no_aliases.cmj stream.cmi)
 
     (action
@@ -433,7 +433,7 @@
 
 
   (rule
-    (targets hashtbl.cmj )
+    (targets hashtbl.cmj hashtbl.cmt )
     (deps (:inputs hashtbl.ml) (alias ../../others/others) array.cmj hashtbl.cmi int.cmj lazy.cmj random.cmj seq.cmj string.cmj sys.cmj)
 
     (action
@@ -441,7 +441,7 @@
 
 
   (rule
-    (targets hashtbl.cmi )
+    (targets hashtbl.cmi hashtbl.cmti )
     (deps (:inputs hashtbl.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -449,7 +449,7 @@
 
 
   (rule
-    (targets in_channel.cmj )
+    (targets in_channel.cmj in_channel.cmt )
     (deps (:inputs in_channel.ml) (alias ../../others/others) bytes.cmj fun.cmj in_channel.cmi sys.cmj)
 
     (action
@@ -457,7 +457,7 @@
 
 
   (rule
-    (targets in_channel.cmi )
+    (targets in_channel.cmi in_channel.cmti )
     (deps (:inputs in_channel.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -465,7 +465,7 @@
 
 
   (rule
-    (targets int.cmj )
+    (targets int.cmj int.cmt )
     (deps (:inputs int.ml) (alias ../../others/others) int.cmi)
 
     (action
@@ -473,7 +473,7 @@
 
 
   (rule
-    (targets int.cmi )
+    (targets int.cmi int.cmti )
     (deps (:inputs int.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -481,7 +481,7 @@
 
 
   (rule
-    (targets int32.cmj )
+    (targets int32.cmj int32.cmt )
     (deps (:inputs int32.ml) (alias ../../others/others) int32.cmi sys.cmj)
 
     (action
@@ -489,7 +489,7 @@
 
 
   (rule
-    (targets int32.cmi )
+    (targets int32.cmi int32.cmti )
     (deps (:inputs int32.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -497,7 +497,7 @@
 
 
   (rule
-    (targets int64.cmj )
+    (targets int64.cmj int64.cmt )
     (deps (:inputs int64.ml) (alias ../../others/others) int64.cmi)
 
     (action
@@ -505,7 +505,7 @@
 
 
   (rule
-    (targets int64.cmi )
+    (targets int64.cmi int64.cmti )
     (deps (:inputs int64.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -513,7 +513,7 @@
 
 
   (rule
-    (targets lazy.cmj )
+    (targets lazy.cmj lazy.cmt )
     (deps (:inputs lazy.ml) (alias ../../others/others) camlinternalLazy.cmj lazy.cmi)
 
     (action
@@ -521,7 +521,7 @@
 
 
   (rule
-    (targets lazy.cmi )
+    (targets lazy.cmi lazy.cmti )
     (deps (:inputs lazy.mli) (alias ../../others/others) camlinternalLazy.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -529,7 +529,7 @@
 
 
   (rule
-    (targets lexing.cmj )
+    (targets lexing.cmj lexing.cmt )
     (deps (:inputs lexing.ml) (alias ../../others/others) array.cmj bytes.cmj int.cmj lexing.cmi string.cmj sys.cmj)
 
     (action
@@ -537,7 +537,7 @@
 
 
   (rule
-    (targets lexing.cmi )
+    (targets lexing.cmi lexing.cmti )
     (deps (:inputs lexing.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -545,7 +545,7 @@
 
 
   (rule
-    (targets list.cmj )
+    (targets list.cmj list.cmt )
     (deps (:inputs list.ml) (alias ../../others/others) either.cmj list.cmi seq.cmj sys.cmj)
 
     (action
@@ -553,7 +553,7 @@
 
 
   (rule
-    (targets list.cmi )
+    (targets list.cmi list.cmti )
     (deps (:inputs list.mli) (alias ../../others/others) either.cmi seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -561,7 +561,7 @@
 
 
   (rule
-    (targets listLabels.cmj )
+    (targets listLabels.cmj listLabels.cmt )
     (deps (:inputs listLabels.ml) (alias ../../others/others) list.cmj listLabels.cmi)
 
     (action
@@ -569,7 +569,7 @@
 
 
   (rule
-    (targets listLabels.cmi )
+    (targets listLabels.cmi listLabels.cmti )
     (deps (:inputs listLabels.mli) (alias ../../others/others) either.cmi seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -577,7 +577,7 @@
 
 
   (rule
-    (targets map.cmj )
+    (targets map.cmj map.cmt )
     (deps (:inputs map.ml) (alias ../../others/others) map.cmi seq.cmj)
 
     (action
@@ -585,7 +585,7 @@
 
 
   (rule
-    (targets map.cmi )
+    (targets map.cmi map.cmti )
     (deps (:inputs map.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -593,7 +593,7 @@
 
 
   (rule
-    (targets marshal.cmj )
+    (targets marshal.cmj marshal.cmt )
     (deps (:inputs marshal.ml) (alias ../../others/others) bytes.cmj marshal.cmi)
 
     (action
@@ -601,7 +601,7 @@
 
 
   (rule
-    (targets marshal.cmi )
+    (targets marshal.cmi marshal.cmti )
     (deps (:inputs marshal.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -609,7 +609,7 @@
 
 
   (rule
-    (targets moreLabels.cmj )
+    (targets moreLabels.cmj moreLabels.cmt )
     (deps (:inputs moreLabels.ml) (alias ../../others/others) hashtbl.cmj map.cmj moreLabels.cmi set.cmj)
 
     (action
@@ -617,7 +617,7 @@
 
 
   (rule
-    (targets moreLabels.cmi )
+    (targets moreLabels.cmi moreLabels.cmti )
     (deps (:inputs moreLabels.mli) (alias ../../others/others) hashtbl.cmi map.cmi seq.cmi set.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -625,7 +625,7 @@
 
 
   (rule
-    (targets obj.cmj )
+    (targets obj.cmj obj.cmt )
     (deps (:inputs obj.ml) (alias ../../others/others) int32.cmj obj.cmi sys.cmj)
 
     (action
@@ -633,7 +633,7 @@
 
 
   (rule
-    (targets obj.cmi )
+    (targets obj.cmi obj.cmti )
     (deps (:inputs obj.mli) (alias ../../others/others) ephemeron.cmi int32.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -641,7 +641,7 @@
 
 
   (rule
-    (targets oo.cmj )
+    (targets oo.cmj oo.cmt )
     (deps (:inputs oo.ml) (alias ../../others/others) camlinternalOO.cmj oo.cmi)
 
     (action
@@ -649,7 +649,7 @@
 
 
   (rule
-    (targets oo.cmi )
+    (targets oo.cmi oo.cmti )
     (deps (:inputs oo.mli) (alias ../../others/others) camlinternalOO.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -657,7 +657,7 @@
 
 
   (rule
-    (targets option.cmj )
+    (targets option.cmj option.cmt )
     (deps (:inputs option.ml) (alias ../../others/others) option.cmi seq.cmj)
 
     (action
@@ -665,7 +665,7 @@
 
 
   (rule
-    (targets option.cmi )
+    (targets option.cmi option.cmti )
     (deps (:inputs option.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -673,7 +673,7 @@
 
 
   (rule
-    (targets out_channel.cmj )
+    (targets out_channel.cmj out_channel.cmt )
     (deps (:inputs out_channel.ml) (alias ../../others/others) fun.cmj out_channel.cmi)
 
     (action
@@ -681,7 +681,7 @@
 
 
   (rule
-    (targets out_channel.cmi )
+    (targets out_channel.cmi out_channel.cmti )
     (deps (:inputs out_channel.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -689,7 +689,7 @@
 
 
   (rule
-    (targets parsing.cmj )
+    (targets parsing.cmj parsing.cmt )
     (deps (:inputs parsing.ml) (alias ../../others/others) array.cmj lexing.cmj obj.cmj parsing.cmi)
 
     (action
@@ -697,7 +697,7 @@
 
 
   (rule
-    (targets parsing.cmi )
+    (targets parsing.cmi parsing.cmti )
     (deps (:inputs parsing.mli) (alias ../../others/others) lexing.cmi obj.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -705,7 +705,7 @@
 
 
   (rule
-    (targets pervasives.cmi pervasives.cmj )
+    (targets pervasives.cmi pervasives.cmj pervasives.cmt )
     (deps (:inputs pervasives.ml) (alias ../../others/others) camlinternalFormatBasics.cmj stdlib__no_aliases.cmj)
 
     (action
@@ -713,7 +713,7 @@
 
 
   (rule
-    (targets printexc.cmj )
+    (targets printexc.cmj printexc.cmt )
     (deps (:inputs printexc.ml) (alias ../../others/others) array.cmj atomic.cmj buffer.cmj printexc.cmi printf.cmj)
 
     (action
@@ -721,7 +721,7 @@
 
 
   (rule
-    (targets printexc.cmi )
+    (targets printexc.cmi printexc.cmti )
     (deps (:inputs printexc.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -729,7 +729,7 @@
 
 
   (rule
-    (targets printf.cmj )
+    (targets printf.cmj printf.cmt )
     (deps (:inputs printf.ml) (alias ../../others/others) buffer.cmj camlinternalFormat.cmj camlinternalFormatBasics.cmj printf.cmi)
 
     (action
@@ -737,7 +737,7 @@
 
 
   (rule
-    (targets printf.cmi )
+    (targets printf.cmi printf.cmti )
     (deps (:inputs printf.mli) (alias ../../others/others) buffer.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -745,7 +745,7 @@
 
 
   (rule
-    (targets queue.cmj )
+    (targets queue.cmj queue.cmt )
     (deps (:inputs queue.ml) (alias ../../others/others) queue.cmi seq.cmj)
 
     (action
@@ -753,7 +753,7 @@
 
 
   (rule
-    (targets queue.cmi )
+    (targets queue.cmi queue.cmti )
     (deps (:inputs queue.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -761,7 +761,7 @@
 
 
   (rule
-    (targets random.cmj )
+    (targets random.cmj random.cmt )
     (deps (:inputs random.ml) (alias ../../others/others) array.cmj char.cmj digest.cmj int.cmj int32.cmj int64.cmj random.cmi)
 
     (action
@@ -769,7 +769,7 @@
 
 
   (rule
-    (targets random.cmi )
+    (targets random.cmi random.cmti )
     (deps (:inputs random.mli) (alias ../../others/others) int32.cmi int64.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -777,7 +777,7 @@
 
 
   (rule
-    (targets result.cmj )
+    (targets result.cmj result.cmt )
     (deps (:inputs result.ml) (alias ../../others/others) result.cmi seq.cmj)
 
     (action
@@ -785,7 +785,7 @@
 
 
   (rule
-    (targets result.cmi )
+    (targets result.cmi result.cmti )
     (deps (:inputs result.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -793,7 +793,7 @@
 
 
   (rule
-    (targets scanf.cmj )
+    (targets scanf.cmj scanf.cmt )
     (deps (:inputs scanf.ml) (alias ../../others/others) buffer.cmj bytes.cmj camlinternalFormat.cmj camlinternalFormatBasics.cmj int.cmj list.cmj printf.cmj scanf.cmi string.cmj)
 
     (action
@@ -801,7 +801,7 @@
 
 
   (rule
-    (targets scanf.cmi )
+    (targets scanf.cmi scanf.cmti )
     (deps (:inputs scanf.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -809,7 +809,7 @@
 
 
   (rule
-    (targets seq.cmj )
+    (targets seq.cmj seq.cmt )
     (deps (:inputs seq.ml) (alias ../../others/others) camlinternalAtomic.cmj either.cmj lazy.cmj seq.cmi)
 
     (action
@@ -817,7 +817,7 @@
 
 
   (rule
-    (targets seq.cmi )
+    (targets seq.cmi seq.cmti )
     (deps (:inputs seq.mli) (alias ../../others/others) either.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -825,7 +825,7 @@
 
 
   (rule
-    (targets set.cmj )
+    (targets set.cmj set.cmt )
     (deps (:inputs set.ml) (alias ../../others/others) list.cmj seq.cmj set.cmi)
 
     (action
@@ -833,7 +833,7 @@
 
 
   (rule
-    (targets set.cmi )
+    (targets set.cmi set.cmti )
     (deps (:inputs set.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -841,7 +841,7 @@
 
 
   (rule
-    (targets stack.cmj )
+    (targets stack.cmj stack.cmt )
     (deps (:inputs stack.ml) (alias ../../others/others) list.cmj seq.cmj stack.cmi)
 
     (action
@@ -849,7 +849,7 @@
 
 
   (rule
-    (targets stack.cmi )
+    (targets stack.cmi stack.cmti )
     (deps (:inputs stack.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj)
 
     (action
@@ -857,7 +857,7 @@
 
 
   (rule
-    (targets stdLabels.cmj )
+    (targets stdLabels.cmj stdLabels.cmt )
     (deps (:inputs stdLabels.ml) (alias ../../others/others) arrayLabels.cmj bytesLabels.cmj listLabels.cmj stdLabels.cmi stringLabels.cmj)
 
     (action
@@ -865,7 +865,7 @@
 
 
   (rule
-    (targets stdLabels.cmi )
+    (targets stdLabels.cmi stdLabels.cmti )
     (deps (:inputs stdLabels.mli) (alias ../../others/others) arrayLabels.cmi bytesLabels.cmi listLabels.cmi stdlib__no_aliases.cmj stringLabels.cmi)
 
     (action
@@ -873,7 +873,7 @@
 
 
   (rule
-    (targets std_exit.cmi std_exit.cmj )
+    (targets std_exit.cmi std_exit.cmj std_exit.cmt )
     (deps (:inputs std_exit.ml) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -881,7 +881,7 @@
 
 
   (rule
-    (targets stream.cmj )
+    (targets stream.cmj stream.cmt )
     (deps (:inputs stream.ml) (alias ../../others/others) bytes.cmj lazy.cmj list.cmj stream.cmi string.cmj)
 
     (action
@@ -889,7 +889,7 @@
 
 
   (rule
-    (targets stream.cmi )
+    (targets stream.cmi stream.cmti )
     (deps (:inputs stream.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -897,7 +897,7 @@
 
 
   (rule
-    (targets string.cmj )
+    (targets string.cmj string.cmt )
     (deps (:inputs string.ml) (alias ../../others/others) bytes.cmj string.cmi)
 
     (action
@@ -905,7 +905,7 @@
 
 
   (rule
-    (targets string.cmi )
+    (targets string.cmi string.cmti )
     (deps (:inputs string.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj uchar.cmi)
 
     (action
@@ -913,7 +913,7 @@
 
 
   (rule
-    (targets stringLabels.cmj )
+    (targets stringLabels.cmj stringLabels.cmt )
     (deps (:inputs stringLabels.ml) (alias ../../others/others) string.cmj stringLabels.cmi)
 
     (action
@@ -921,7 +921,7 @@
 
 
   (rule
-    (targets stringLabels.cmi )
+    (targets stringLabels.cmi stringLabels.cmti )
     (deps (:inputs stringLabels.mli) (alias ../../others/others) seq.cmi stdlib__no_aliases.cmj uchar.cmi)
 
     (action
@@ -929,7 +929,7 @@
 
 
   (rule
-    (targets sys.cmj )
+    (targets sys.cmj sys.cmt )
     (deps (:inputs sys.ml) (alias ../../others/others) sys.cmi)
 
     (action
@@ -937,7 +937,7 @@
 
 
   (rule
-    (targets sys.cmi )
+    (targets sys.cmi sys.cmti )
     (deps (:inputs sys.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -945,7 +945,7 @@
 
 
   (rule
-    (targets uchar.cmj )
+    (targets uchar.cmj uchar.cmt )
     (deps (:inputs uchar.ml) (alias ../../others/others) char.cmj uchar.cmi)
 
     (action
@@ -953,7 +953,7 @@
 
 
   (rule
-    (targets uchar.cmi )
+    (targets uchar.cmi uchar.cmti )
     (deps (:inputs uchar.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -961,7 +961,7 @@
 
 
   (rule
-    (targets unit.cmj )
+    (targets unit.cmj unit.cmt )
     (deps (:inputs unit.ml) (alias ../../others/others) unit.cmi)
 
     (action
@@ -969,7 +969,7 @@
 
 
   (rule
-    (targets unit.cmi )
+    (targets unit.cmi unit.cmti )
     (deps (:inputs unit.mli) (alias ../../others/others) stdlib__no_aliases.cmj)
 
     (action
@@ -977,7 +977,7 @@
 
 
   (rule
-    (targets weak.cmj )
+    (targets weak.cmj weak.cmt )
     (deps (:inputs weak.ml) (alias ../../others/others) array.cmj hashtbl.cmj int.cmj obj.cmj sys.cmj weak.cmi)
 
     (action
@@ -985,7 +985,7 @@
 
 
   (rule
-    (targets weak.cmi )
+    (targets weak.cmi weak.cmti )
     (deps (:inputs weak.mli) (alias ../../others/others) hashtbl.cmi stdlib__no_aliases.cmj)
 
     (action

--- a/jscomp/test/dune.gen
+++ b/jscomp/test/dune.gen
@@ -1,6 +1,6 @@
 
   (rule
-    (targets 406_primitive_test.cmi 406_primitive_test.cmj 406_primitive_test.js)
+    (targets 406_primitive_test.cmi 406_primitive_test.cmj 406_primitive_test.cmt 406_primitive_test.js)
     (deps (:inputs 406_primitive_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -13,7 +13,7 @@
 
 
   (rule
-    (targets a.cmi a.cmj a.js)
+    (targets a.cmi a.cmj a.cmt a.js)
     (deps (:inputs a.ml) ../stdlib-412/stdlib.cmj test_order.cmj)
 
   (mode
@@ -26,7 +26,7 @@
 
 
   (rule
-    (targets a_filename_test.cmi a_filename_test.cmj a_filename_test.js)
+    (targets a_filename_test.cmi a_filename_test.cmj a_filename_test.cmt a_filename_test.js)
     (deps (:inputs a_filename_test.ml) ../stdlib-412/stdlib.cmj ext_filename_test.cmj mt.cmj)
 
   (mode
@@ -39,7 +39,7 @@
 
 
   (rule
-    (targets a_list_test.cmi a_list_test.cmj a_list_test.js)
+    (targets a_list_test.cmi a_list_test.cmj a_list_test.cmt a_list_test.js)
     (deps (:inputs a_list_test.ml) ../stdlib-412/stdlib.cmj ext_list_test.cmj mt.cmj)
 
   (mode
@@ -52,7 +52,7 @@
 
 
   (rule
-    (targets a_recursive_type.cmj a_recursive_type.js)
+    (targets a_recursive_type.cmj a_recursive_type.cmt a_recursive_type.js)
     (deps (:inputs a_recursive_type.ml) ../stdlib-412/stdlib.cmj a_recursive_type.cmi)
 
   (mode
@@ -65,7 +65,7 @@
 
 
   (rule
-    (targets a_recursive_type.cmi )
+    (targets a_recursive_type.cmi a_recursive_type.cmti )
     (deps (:inputs a_recursive_type.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -78,7 +78,7 @@
 
 
   (rule
-    (targets a_scope_bug.cmi a_scope_bug.cmj a_scope_bug.js)
+    (targets a_scope_bug.cmi a_scope_bug.cmj a_scope_bug.cmt a_scope_bug.js)
     (deps (:inputs a_scope_bug.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -91,7 +91,7 @@
 
 
   (rule
-    (targets a_string_test.cmi a_string_test.cmj a_string_test.js)
+    (targets a_string_test.cmi a_string_test.cmj a_string_test.cmt a_string_test.js)
     (deps (:inputs a_string_test.ml) ../stdlib-412/stdlib.cmj ext_string_test.cmj mt.cmj)
 
   (mode
@@ -104,7 +104,7 @@
 
 
   (rule
-    (targets abstract_type.cmj abstract_type.js)
+    (targets abstract_type.cmj abstract_type.cmt abstract_type.js)
     (deps (:inputs abstract_type.ml) ../stdlib-412/stdlib.cmj abstract_type.cmi)
 
   (mode
@@ -117,7 +117,7 @@
 
 
   (rule
-    (targets abstract_type.cmi )
+    (targets abstract_type.cmi abstract_type.cmti )
     (deps (:inputs abstract_type.mli) ../stdlib-412/stdlib.cmj mt.cmi)
 
   (mode
@@ -130,7 +130,7 @@
 
 
   (rule
-    (targets adt_optimize_test.cmi adt_optimize_test.cmj adt_optimize_test.js)
+    (targets adt_optimize_test.cmi adt_optimize_test.cmj adt_optimize_test.cmt adt_optimize_test.js)
     (deps (:inputs adt_optimize_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -143,7 +143,7 @@
 
 
   (rule
-    (targets alias_test.cmj alias_test.js)
+    (targets alias_test.cmj alias_test.cmt alias_test.js)
     (deps (:inputs alias_test.ml) ../stdlib-412/stdlib.cmj alias_test.cmi)
 
   (mode
@@ -156,7 +156,7 @@
 
 
   (rule
-    (targets alias_test.cmi )
+    (targets alias_test.cmi alias_test.cmti )
     (deps (:inputs alias_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -169,7 +169,7 @@
 
 
   (rule
-    (targets and_or_tailcall_test.cmi and_or_tailcall_test.cmj and_or_tailcall_test.js)
+    (targets and_or_tailcall_test.cmi and_or_tailcall_test.cmj and_or_tailcall_test.cmt and_or_tailcall_test.js)
     (deps (:inputs and_or_tailcall_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -182,7 +182,7 @@
 
 
   (rule
-    (targets app_root_finder.cmi app_root_finder.cmj app_root_finder.js)
+    (targets app_root_finder.cmi app_root_finder.cmj app_root_finder.cmt app_root_finder.js)
     (deps (:inputs app_root_finder.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -195,7 +195,7 @@
 
 
   (rule
-    (targets argv_test.cmi argv_test.cmj argv_test.js)
+    (targets argv_test.cmi argv_test.cmj argv_test.cmt argv_test.js)
     (deps (:inputs argv_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -208,7 +208,7 @@
 
 
   (rule
-    (targets ari_regress_test.cmj ari_regress_test.js)
+    (targets ari_regress_test.cmj ari_regress_test.cmt ari_regress_test.js)
     (deps (:inputs ari_regress_test.ml) ../stdlib-412/stdlib.cmj ari_regress_test.cmi mt.cmj)
 
   (mode
@@ -221,7 +221,7 @@
 
 
   (rule
-    (targets ari_regress_test.cmi )
+    (targets ari_regress_test.cmi ari_regress_test.cmti )
     (deps (:inputs ari_regress_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -234,7 +234,7 @@
 
 
   (rule
-    (targets arith_lexer.cmi arith_lexer.cmj arith_lexer.js)
+    (targets arith_lexer.cmi arith_lexer.cmj arith_lexer.cmt arith_lexer.js)
     (deps (:inputs arith_lexer.ml) ../stdlib-412/stdlib.cmj arith_parser.cmj arith_syntax.cmj)
 
   (mode
@@ -247,7 +247,7 @@
 
 
   (rule
-    (targets arith_parser.cmi arith_parser.cmj arith_parser.js)
+    (targets arith_parser.cmi arith_parser.cmj arith_parser.cmt arith_parser.js)
     (deps (:inputs arith_parser.ml) ../stdlib-412/stdlib.cmj arith_syntax.cmj)
 
   (mode
@@ -260,7 +260,7 @@
 
 
   (rule
-    (targets arith_syntax.cmi arith_syntax.cmj arith_syntax.js)
+    (targets arith_syntax.cmi arith_syntax.cmj arith_syntax.cmt arith_syntax.js)
     (deps (:inputs arith_syntax.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -273,7 +273,7 @@
 
 
   (rule
-    (targets arity.cmi arity.cmj arity.js)
+    (targets arity.cmi arity.cmj arity.cmt arity.js)
     (deps (:inputs arity.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -286,7 +286,7 @@
 
 
   (rule
-    (targets arity_deopt.cmi arity_deopt.cmj arity_deopt.js)
+    (targets arity_deopt.cmi arity_deopt.cmj arity_deopt.cmt arity_deopt.js)
     (deps (:inputs arity_deopt.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -299,7 +299,7 @@
 
 
   (rule
-    (targets arity_infer.cmi arity_infer.cmj arity_infer.js)
+    (targets arity_infer.cmi arity_infer.cmj arity_infer.cmt arity_infer.js)
     (deps (:inputs arity_infer.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -312,7 +312,7 @@
 
 
   (rule
-    (targets arity_ml.cmi arity_ml.cmj arity_ml.js)
+    (targets arity_ml.cmi arity_ml.cmj arity_ml.cmt arity_ml.js)
     (deps (:inputs arity_ml.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -325,7 +325,7 @@
 
 
   (rule
-    (targets array_data_util.cmi array_data_util.cmj array_data_util.js)
+    (targets array_data_util.cmi array_data_util.cmj array_data_util.cmt array_data_util.js)
     (deps (:inputs array_data_util.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -338,7 +338,7 @@
 
 
   (rule
-    (targets array_safe_get.cmi array_safe_get.cmj array_safe_get.js)
+    (targets array_safe_get.cmi array_safe_get.cmj array_safe_get.cmt array_safe_get.js)
     (deps (:inputs array_safe_get.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -351,7 +351,7 @@
 
 
   (rule
-    (targets array_subtle_test.cmi array_subtle_test.cmj array_subtle_test.js)
+    (targets array_subtle_test.cmi array_subtle_test.cmj array_subtle_test.cmt array_subtle_test.js)
     (deps (:inputs array_subtle_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -364,7 +364,7 @@
 
 
   (rule
-    (targets array_test.cmj array_test.js)
+    (targets array_test.cmj array_test.cmt array_test.js)
     (deps (:inputs array_test.ml) ../stdlib-412/stdlib.cmj array_test.cmi mt.cmj)
 
   (mode
@@ -377,7 +377,7 @@
 
 
   (rule
-    (targets array_test.cmi )
+    (targets array_test.cmi array_test.cmti )
     (deps (:inputs array_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -390,7 +390,7 @@
 
 
   (rule
-    (targets ast_abstract_test.cmi ast_abstract_test.cmj ast_abstract_test.js)
+    (targets ast_abstract_test.cmi ast_abstract_test.cmj ast_abstract_test.cmt ast_abstract_test.js)
     (deps (:inputs ast_abstract_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -403,7 +403,7 @@
 
 
   (rule
-    (targets ast_js_mapper_poly_test.cmi ast_js_mapper_poly_test.cmj ast_js_mapper_poly_test.js)
+    (targets ast_js_mapper_poly_test.cmi ast_js_mapper_poly_test.cmj ast_js_mapper_poly_test.cmt ast_js_mapper_poly_test.js)
     (deps (:inputs ast_js_mapper_poly_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -416,7 +416,7 @@
 
 
   (rule
-    (targets ast_js_mapper_test.cmj ast_js_mapper_test.js)
+    (targets ast_js_mapper_test.cmj ast_js_mapper_test.cmt ast_js_mapper_test.js)
     (deps (:inputs ast_js_mapper_test.ml) ../stdlib-412/stdlib.cmj ast_js_mapper_test.cmi)
 
   (mode
@@ -429,7 +429,7 @@
 
 
   (rule
-    (targets ast_js_mapper_test.cmi )
+    (targets ast_js_mapper_test.cmi ast_js_mapper_test.cmti )
     (deps (:inputs ast_js_mapper_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -442,7 +442,7 @@
 
 
   (rule
-    (targets ast_mapper_defensive_test.cmi ast_mapper_defensive_test.cmj ast_mapper_defensive_test.js)
+    (targets ast_mapper_defensive_test.cmi ast_mapper_defensive_test.cmj ast_mapper_defensive_test.cmt ast_mapper_defensive_test.js)
     (deps (:inputs ast_mapper_defensive_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -455,7 +455,7 @@
 
 
   (rule
-    (targets ast_mapper_unused_warning_test.cmi ast_mapper_unused_warning_test.cmj ast_mapper_unused_warning_test.js)
+    (targets ast_mapper_unused_warning_test.cmi ast_mapper_unused_warning_test.cmj ast_mapper_unused_warning_test.cmt ast_mapper_unused_warning_test.js)
     (deps (:inputs ast_mapper_unused_warning_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -468,7 +468,7 @@
 
 
   (rule
-    (targets async_ideas.cmi async_ideas.cmj async_ideas.js)
+    (targets async_ideas.cmi async_ideas.cmj async_ideas.cmt async_ideas.js)
     (deps (:inputs async_ideas.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -481,7 +481,7 @@
 
 
   (rule
-    (targets attr_test.cmi attr_test.cmj attr_test.js)
+    (targets attr_test.cmi attr_test.cmj attr_test.cmt attr_test.js)
     (deps (:inputs attr_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -494,7 +494,7 @@
 
 
   (rule
-    (targets b.cmi b.cmj b.js)
+    (targets b.cmi b.cmj b.cmt b.js)
     (deps (:inputs b.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -507,7 +507,7 @@
 
 
   (rule
-    (targets bal_set_mini.cmi bal_set_mini.cmj bal_set_mini.js)
+    (targets bal_set_mini.cmi bal_set_mini.cmj bal_set_mini.cmt bal_set_mini.js)
     (deps (:inputs bal_set_mini.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -520,7 +520,7 @@
 
 
   (rule
-    (targets bang_primitive.cmi bang_primitive.cmj bang_primitive.js)
+    (targets bang_primitive.cmi bang_primitive.cmj bang_primitive.cmt bang_primitive.js)
     (deps (:inputs bang_primitive.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -533,7 +533,7 @@
 
 
   (rule
-    (targets basic_module_test.cmj basic_module_test.js)
+    (targets basic_module_test.cmj basic_module_test.cmt basic_module_test.js)
     (deps (:inputs basic_module_test.ml) ../stdlib-412/stdlib.cmj basic_module_test.cmi mt.cmj mt_global.cmj offset.cmj pr6726.cmj)
 
   (mode
@@ -546,7 +546,7 @@
 
 
   (rule
-    (targets basic_module_test.cmi )
+    (targets basic_module_test.cmi basic_module_test.cmti )
     (deps (:inputs basic_module_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -559,7 +559,7 @@
 
 
   (rule
-    (targets bb.cmi bb.cmj bb.js)
+    (targets bb.cmi bb.cmj bb.cmt bb.js)
     (deps (:inputs bb.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -572,7 +572,7 @@
 
 
   (rule
-    (targets bdd.cmi bdd.cmj bdd.js)
+    (targets bdd.cmi bdd.cmj bdd.cmt bdd.js)
     (deps (:inputs bdd.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -585,7 +585,7 @@
 
 
   (rule
-    (targets belt_internal_test.cmi belt_internal_test.cmj belt_internal_test.js)
+    (targets belt_internal_test.cmi belt_internal_test.cmj belt_internal_test.cmt belt_internal_test.js)
     (deps (:inputs belt_internal_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -598,7 +598,7 @@
 
 
   (rule
-    (targets belt_result_alias_test.cmi belt_result_alias_test.cmj belt_result_alias_test.js)
+    (targets belt_result_alias_test.cmi belt_result_alias_test.cmj belt_result_alias_test.cmt belt_result_alias_test.js)
     (deps (:inputs belt_result_alias_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -611,7 +611,7 @@
 
 
   (rule
-    (targets bench.cmi bench.cmj bench.js)
+    (targets bench.cmi bench.cmj bench.cmt bench.js)
     (deps (:inputs bench.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -624,7 +624,7 @@
 
 
   (rule
-    (targets big_enum.cmi big_enum.cmj big_enum.js)
+    (targets big_enum.cmi big_enum.cmj big_enum.cmt big_enum.js)
     (deps (:inputs big_enum.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -637,7 +637,7 @@
 
 
   (rule
-    (targets big_polyvar_test.cmi big_polyvar_test.cmj big_polyvar_test.js)
+    (targets big_polyvar_test.cmi big_polyvar_test.cmj big_polyvar_test.cmt big_polyvar_test.js)
     (deps (:inputs big_polyvar_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -650,7 +650,7 @@
 
 
   (rule
-    (targets block_alias_test.cmi block_alias_test.cmj block_alias_test.js)
+    (targets block_alias_test.cmi block_alias_test.cmj block_alias_test.cmt block_alias_test.js)
     (deps (:inputs block_alias_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -663,7 +663,7 @@
 
 
   (rule
-    (targets boolean_test.cmi boolean_test.cmj boolean_test.js)
+    (targets boolean_test.cmi boolean_test.cmj boolean_test.cmt boolean_test.js)
     (deps (:inputs boolean_test.ml) ../stdlib-412/stdlib.cmj mt.cmj test_bool_equal.cmj)
 
   (mode
@@ -676,7 +676,7 @@
 
 
   (rule
-    (targets bs_MapInt_test.cmi bs_MapInt_test.cmj bs_MapInt_test.js)
+    (targets bs_MapInt_test.cmi bs_MapInt_test.cmj bs_MapInt_test.cmt bs_MapInt_test.js)
     (deps (:inputs bs_MapInt_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -689,7 +689,7 @@
 
 
   (rule
-    (targets bs_abstract_test.cmj bs_abstract_test.js)
+    (targets bs_abstract_test.cmj bs_abstract_test.cmt bs_abstract_test.js)
     (deps (:inputs bs_abstract_test.ml) ../stdlib-412/stdlib.cmj bs_abstract_test.cmi)
 
   (mode
@@ -702,7 +702,7 @@
 
 
   (rule
-    (targets bs_abstract_test.cmi )
+    (targets bs_abstract_test.cmi bs_abstract_test.cmti )
     (deps (:inputs bs_abstract_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -715,7 +715,7 @@
 
 
   (rule
-    (targets bs_array_test.cmi bs_array_test.cmj bs_array_test.js)
+    (targets bs_array_test.cmi bs_array_test.cmj bs_array_test.cmt bs_array_test.js)
     (deps (:inputs bs_array_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -728,7 +728,7 @@
 
 
   (rule
-    (targets bs_auto_uncurry.cmi bs_auto_uncurry.cmj bs_auto_uncurry.js)
+    (targets bs_auto_uncurry.cmi bs_auto_uncurry.cmj bs_auto_uncurry.cmt bs_auto_uncurry.js)
     (deps (:inputs bs_auto_uncurry.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -741,7 +741,7 @@
 
 
   (rule
-    (targets bs_auto_uncurry_test.cmi bs_auto_uncurry_test.cmj bs_auto_uncurry_test.js)
+    (targets bs_auto_uncurry_test.cmi bs_auto_uncurry_test.cmj bs_auto_uncurry_test.cmt bs_auto_uncurry_test.js)
     (deps (:inputs bs_auto_uncurry_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -754,7 +754,7 @@
 
 
   (rule
-    (targets bs_float_test.cmi bs_float_test.cmj bs_float_test.js)
+    (targets bs_float_test.cmi bs_float_test.cmj bs_float_test.cmt bs_float_test.js)
     (deps (:inputs bs_float_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -767,7 +767,7 @@
 
 
   (rule
-    (targets bs_hashmap_test.cmi bs_hashmap_test.cmj bs_hashmap_test.js)
+    (targets bs_hashmap_test.cmi bs_hashmap_test.cmj bs_hashmap_test.cmt bs_hashmap_test.js)
     (deps (:inputs bs_hashmap_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -780,7 +780,7 @@
 
 
   (rule
-    (targets bs_hashset_int_test.cmi bs_hashset_int_test.cmj bs_hashset_int_test.js)
+    (targets bs_hashset_int_test.cmi bs_hashset_int_test.cmj bs_hashset_int_test.cmt bs_hashset_int_test.js)
     (deps (:inputs bs_hashset_int_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -793,7 +793,7 @@
 
 
   (rule
-    (targets bs_hashtbl_string_test.cmi bs_hashtbl_string_test.cmj bs_hashtbl_string_test.js)
+    (targets bs_hashtbl_string_test.cmi bs_hashtbl_string_test.cmj bs_hashtbl_string_test.cmt bs_hashtbl_string_test.js)
     (deps (:inputs bs_hashtbl_string_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -806,7 +806,7 @@
 
 
   (rule
-    (targets bs_ignore_effect.cmi bs_ignore_effect.cmj bs_ignore_effect.js)
+    (targets bs_ignore_effect.cmi bs_ignore_effect.cmj bs_ignore_effect.cmt bs_ignore_effect.js)
     (deps (:inputs bs_ignore_effect.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -819,7 +819,7 @@
 
 
   (rule
-    (targets bs_ignore_test.cmi bs_ignore_test.cmj bs_ignore_test.js)
+    (targets bs_ignore_test.cmi bs_ignore_test.cmj bs_ignore_test.cmt bs_ignore_test.js)
     (deps (:inputs bs_ignore_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -832,7 +832,7 @@
 
 
   (rule
-    (targets bs_int_test.cmi bs_int_test.cmj bs_int_test.js)
+    (targets bs_int_test.cmi bs_int_test.cmj bs_int_test.cmt bs_int_test.js)
     (deps (:inputs bs_int_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -845,7 +845,7 @@
 
 
   (rule
-    (targets bs_list_test.cmi bs_list_test.cmj bs_list_test.js)
+    (targets bs_list_test.cmi bs_list_test.cmj bs_list_test.cmt bs_list_test.js)
     (deps (:inputs bs_list_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -858,7 +858,7 @@
 
 
   (rule
-    (targets bs_map_set_dict_test.cmi bs_map_set_dict_test.cmj bs_map_set_dict_test.js)
+    (targets bs_map_set_dict_test.cmi bs_map_set_dict_test.cmj bs_map_set_dict_test.cmt bs_map_set_dict_test.js)
     (deps (:inputs bs_map_set_dict_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -871,7 +871,7 @@
 
 
   (rule
-    (targets bs_map_test.cmi bs_map_test.cmj bs_map_test.js)
+    (targets bs_map_test.cmi bs_map_test.cmj bs_map_test.cmt bs_map_test.js)
     (deps (:inputs bs_map_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -884,7 +884,7 @@
 
 
   (rule
-    (targets bs_min_max_test.cmi bs_min_max_test.cmj bs_min_max_test.js)
+    (targets bs_min_max_test.cmi bs_min_max_test.cmj bs_min_max_test.cmt bs_min_max_test.js)
     (deps (:inputs bs_min_max_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -897,7 +897,7 @@
 
 
   (rule
-    (targets bs_mutable_set_test.cmi bs_mutable_set_test.cmj bs_mutable_set_test.js)
+    (targets bs_mutable_set_test.cmi bs_mutable_set_test.cmj bs_mutable_set_test.cmt bs_mutable_set_test.js)
     (deps (:inputs bs_mutable_set_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -910,7 +910,7 @@
 
 
   (rule
-    (targets bs_node_string_buffer_test.cmi bs_node_string_buffer_test.cmj bs_node_string_buffer_test.js)
+    (targets bs_node_string_buffer_test.cmi bs_node_string_buffer_test.cmj bs_node_string_buffer_test.cmt bs_node_string_buffer_test.js)
     (deps (:inputs bs_node_string_buffer_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -923,7 +923,7 @@
 
 
   (rule
-    (targets bs_poly_map_test.cmi bs_poly_map_test.cmj bs_poly_map_test.js)
+    (targets bs_poly_map_test.cmi bs_poly_map_test.cmj bs_poly_map_test.cmt bs_poly_map_test.js)
     (deps (:inputs bs_poly_map_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -936,7 +936,7 @@
 
 
   (rule
-    (targets bs_poly_mutable_map_test.cmi bs_poly_mutable_map_test.cmj bs_poly_mutable_map_test.js)
+    (targets bs_poly_mutable_map_test.cmi bs_poly_mutable_map_test.cmj bs_poly_mutable_map_test.cmt bs_poly_mutable_map_test.js)
     (deps (:inputs bs_poly_mutable_map_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -949,7 +949,7 @@
 
 
   (rule
-    (targets bs_poly_mutable_set_test.cmi bs_poly_mutable_set_test.cmj bs_poly_mutable_set_test.js)
+    (targets bs_poly_mutable_set_test.cmi bs_poly_mutable_set_test.cmj bs_poly_mutable_set_test.cmt bs_poly_mutable_set_test.js)
     (deps (:inputs bs_poly_mutable_set_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -962,7 +962,7 @@
 
 
   (rule
-    (targets bs_poly_set_test.cmi bs_poly_set_test.cmj bs_poly_set_test.js)
+    (targets bs_poly_set_test.cmi bs_poly_set_test.cmj bs_poly_set_test.cmt bs_poly_set_test.js)
     (deps (:inputs bs_poly_set_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -975,7 +975,7 @@
 
 
   (rule
-    (targets bs_qualified.cmi bs_qualified.cmj bs_qualified.js)
+    (targets bs_qualified.cmi bs_qualified.cmj bs_qualified.cmt bs_qualified.js)
     (deps (:inputs bs_qualified.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -988,7 +988,7 @@
 
 
   (rule
-    (targets bs_queue_test.cmi bs_queue_test.cmj bs_queue_test.js)
+    (targets bs_queue_test.cmi bs_queue_test.cmj bs_queue_test.cmt bs_queue_test.js)
     (deps (:inputs bs_queue_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1001,7 +1001,7 @@
 
 
   (rule
-    (targets bs_rbset_int_bench.cmi bs_rbset_int_bench.cmj bs_rbset_int_bench.js)
+    (targets bs_rbset_int_bench.cmi bs_rbset_int_bench.cmj bs_rbset_int_bench.cmt bs_rbset_int_bench.js)
     (deps (:inputs bs_rbset_int_bench.ml) ../stdlib-412/stdlib.cmj rbset.cmj)
 
   (mode
@@ -1014,7 +1014,7 @@
 
 
   (rule
-    (targets bs_rest_test.cmi bs_rest_test.cmj bs_rest_test.js)
+    (targets bs_rest_test.cmi bs_rest_test.cmj bs_rest_test.cmt bs_rest_test.js)
     (deps (:inputs bs_rest_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1027,7 +1027,7 @@
 
 
   (rule
-    (targets bs_set_bench.cmi bs_set_bench.cmj bs_set_bench.js)
+    (targets bs_set_bench.cmi bs_set_bench.cmj bs_set_bench.cmt bs_set_bench.js)
     (deps (:inputs bs_set_bench.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1040,7 +1040,7 @@
 
 
   (rule
-    (targets bs_set_int_test.cmi bs_set_int_test.cmj bs_set_int_test.js)
+    (targets bs_set_int_test.cmi bs_set_int_test.cmj bs_set_int_test.cmt bs_set_int_test.js)
     (deps (:inputs bs_set_int_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -1053,7 +1053,7 @@
 
 
   (rule
-    (targets bs_sort_test.cmi bs_sort_test.cmj bs_sort_test.js)
+    (targets bs_sort_test.cmi bs_sort_test.cmj bs_sort_test.cmt bs_sort_test.js)
     (deps (:inputs bs_sort_test.ml) ../stdlib-412/stdlib.cmj array_data_util.cmj mt.cmj)
 
   (mode
@@ -1066,7 +1066,7 @@
 
 
   (rule
-    (targets bs_splice_partial.cmi bs_splice_partial.cmj bs_splice_partial.js)
+    (targets bs_splice_partial.cmi bs_splice_partial.cmj bs_splice_partial.cmt bs_splice_partial.js)
     (deps (:inputs bs_splice_partial.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1079,7 +1079,7 @@
 
 
   (rule
-    (targets bs_stack_test.cmi bs_stack_test.cmj bs_stack_test.js)
+    (targets bs_stack_test.cmi bs_stack_test.cmj bs_stack_test.cmt bs_stack_test.js)
     (deps (:inputs bs_stack_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1092,7 +1092,7 @@
 
 
   (rule
-    (targets bs_string_test.cmi bs_string_test.cmj bs_string_test.js)
+    (targets bs_string_test.cmi bs_string_test.cmj bs_string_test.cmt bs_string_test.js)
     (deps (:inputs bs_string_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1105,7 +1105,7 @@
 
 
   (rule
-    (targets bs_unwrap_test.cmi bs_unwrap_test.cmj bs_unwrap_test.js)
+    (targets bs_unwrap_test.cmi bs_unwrap_test.cmj bs_unwrap_test.cmt bs_unwrap_test.js)
     (deps (:inputs bs_unwrap_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1118,7 +1118,7 @@
 
 
   (rule
-    (targets buffer_test.cmi buffer_test.cmj buffer_test.js)
+    (targets buffer_test.cmi buffer_test.cmj buffer_test.cmt buffer_test.js)
     (deps (:inputs buffer_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1131,7 +1131,7 @@
 
 
   (rule
-    (targets bytes_split_gpr_743_test.cmi bytes_split_gpr_743_test.cmj bytes_split_gpr_743_test.js)
+    (targets bytes_split_gpr_743_test.cmi bytes_split_gpr_743_test.cmj bytes_split_gpr_743_test.cmt bytes_split_gpr_743_test.js)
     (deps (:inputs bytes_split_gpr_743_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1144,7 +1144,7 @@
 
 
   (rule
-    (targets caml_compare_test.cmi caml_compare_test.cmj caml_compare_test.js)
+    (targets caml_compare_test.cmi caml_compare_test.cmj caml_compare_test.cmt caml_compare_test.js)
     (deps (:inputs caml_compare_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1157,7 +1157,7 @@
 
 
   (rule
-    (targets caml_format_test.cmi caml_format_test.cmj caml_format_test.js)
+    (targets caml_format_test.cmi caml_format_test.cmj caml_format_test.cmt caml_format_test.js)
     (deps (:inputs caml_format_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1170,7 +1170,7 @@
 
 
   (rule
-    (targets caml_sys_poly_fill_test.cmi caml_sys_poly_fill_test.cmj caml_sys_poly_fill_test.js)
+    (targets caml_sys_poly_fill_test.cmi caml_sys_poly_fill_test.cmj caml_sys_poly_fill_test.cmt caml_sys_poly_fill_test.js)
     (deps (:inputs caml_sys_poly_fill_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1183,7 +1183,7 @@
 
 
   (rule
-    (targets chain_code_test.cmi chain_code_test.cmj chain_code_test.js)
+    (targets chain_code_test.cmi chain_code_test.cmj chain_code_test.cmt chain_code_test.js)
     (deps (:inputs chain_code_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1196,7 +1196,7 @@
 
 
   (rule
-    (targets chn_test.cmi chn_test.cmj chn_test.js)
+    (targets chn_test.cmi chn_test.cmj chn_test.cmt chn_test.js)
     (deps (:inputs chn_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1209,7 +1209,7 @@
 
 
   (rule
-    (targets class3_test.cmi class3_test.cmj class3_test.js)
+    (targets class3_test.cmi class3_test.cmj class3_test.cmt class3_test.js)
     (deps (:inputs class3_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1222,7 +1222,7 @@
 
 
   (rule
-    (targets class4_test.cmi class4_test.cmj class4_test.js)
+    (targets class4_test.cmi class4_test.cmj class4_test.cmt class4_test.js)
     (deps (:inputs class4_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1235,7 +1235,7 @@
 
 
   (rule
-    (targets class5_test.cmi class5_test.cmj class5_test.js)
+    (targets class5_test.cmi class5_test.cmj class5_test.cmt class5_test.js)
     (deps (:inputs class5_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1248,7 +1248,7 @@
 
 
   (rule
-    (targets class6_test.cmi class6_test.cmj class6_test.js)
+    (targets class6_test.cmi class6_test.cmj class6_test.cmt class6_test.js)
     (deps (:inputs class6_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1261,7 +1261,7 @@
 
 
   (rule
-    (targets class7_test.cmi class7_test.cmj class7_test.js)
+    (targets class7_test.cmi class7_test.cmj class7_test.cmt class7_test.js)
     (deps (:inputs class7_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1274,7 +1274,7 @@
 
 
   (rule
-    (targets class8_test.cmi class8_test.cmj class8_test.js)
+    (targets class8_test.cmi class8_test.cmj class8_test.cmt class8_test.js)
     (deps (:inputs class8_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1287,7 +1287,7 @@
 
 
   (rule
-    (targets class_fib_open_recursion_test.cmi class_fib_open_recursion_test.cmj class_fib_open_recursion_test.js)
+    (targets class_fib_open_recursion_test.cmi class_fib_open_recursion_test.cmj class_fib_open_recursion_test.cmt class_fib_open_recursion_test.js)
     (deps (:inputs class_fib_open_recursion_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1300,7 +1300,7 @@
 
 
   (rule
-    (targets class_repr.cmi class_repr.cmj class_repr.js)
+    (targets class_repr.cmi class_repr.cmj class_repr.cmt class_repr.js)
     (deps (:inputs class_repr.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1313,7 +1313,7 @@
 
 
   (rule
-    (targets class_setter_getter.cmj class_setter_getter.js)
+    (targets class_setter_getter.cmj class_setter_getter.cmt class_setter_getter.js)
     (deps (:inputs class_setter_getter.ml) ../stdlib-412/stdlib.cmj class_setter_getter.cmi)
 
   (mode
@@ -1326,7 +1326,7 @@
 
 
   (rule
-    (targets class_setter_getter.cmi )
+    (targets class_setter_getter.cmi class_setter_getter.cmti )
     (deps (:inputs class_setter_getter.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1339,7 +1339,7 @@
 
 
   (rule
-    (targets class_test.cmi class_test.cmj class_test.js)
+    (targets class_test.cmi class_test.cmj class_test.cmt class_test.js)
     (deps (:inputs class_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1352,7 +1352,7 @@
 
 
   (rule
-    (targets class_type_ffi_test.cmi class_type_ffi_test.cmj class_type_ffi_test.js)
+    (targets class_type_ffi_test.cmi class_type_ffi_test.cmj class_type_ffi_test.cmt class_type_ffi_test.js)
     (deps (:inputs class_type_ffi_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1365,7 +1365,7 @@
 
 
   (rule
-    (targets coercion_module_alias_test.cmi coercion_module_alias_test.cmj coercion_module_alias_test.js)
+    (targets coercion_module_alias_test.cmi coercion_module_alias_test.cmj coercion_module_alias_test.cmt coercion_module_alias_test.js)
     (deps (:inputs coercion_module_alias_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1378,7 +1378,7 @@
 
 
   (rule
-    (targets compare_test.cmi compare_test.cmj compare_test.js)
+    (targets compare_test.cmi compare_test.cmj compare_test.cmt compare_test.js)
     (deps (:inputs compare_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1391,7 +1391,7 @@
 
 
   (rule
-    (targets complete_parmatch_test.cmi complete_parmatch_test.cmj complete_parmatch_test.js)
+    (targets complete_parmatch_test.cmi complete_parmatch_test.cmj complete_parmatch_test.cmt complete_parmatch_test.js)
     (deps (:inputs complete_parmatch_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1404,7 +1404,7 @@
 
 
   (rule
-    (targets complex_if_test.cmi complex_if_test.cmj complex_if_test.js)
+    (targets complex_if_test.cmi complex_if_test.cmj complex_if_test.cmt complex_if_test.js)
     (deps (:inputs complex_if_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1417,7 +1417,7 @@
 
 
   (rule
-    (targets complex_test.cmi complex_test.cmj complex_test.js)
+    (targets complex_test.cmi complex_test.cmj complex_test.cmt complex_test.js)
     (deps (:inputs complex_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1430,7 +1430,7 @@
 
 
   (rule
-    (targets complex_while_loop.cmi complex_while_loop.cmj complex_while_loop.js)
+    (targets complex_while_loop.cmi complex_while_loop.cmj complex_while_loop.cmt complex_while_loop.js)
     (deps (:inputs complex_while_loop.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1443,7 +1443,7 @@
 
 
   (rule
-    (targets condition_compilation_test.cmi condition_compilation_test.cmj condition_compilation_test.js)
+    (targets condition_compilation_test.cmi condition_compilation_test.cmj condition_compilation_test.cmt condition_compilation_test.js)
     (deps (:inputs condition_compilation_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1456,7 +1456,7 @@
 
 
   (rule
-    (targets config1_test.cmi config1_test.cmj config1_test.js)
+    (targets config1_test.cmi config1_test.cmj config1_test.cmt config1_test.js)
     (deps (:inputs config1_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1469,7 +1469,7 @@
 
 
   (rule
-    (targets config2_test.cmj config2_test.js)
+    (targets config2_test.cmj config2_test.cmt config2_test.js)
     (deps (:inputs config2_test.ml) ../stdlib-412/stdlib.cmj config2_test.cmi)
 
   (mode
@@ -1482,7 +1482,7 @@
 
 
   (rule
-    (targets config2_test.cmi )
+    (targets config2_test.cmi config2_test.cmti )
     (deps (:inputs config2_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1495,7 +1495,7 @@
 
 
   (rule
-    (targets console_log_test.cmi console_log_test.cmj console_log_test.js)
+    (targets console_log_test.cmi console_log_test.cmj console_log_test.cmt console_log_test.js)
     (deps (:inputs console_log_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1508,7 +1508,7 @@
 
 
   (rule
-    (targets const_block_test.cmj const_block_test.js)
+    (targets const_block_test.cmj const_block_test.cmt const_block_test.js)
     (deps (:inputs const_block_test.ml) ../stdlib-412/stdlib.cmj const_block_test.cmi mt.cmj)
 
   (mode
@@ -1521,7 +1521,7 @@
 
 
   (rule
-    (targets const_block_test.cmi )
+    (targets const_block_test.cmi const_block_test.cmti )
     (deps (:inputs const_block_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1534,7 +1534,7 @@
 
 
   (rule
-    (targets const_defs.cmi const_defs.cmj const_defs.js)
+    (targets const_defs.cmi const_defs.cmj const_defs.cmt const_defs.js)
     (deps (:inputs const_defs.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1547,7 +1547,7 @@
 
 
   (rule
-    (targets const_defs_test.cmi const_defs_test.cmj const_defs_test.js)
+    (targets const_defs_test.cmi const_defs_test.cmj const_defs_test.cmt const_defs_test.js)
     (deps (:inputs const_defs_test.ml) ../stdlib-412/stdlib.cmj const_defs.cmj)
 
   (mode
@@ -1560,7 +1560,7 @@
 
 
   (rule
-    (targets const_test.cmi const_test.cmj const_test.js)
+    (targets const_test.cmi const_test.cmj const_test.cmt const_test.js)
     (deps (:inputs const_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1573,7 +1573,7 @@
 
 
   (rule
-    (targets cont_int_fold_test.cmi cont_int_fold_test.cmj cont_int_fold_test.js)
+    (targets cont_int_fold_test.cmi cont_int_fold_test.cmj cont_int_fold_test.cmt cont_int_fold_test.js)
     (deps (:inputs cont_int_fold_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1586,7 +1586,7 @@
 
 
   (rule
-    (targets cps_test.cmi cps_test.cmj cps_test.js)
+    (targets cps_test.cmi cps_test.cmj cps_test.cmt cps_test.js)
     (deps (:inputs cps_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1599,7 +1599,7 @@
 
 
   (rule
-    (targets cross_module_inline_test.cmi cross_module_inline_test.cmj cross_module_inline_test.js)
+    (targets cross_module_inline_test.cmi cross_module_inline_test.cmj cross_module_inline_test.cmt cross_module_inline_test.js)
     (deps (:inputs cross_module_inline_test.ml) ../stdlib-412/stdlib.cmj test_char.cmj)
 
   (mode
@@ -1612,7 +1612,7 @@
 
 
   (rule
-    (targets custom_error_test.cmi custom_error_test.cmj custom_error_test.js)
+    (targets custom_error_test.cmi custom_error_test.cmj custom_error_test.cmt custom_error_test.js)
     (deps (:inputs custom_error_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1625,7 +1625,7 @@
 
 
   (rule
-    (targets debug_keep_test.cmi debug_keep_test.cmj debug_keep_test.js)
+    (targets debug_keep_test.cmi debug_keep_test.cmj debug_keep_test.cmt debug_keep_test.js)
     (deps (:inputs debug_keep_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1638,7 +1638,7 @@
 
 
   (rule
-    (targets debug_mode_value.cmi debug_mode_value.cmj debug_mode_value.js)
+    (targets debug_mode_value.cmi debug_mode_value.cmj debug_mode_value.cmt debug_mode_value.js)
     (deps (:inputs debug_mode_value.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1651,7 +1651,7 @@
 
 
   (rule
-    (targets debug_tmp.cmi debug_tmp.cmj debug_tmp.js)
+    (targets debug_tmp.cmi debug_tmp.cmj debug_tmp.cmt debug_tmp.js)
     (deps (:inputs debug_tmp.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1664,7 +1664,7 @@
 
 
   (rule
-    (targets debugger_test.cmi debugger_test.cmj debugger_test.js)
+    (targets debugger_test.cmi debugger_test.cmj debugger_test.cmt debugger_test.js)
     (deps (:inputs debugger_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1677,7 +1677,7 @@
 
 
   (rule
-    (targets default_export_test.cmi default_export_test.cmj default_export_test.js)
+    (targets default_export_test.cmi default_export_test.cmj default_export_test.cmt default_export_test.js)
     (deps (:inputs default_export_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1690,7 +1690,7 @@
 
 
   (rule
-    (targets defunctor_make_test.cmi defunctor_make_test.cmj defunctor_make_test.js)
+    (targets defunctor_make_test.cmi defunctor_make_test.cmj defunctor_make_test.cmt defunctor_make_test.js)
     (deps (:inputs defunctor_make_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1703,7 +1703,7 @@
 
 
   (rule
-    (targets demo.cmi demo.cmj demo.js)
+    (targets demo.cmi demo.cmj demo.cmt demo.js)
     (deps (:inputs demo.ml) ../stdlib-412/stdlib.cmj demo_binding.cmj)
 
   (mode
@@ -1716,7 +1716,7 @@
 
 
   (rule
-    (targets demo_binding.cmi demo_binding.cmj demo_binding.js)
+    (targets demo_binding.cmi demo_binding.cmj demo_binding.cmt demo_binding.js)
     (deps (:inputs demo_binding.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1729,7 +1729,7 @@
 
 
   (rule
-    (targets demo_int_map.cmj demo_int_map.js)
+    (targets demo_int_map.cmj demo_int_map.cmt demo_int_map.js)
     (deps (:inputs demo_int_map.ml) ../stdlib-412/stdlib.cmj demo_int_map.cmi)
 
   (mode
@@ -1742,7 +1742,7 @@
 
 
   (rule
-    (targets demo_int_map.cmi )
+    (targets demo_int_map.cmi demo_int_map.cmti )
     (deps (:inputs demo_int_map.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1755,7 +1755,7 @@
 
 
   (rule
-    (targets demo_page.cmi demo_page.cmj demo_page.js)
+    (targets demo_page.cmi demo_page.cmj demo_page.cmt demo_page.js)
     (deps (:inputs demo_page.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1768,7 +1768,7 @@
 
 
   (rule
-    (targets demo_pipe.cmi demo_pipe.cmj demo_pipe.js)
+    (targets demo_pipe.cmi demo_pipe.cmj demo_pipe.cmt demo_pipe.js)
     (deps (:inputs demo_pipe.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1781,7 +1781,7 @@
 
 
   (rule
-    (targets derive_dyntype.cmi derive_dyntype.cmj derive_dyntype.js)
+    (targets derive_dyntype.cmi derive_dyntype.cmj derive_dyntype.cmt derive_dyntype.js)
     (deps (:inputs derive_dyntype.ml) ../stdlib-412/stdlib.cmj a.cmj b.cmj)
 
   (mode
@@ -1794,7 +1794,7 @@
 
 
   (rule
-    (targets derive_projector_test.cmj derive_projector_test.js)
+    (targets derive_projector_test.cmj derive_projector_test.cmt derive_projector_test.js)
     (deps (:inputs derive_projector_test.ml) ../stdlib-412/stdlib.cmj derive_projector_test.cmi)
 
   (mode
@@ -1807,7 +1807,7 @@
 
 
   (rule
-    (targets derive_projector_test.cmi )
+    (targets derive_projector_test.cmi derive_projector_test.cmti )
     (deps (:inputs derive_projector_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1820,7 +1820,7 @@
 
 
   (rule
-    (targets derive_type_test.cmi derive_type_test.cmj derive_type_test.js)
+    (targets derive_type_test.cmi derive_type_test.cmj derive_type_test.cmt derive_type_test.js)
     (deps (:inputs derive_type_test.ml) ../stdlib-412/stdlib.cmj a.cmj b.cmj)
 
   (mode
@@ -1833,7 +1833,7 @@
 
 
   (rule
-    (targets digest_test.cmi digest_test.cmj digest_test.js)
+    (targets digest_test.cmi digest_test.cmj digest_test.cmt digest_test.js)
     (deps (:inputs digest_test.ml) ../stdlib-412/stdlib.cmj ext_array_test.cmj mt.cmj)
 
   (mode
@@ -1846,7 +1846,7 @@
 
 
   (rule
-    (targets div_by_zero_test.cmi div_by_zero_test.cmj div_by_zero_test.js)
+    (targets div_by_zero_test.cmi div_by_zero_test.cmj div_by_zero_test.cmt div_by_zero_test.js)
     (deps (:inputs div_by_zero_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1859,7 +1859,7 @@
 
 
   (rule
-    (targets dollar_escape_test.cmi dollar_escape_test.cmj dollar_escape_test.js)
+    (targets dollar_escape_test.cmi dollar_escape_test.cmj dollar_escape_test.cmt dollar_escape_test.js)
     (deps (:inputs dollar_escape_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1872,7 +1872,7 @@
 
 
   (rule
-    (targets earger_curry_test.cmi earger_curry_test.cmj earger_curry_test.js)
+    (targets earger_curry_test.cmi earger_curry_test.cmj earger_curry_test.cmt earger_curry_test.js)
     (deps (:inputs earger_curry_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1885,7 +1885,7 @@
 
 
   (rule
-    (targets effect.cmi effect.cmj effect.js)
+    (targets effect.cmi effect.cmj effect.cmt effect.js)
     (deps (:inputs effect.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1898,7 +1898,7 @@
 
 
   (rule
-    (targets empty_obj.cmi empty_obj.cmj empty_obj.js)
+    (targets empty_obj.cmi empty_obj.cmj empty_obj.cmt empty_obj.js)
     (deps (:inputs empty_obj.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1911,7 +1911,7 @@
 
 
   (rule
-    (targets epsilon_test.cmi epsilon_test.cmj epsilon_test.js)
+    (targets epsilon_test.cmi epsilon_test.cmj epsilon_test.cmt epsilon_test.js)
     (deps (:inputs epsilon_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1924,7 +1924,7 @@
 
 
   (rule
-    (targets equal_box_test.cmi equal_box_test.cmj equal_box_test.js)
+    (targets equal_box_test.cmi equal_box_test.cmj equal_box_test.cmt equal_box_test.js)
     (deps (:inputs equal_box_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1937,7 +1937,7 @@
 
 
   (rule
-    (targets equal_exception_test.cmi equal_exception_test.cmj equal_exception_test.js)
+    (targets equal_exception_test.cmi equal_exception_test.cmj equal_exception_test.cmt equal_exception_test.js)
     (deps (:inputs equal_exception_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1950,7 +1950,7 @@
 
 
   (rule
-    (targets equal_test.cmi equal_test.cmj equal_test.js)
+    (targets equal_test.cmi equal_test.cmj equal_test.cmt equal_test.js)
     (deps (:inputs equal_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1963,7 +1963,7 @@
 
 
   (rule
-    (targets es6_module_test.cmi es6_module_test.cmj es6_module_test.js)
+    (targets es6_module_test.cmi es6_module_test.cmj es6_module_test.cmt es6_module_test.js)
     (deps (:inputs es6_module_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -1976,7 +1976,7 @@
 
 
   (rule
-    (targets escape_esmodule.cmi escape_esmodule.cmj escape_esmodule.js)
+    (targets escape_esmodule.cmi escape_esmodule.cmj escape_esmodule.cmt escape_esmodule.js)
     (deps (:inputs escape_esmodule.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -1989,7 +1989,7 @@
 
 
   (rule
-    (targets esmodule_ref.cmi esmodule_ref.cmj esmodule_ref.js)
+    (targets esmodule_ref.cmi esmodule_ref.cmj esmodule_ref.cmt esmodule_ref.js)
     (deps (:inputs esmodule_ref.ml) ../stdlib-412/stdlib.cmj escape_esmodule.cmj)
 
   (mode
@@ -2002,7 +2002,7 @@
 
 
   (rule
-    (targets event_ffi.cmi event_ffi.cmj event_ffi.js)
+    (targets event_ffi.cmi event_ffi.cmj event_ffi.cmt event_ffi.js)
     (deps (:inputs event_ffi.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2015,7 +2015,7 @@
 
 
   (rule
-    (targets exception_alias.cmi exception_alias.cmj exception_alias.js)
+    (targets exception_alias.cmi exception_alias.cmj exception_alias.cmt exception_alias.js)
     (deps (:inputs exception_alias.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2028,7 +2028,7 @@
 
 
   (rule
-    (targets exception_def.cmi exception_def.cmj exception_def.js)
+    (targets exception_def.cmi exception_def.cmj exception_def.cmt exception_def.js)
     (deps (:inputs exception_def.ml) ../stdlib-412/stdlib.cmj mt.cmj test_other_exn.cmj)
 
   (mode
@@ -2041,7 +2041,7 @@
 
 
   (rule
-    (targets exception_raise_test.cmi exception_raise_test.cmj exception_raise_test.js)
+    (targets exception_raise_test.cmi exception_raise_test.cmj exception_raise_test.cmt exception_raise_test.js)
     (deps (:inputs exception_raise_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2054,7 +2054,7 @@
 
 
   (rule
-    (targets exception_rebind_test.cmi exception_rebind_test.cmj exception_rebind_test.js)
+    (targets exception_rebind_test.cmi exception_rebind_test.cmj exception_rebind_test.cmt exception_rebind_test.js)
     (deps (:inputs exception_rebind_test.ml) ../stdlib-412/stdlib.cmj a.cmj b.cmj exception_def.cmj)
 
   (mode
@@ -2067,7 +2067,7 @@
 
 
   (rule
-    (targets exception_rebound_err_test.cmi exception_rebound_err_test.cmj exception_rebound_err_test.js)
+    (targets exception_rebound_err_test.cmi exception_rebound_err_test.cmj exception_rebound_err_test.cmt exception_rebound_err_test.js)
     (deps (:inputs exception_rebound_err_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2080,7 +2080,7 @@
 
 
   (rule
-    (targets exception_repr_test.cmi exception_repr_test.cmj exception_repr_test.js)
+    (targets exception_repr_test.cmi exception_repr_test.cmj exception_repr_test.cmt exception_repr_test.js)
     (deps (:inputs exception_repr_test.ml) ../stdlib-412/stdlib.cmj exception_def.cmj mt.cmj)
 
   (mode
@@ -2093,7 +2093,7 @@
 
 
   (rule
-    (targets exception_value_test.cmi exception_value_test.cmj exception_value_test.js)
+    (targets exception_value_test.cmi exception_value_test.cmj exception_value_test.cmt exception_value_test.js)
     (deps (:inputs exception_value_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2106,7 +2106,7 @@
 
 
   (rule
-    (targets exn_error_pattern.cmi exn_error_pattern.cmj exn_error_pattern.js)
+    (targets exn_error_pattern.cmi exn_error_pattern.cmj exn_error_pattern.cmt exn_error_pattern.js)
     (deps (:inputs exn_error_pattern.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2119,7 +2119,7 @@
 
 
   (rule
-    (targets export_keyword.cmi export_keyword.cmj export_keyword.js)
+    (targets export_keyword.cmi export_keyword.cmj export_keyword.cmt export_keyword.js)
     (deps (:inputs export_keyword.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2132,7 +2132,7 @@
 
 
   (rule
-    (targets ext_array_test.cmi ext_array_test.cmj ext_array_test.js)
+    (targets ext_array_test.cmi ext_array_test.cmj ext_array_test.cmt ext_array_test.js)
     (deps (:inputs ext_array_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2145,7 +2145,7 @@
 
 
   (rule
-    (targets ext_bytes_test.cmi ext_bytes_test.cmj ext_bytes_test.js)
+    (targets ext_bytes_test.cmi ext_bytes_test.cmj ext_bytes_test.cmt ext_bytes_test.js)
     (deps (:inputs ext_bytes_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2158,7 +2158,7 @@
 
 
   (rule
-    (targets ext_filename_test.cmi ext_filename_test.cmj ext_filename_test.js)
+    (targets ext_filename_test.cmi ext_filename_test.cmj ext_filename_test.cmt ext_filename_test.js)
     (deps (:inputs ext_filename_test.ml) ../stdlib-412/stdlib.cmj ext_pervasives_test.cmj ext_string_test.cmj test_literals.cmj)
 
   (mode
@@ -2171,7 +2171,7 @@
 
 
   (rule
-    (targets ext_list_test.cmi ext_list_test.cmj ext_list_test.js)
+    (targets ext_list_test.cmi ext_list_test.cmj ext_list_test.cmt ext_list_test.js)
     (deps (:inputs ext_list_test.ml) ../stdlib-412/stdlib.cmj ext_string_test.cmj)
 
   (mode
@@ -2184,7 +2184,7 @@
 
 
   (rule
-    (targets ext_log_test.cmi ext_log_test.cmj ext_log_test.js)
+    (targets ext_log_test.cmi ext_log_test.cmj ext_log_test.cmt ext_log_test.js)
     (deps (:inputs ext_log_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2197,7 +2197,7 @@
 
 
   (rule
-    (targets ext_pervasives_test.cmj ext_pervasives_test.js)
+    (targets ext_pervasives_test.cmj ext_pervasives_test.cmt ext_pervasives_test.js)
     (deps (:inputs ext_pervasives_test.ml) ../stdlib-412/stdlib.cmj ext_pervasives_test.cmi)
 
   (mode
@@ -2210,7 +2210,7 @@
 
 
   (rule
-    (targets ext_pervasives_test.cmi )
+    (targets ext_pervasives_test.cmi ext_pervasives_test.cmti )
     (deps (:inputs ext_pervasives_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2223,7 +2223,7 @@
 
 
   (rule
-    (targets ext_string_test.cmi ext_string_test.cmj ext_string_test.js)
+    (targets ext_string_test.cmi ext_string_test.cmj ext_string_test.cmt ext_string_test.js)
     (deps (:inputs ext_string_test.ml) ../stdlib-412/stdlib.cmj ext_bytes_test.cmj)
 
   (mode
@@ -2236,7 +2236,7 @@
 
 
   (rule
-    (targets ext_sys_test.cmj ext_sys_test.js)
+    (targets ext_sys_test.cmj ext_sys_test.cmt ext_sys_test.js)
     (deps (:inputs ext_sys_test.ml) ../stdlib-412/stdlib.cmj ext_sys_test.cmi)
 
   (mode
@@ -2249,7 +2249,7 @@
 
 
   (rule
-    (targets ext_sys_test.cmi )
+    (targets ext_sys_test.cmi ext_sys_test.cmti )
     (deps (:inputs ext_sys_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2262,7 +2262,7 @@
 
 
   (rule
-    (targets extensible_variant_test.cmi extensible_variant_test.cmj extensible_variant_test.js)
+    (targets extensible_variant_test.cmi extensible_variant_test.cmj extensible_variant_test.cmt extensible_variant_test.js)
     (deps (:inputs extensible_variant_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2275,7 +2275,7 @@
 
 
   (rule
-    (targets external_intf_impl.cmj external_intf_impl.js)
+    (targets external_intf_impl.cmj external_intf_impl.cmt external_intf_impl.js)
     (deps (:inputs external_intf_impl.ml) ../stdlib-412/stdlib.cmj external_intf_impl.cmi)
 
   (mode
@@ -2288,7 +2288,7 @@
 
 
   (rule
-    (targets external_intf_impl.cmi )
+    (targets external_intf_impl.cmi external_intf_impl.cmti )
     (deps (:inputs external_intf_impl.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2301,7 +2301,7 @@
 
 
   (rule
-    (targets external_polyfill_test.cmi external_polyfill_test.cmj external_polyfill_test.js)
+    (targets external_polyfill_test.cmi external_polyfill_test.cmj external_polyfill_test.cmt external_polyfill_test.js)
     (deps (:inputs external_polyfill_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2314,7 +2314,7 @@
 
 
   (rule
-    (targets external_ppx.cmi external_ppx.cmj external_ppx.js)
+    (targets external_ppx.cmi external_ppx.cmj external_ppx.cmt external_ppx.js)
     (deps (:inputs external_ppx.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2327,7 +2327,7 @@
 
 
   (rule
-    (targets fail_comp.cmi fail_comp.cmj fail_comp.js)
+    (targets fail_comp.cmi fail_comp.cmj fail_comp.cmt fail_comp.js)
     (deps (:inputs fail_comp.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2340,7 +2340,7 @@
 
 
   (rule
-    (targets ffi_arity_test.cmi ffi_arity_test.cmj ffi_arity_test.js)
+    (targets ffi_arity_test.cmi ffi_arity_test.cmj ffi_arity_test.cmt ffi_arity_test.js)
     (deps (:inputs ffi_arity_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2353,7 +2353,7 @@
 
 
   (rule
-    (targets ffi_array_test.cmi ffi_array_test.cmj ffi_array_test.js)
+    (targets ffi_array_test.cmi ffi_array_test.cmj ffi_array_test.cmt ffi_array_test.js)
     (deps (:inputs ffi_array_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2366,7 +2366,7 @@
 
 
   (rule
-    (targets ffi_js_test.cmi ffi_js_test.cmj ffi_js_test.js)
+    (targets ffi_js_test.cmi ffi_js_test.cmj ffi_js_test.cmt ffi_js_test.js)
     (deps (:inputs ffi_js_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2379,7 +2379,7 @@
 
 
   (rule
-    (targets ffi_splice_test.cmi ffi_splice_test.cmj ffi_splice_test.js)
+    (targets ffi_splice_test.cmi ffi_splice_test.cmj ffi_splice_test.cmt ffi_splice_test.js)
     (deps (:inputs ffi_splice_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2392,7 +2392,7 @@
 
 
   (rule
-    (targets ffi_test.cmi ffi_test.cmj ffi_test.js)
+    (targets ffi_test.cmi ffi_test.cmj ffi_test.cmt ffi_test.js)
     (deps (:inputs ffi_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2405,7 +2405,7 @@
 
 
   (rule
-    (targets fib.cmi fib.cmj fib.js)
+    (targets fib.cmi fib.cmj fib.cmt fib.js)
     (deps (:inputs fib.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2418,7 +2418,7 @@
 
 
   (rule
-    (targets flattern_order_test.cmi flattern_order_test.cmj flattern_order_test.js)
+    (targets flattern_order_test.cmi flattern_order_test.cmj flattern_order_test.cmt flattern_order_test.js)
     (deps (:inputs flattern_order_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2431,7 +2431,7 @@
 
 
   (rule
-    (targets flexible_array_test.cmi flexible_array_test.cmj flexible_array_test.js)
+    (targets flexible_array_test.cmi flexible_array_test.cmj flexible_array_test.cmt flexible_array_test.js)
     (deps (:inputs flexible_array_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2444,7 +2444,7 @@
 
 
   (rule
-    (targets float_array.cmi float_array.cmj float_array.js)
+    (targets float_array.cmi float_array.cmj float_array.cmt float_array.js)
     (deps (:inputs float_array.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2457,7 +2457,7 @@
 
 
   (rule
-    (targets float_of_bits_test.cmi float_of_bits_test.cmj float_of_bits_test.js)
+    (targets float_of_bits_test.cmi float_of_bits_test.cmj float_of_bits_test.cmt float_of_bits_test.js)
     (deps (:inputs float_of_bits_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2470,7 +2470,7 @@
 
 
   (rule
-    (targets float_record.cmj float_record.js)
+    (targets float_record.cmj float_record.cmt float_record.js)
     (deps (:inputs float_record.ml) ../stdlib-412/stdlib.cmj float_record.cmi)
 
   (mode
@@ -2483,7 +2483,7 @@
 
 
   (rule
-    (targets float_record.cmi )
+    (targets float_record.cmi float_record.cmti )
     (deps (:inputs float_record.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2496,7 +2496,7 @@
 
 
   (rule
-    (targets float_test.cmi float_test.cmj float_test.js)
+    (targets float_test.cmi float_test.cmj float_test.cmt float_test.js)
     (deps (:inputs float_test.ml) ../stdlib-412/stdlib.cmj mt.cmj mt_global.cmj)
 
   (mode
@@ -2509,7 +2509,7 @@
 
 
   (rule
-    (targets floatarray_test.cmi floatarray_test.cmj floatarray_test.js)
+    (targets floatarray_test.cmi floatarray_test.cmj floatarray_test.cmt floatarray_test.js)
     (deps (:inputs floatarray_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2522,7 +2522,7 @@
 
 
   (rule
-    (targets flow_parser_reg_test.cmj flow_parser_reg_test.js)
+    (targets flow_parser_reg_test.cmj  flow_parser_reg_test.js)
     (deps (:inputs flow_parser_reg_test.ml) ../stdlib-412/stdlib.cmj flow_parser_reg_test.cmi mt.cmj)
 
   (mode
@@ -2535,7 +2535,7 @@
 
 
   (rule
-    (targets flow_parser_reg_test.cmi )
+    (targets flow_parser_reg_test.cmi  )
     (deps (:inputs flow_parser_reg_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2548,7 +2548,7 @@
 
 
   (rule
-    (targets for_loop_test.cmi for_loop_test.cmj for_loop_test.js)
+    (targets for_loop_test.cmi for_loop_test.cmj for_loop_test.cmt for_loop_test.js)
     (deps (:inputs for_loop_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2561,7 +2561,7 @@
 
 
   (rule
-    (targets for_side_effect_test.cmi for_side_effect_test.cmj for_side_effect_test.js)
+    (targets for_side_effect_test.cmi for_side_effect_test.cmj for_side_effect_test.cmt for_side_effect_test.js)
     (deps (:inputs for_side_effect_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2574,7 +2574,7 @@
 
 
   (rule
-    (targets format_regression.cmi format_regression.cmj format_regression.js)
+    (targets format_regression.cmi format_regression.cmj format_regression.cmt format_regression.js)
     (deps (:inputs format_regression.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2587,7 +2587,7 @@
 
 
   (rule
-    (targets format_test.cmi format_test.cmj format_test.js)
+    (targets format_test.cmi format_test.cmj format_test.cmt format_test.js)
     (deps (:inputs format_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2600,7 +2600,7 @@
 
 
   (rule
-    (targets fs_test.cmi fs_test.cmj fs_test.js)
+    (targets fs_test.cmi fs_test.cmj fs_test.cmt fs_test.js)
     (deps (:inputs fs_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2613,7 +2613,7 @@
 
 
   (rule
-    (targets fun_pattern_match.cmi fun_pattern_match.cmj fun_pattern_match.js)
+    (targets fun_pattern_match.cmi fun_pattern_match.cmj fun_pattern_match.cmt fun_pattern_match.js)
     (deps (:inputs fun_pattern_match.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2626,7 +2626,7 @@
 
 
   (rule
-    (targets functor_app_test.cmi functor_app_test.cmj functor_app_test.js)
+    (targets functor_app_test.cmi functor_app_test.cmj functor_app_test.cmt functor_app_test.js)
     (deps (:inputs functor_app_test.ml) ../stdlib-412/stdlib.cmj functor_def.cmj functor_inst.cmj mt.cmj)
 
   (mode
@@ -2639,7 +2639,7 @@
 
 
   (rule
-    (targets functor_def.cmi functor_def.cmj functor_def.js)
+    (targets functor_def.cmi functor_def.cmj functor_def.cmt functor_def.js)
     (deps (:inputs functor_def.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2652,7 +2652,7 @@
 
 
   (rule
-    (targets functor_ffi.cmi functor_ffi.cmj functor_ffi.js)
+    (targets functor_ffi.cmi functor_ffi.cmj functor_ffi.cmt functor_ffi.js)
     (deps (:inputs functor_ffi.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2665,7 +2665,7 @@
 
 
   (rule
-    (targets functor_inst.cmi functor_inst.cmj functor_inst.js)
+    (targets functor_inst.cmi functor_inst.cmj functor_inst.cmt functor_inst.js)
     (deps (:inputs functor_inst.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2678,7 +2678,7 @@
 
 
   (rule
-    (targets functors.cmi functors.cmj functors.js)
+    (targets functors.cmi functors.cmj functors.cmt functors.js)
     (deps (:inputs functors.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2691,7 +2691,7 @@
 
 
   (rule
-    (targets gbk.cmi gbk.cmj gbk.js)
+    (targets gbk.cmi gbk.cmj gbk.cmt gbk.js)
     (deps (:inputs gbk.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2704,7 +2704,7 @@
 
 
   (rule
-    (targets genlex_test.cmi genlex_test.cmj genlex_test.js)
+    (targets genlex_test.cmi genlex_test.cmj genlex_test.cmt genlex_test.js)
     (deps (:inputs genlex_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2717,7 +2717,7 @@
 
 
   (rule
-    (targets gentTypeReTest.cmi gentTypeReTest.cmj gentTypeReTest.js)
+    (targets gentTypeReTest.cmi gentTypeReTest.cmj gentTypeReTest.cmt gentTypeReTest.js)
     (deps (:inputs gentTypeReTest.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2730,7 +2730,7 @@
 
 
   (rule
-    (targets global_exception_regression_test.cmi global_exception_regression_test.cmj global_exception_regression_test.js)
+    (targets global_exception_regression_test.cmi global_exception_regression_test.cmj global_exception_regression_test.cmt global_exception_regression_test.js)
     (deps (:inputs global_exception_regression_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2743,7 +2743,7 @@
 
 
   (rule
-    (targets global_mangles.cmi global_mangles.cmj global_mangles.js)
+    (targets global_mangles.cmi global_mangles.cmj global_mangles.cmt global_mangles.js)
     (deps (:inputs global_mangles.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2756,7 +2756,7 @@
 
 
   (rule
-    (targets global_module_alias_test.cmi global_module_alias_test.cmj global_module_alias_test.js)
+    (targets global_module_alias_test.cmi global_module_alias_test.cmj global_module_alias_test.cmt global_module_alias_test.js)
     (deps (:inputs global_module_alias_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2769,7 +2769,7 @@
 
 
   (rule
-    (targets google_closure_test.cmi google_closure_test.cmj google_closure_test.js)
+    (targets google_closure_test.cmi google_closure_test.cmj google_closure_test.cmt google_closure_test.js)
     (deps (:inputs google_closure_test.ml) ../stdlib-412/stdlib.cmj mt.cmj test_google_closure.cmj)
 
   (mode
@@ -2782,7 +2782,7 @@
 
 
   (rule
-    (targets gpr496_test.cmi gpr496_test.cmj gpr496_test.js)
+    (targets gpr496_test.cmi gpr496_test.cmj gpr496_test.cmt gpr496_test.js)
     (deps (:inputs gpr496_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2795,7 +2795,7 @@
 
 
   (rule
-    (targets gpr_1063_test.cmi gpr_1063_test.cmj gpr_1063_test.js)
+    (targets gpr_1063_test.cmi gpr_1063_test.cmj gpr_1063_test.cmt gpr_1063_test.js)
     (deps (:inputs gpr_1063_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2808,7 +2808,7 @@
 
 
   (rule
-    (targets gpr_1072.cmi gpr_1072.cmj gpr_1072.js)
+    (targets gpr_1072.cmi gpr_1072.cmj gpr_1072.cmt gpr_1072.js)
     (deps (:inputs gpr_1072.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2821,7 +2821,7 @@
 
 
   (rule
-    (targets gpr_1072_reg.cmi gpr_1072_reg.cmj gpr_1072_reg.js)
+    (targets gpr_1072_reg.cmi gpr_1072_reg.cmj gpr_1072_reg.cmt gpr_1072_reg.js)
     (deps (:inputs gpr_1072_reg.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2834,7 +2834,7 @@
 
 
   (rule
-    (targets gpr_1150.cmi gpr_1150.cmj gpr_1150.js)
+    (targets gpr_1150.cmi gpr_1150.cmj gpr_1150.cmt gpr_1150.js)
     (deps (:inputs gpr_1150.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2847,7 +2847,7 @@
 
 
   (rule
-    (targets gpr_1154_test.cmi gpr_1154_test.cmj gpr_1154_test.js)
+    (targets gpr_1154_test.cmi gpr_1154_test.cmj gpr_1154_test.cmt gpr_1154_test.js)
     (deps (:inputs gpr_1154_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2860,7 +2860,7 @@
 
 
   (rule
-    (targets gpr_1170.cmi gpr_1170.cmj gpr_1170.js)
+    (targets gpr_1170.cmi gpr_1170.cmj gpr_1170.cmt gpr_1170.js)
     (deps (:inputs gpr_1170.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2873,7 +2873,7 @@
 
 
   (rule
-    (targets gpr_1240_missing_unbox.cmi gpr_1240_missing_unbox.cmj gpr_1240_missing_unbox.js)
+    (targets gpr_1240_missing_unbox.cmi gpr_1240_missing_unbox.cmj gpr_1240_missing_unbox.cmt gpr_1240_missing_unbox.js)
     (deps (:inputs gpr_1240_missing_unbox.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2886,7 +2886,7 @@
 
 
   (rule
-    (targets gpr_1245_test.cmi gpr_1245_test.cmj gpr_1245_test.js)
+    (targets gpr_1245_test.cmi gpr_1245_test.cmj gpr_1245_test.cmt gpr_1245_test.js)
     (deps (:inputs gpr_1245_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2899,7 +2899,7 @@
 
 
   (rule
-    (targets gpr_1268.cmi gpr_1268.cmj gpr_1268.js)
+    (targets gpr_1268.cmi gpr_1268.cmj gpr_1268.cmt gpr_1268.js)
     (deps (:inputs gpr_1268.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2912,7 +2912,7 @@
 
 
   (rule
-    (targets gpr_1285_test.cmi gpr_1285_test.cmj gpr_1285_test.js)
+    (targets gpr_1285_test.cmi gpr_1285_test.cmj gpr_1285_test.cmt gpr_1285_test.js)
     (deps (:inputs gpr_1285_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -2925,7 +2925,7 @@
 
 
   (rule
-    (targets gpr_1409_test.cmi gpr_1409_test.cmj gpr_1409_test.js)
+    (targets gpr_1409_test.cmi gpr_1409_test.cmj gpr_1409_test.cmt gpr_1409_test.js)
     (deps (:inputs gpr_1409_test.ml) ../stdlib-412/stdlib.cmj mt.cmj string_set.cmj)
 
   (mode
@@ -2938,7 +2938,7 @@
 
 
   (rule
-    (targets gpr_1423_app_test.cmi gpr_1423_app_test.cmj gpr_1423_app_test.js)
+    (targets gpr_1423_app_test.cmi gpr_1423_app_test.cmj gpr_1423_app_test.cmt gpr_1423_app_test.js)
     (deps (:inputs gpr_1423_app_test.ml) ../stdlib-412/stdlib.cmj gpr_1423_nav.cmj mt.cmj)
 
   (mode
@@ -2951,7 +2951,7 @@
 
 
   (rule
-    (targets gpr_1423_nav.cmi gpr_1423_nav.cmj gpr_1423_nav.js)
+    (targets gpr_1423_nav.cmi gpr_1423_nav.cmj gpr_1423_nav.cmt gpr_1423_nav.js)
     (deps (:inputs gpr_1423_nav.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2964,7 +2964,7 @@
 
 
   (rule
-    (targets gpr_1438.cmi gpr_1438.cmj gpr_1438.js)
+    (targets gpr_1438.cmi gpr_1438.cmj gpr_1438.cmt gpr_1438.js)
     (deps (:inputs gpr_1438.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2977,7 +2977,7 @@
 
 
   (rule
-    (targets gpr_1481.cmi gpr_1481.cmj gpr_1481.js)
+    (targets gpr_1481.cmi gpr_1481.cmj gpr_1481.cmt gpr_1481.js)
     (deps (:inputs gpr_1481.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -2990,7 +2990,7 @@
 
 
   (rule
-    (targets gpr_1484.cmi gpr_1484.cmj gpr_1484.js)
+    (targets gpr_1484.cmi gpr_1484.cmj gpr_1484.cmt gpr_1484.js)
     (deps (:inputs gpr_1484.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3003,7 +3003,7 @@
 
 
   (rule
-    (targets gpr_1501_test.cmi gpr_1501_test.cmj gpr_1501_test.js)
+    (targets gpr_1501_test.cmi gpr_1501_test.cmj gpr_1501_test.cmt gpr_1501_test.js)
     (deps (:inputs gpr_1501_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3016,7 +3016,7 @@
 
 
   (rule
-    (targets gpr_1503_test.cmi gpr_1503_test.cmj gpr_1503_test.js)
+    (targets gpr_1503_test.cmi gpr_1503_test.cmj gpr_1503_test.cmt gpr_1503_test.js)
     (deps (:inputs gpr_1503_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3029,7 +3029,7 @@
 
 
   (rule
-    (targets gpr_1539_test.cmi gpr_1539_test.cmj gpr_1539_test.js)
+    (targets gpr_1539_test.cmi gpr_1539_test.cmj gpr_1539_test.cmt gpr_1539_test.js)
     (deps (:inputs gpr_1539_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3042,7 +3042,7 @@
 
 
   (rule
-    (targets gpr_1600_test.cmi gpr_1600_test.cmj gpr_1600_test.js)
+    (targets gpr_1600_test.cmi gpr_1600_test.cmj gpr_1600_test.cmt gpr_1600_test.js)
     (deps (:inputs gpr_1600_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3055,7 +3055,7 @@
 
 
   (rule
-    (targets gpr_1658_test.cmi gpr_1658_test.cmj gpr_1658_test.js)
+    (targets gpr_1658_test.cmi gpr_1658_test.cmj gpr_1658_test.cmt gpr_1658_test.js)
     (deps (:inputs gpr_1658_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3068,7 +3068,7 @@
 
 
   (rule
-    (targets gpr_1667_test.cmi gpr_1667_test.cmj gpr_1667_test.js)
+    (targets gpr_1667_test.cmi gpr_1667_test.cmj gpr_1667_test.cmt gpr_1667_test.js)
     (deps (:inputs gpr_1667_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3081,7 +3081,7 @@
 
 
   (rule
-    (targets gpr_1692_test.cmi gpr_1692_test.cmj gpr_1692_test.js)
+    (targets gpr_1692_test.cmi gpr_1692_test.cmj gpr_1692_test.cmt gpr_1692_test.js)
     (deps (:inputs gpr_1692_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3094,7 +3094,7 @@
 
 
   (rule
-    (targets gpr_1698_test.cmi gpr_1698_test.cmj gpr_1698_test.js)
+    (targets gpr_1698_test.cmi gpr_1698_test.cmj gpr_1698_test.cmt gpr_1698_test.js)
     (deps (:inputs gpr_1698_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3107,7 +3107,7 @@
 
 
   (rule
-    (targets gpr_1701_test.cmi gpr_1701_test.cmj gpr_1701_test.js)
+    (targets gpr_1701_test.cmi gpr_1701_test.cmj gpr_1701_test.cmt gpr_1701_test.js)
     (deps (:inputs gpr_1701_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3120,7 +3120,7 @@
 
 
   (rule
-    (targets gpr_1716_test.cmi gpr_1716_test.cmj gpr_1716_test.js)
+    (targets gpr_1716_test.cmi gpr_1716_test.cmj gpr_1716_test.cmt gpr_1716_test.js)
     (deps (:inputs gpr_1716_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3133,7 +3133,7 @@
 
 
   (rule
-    (targets gpr_1717_test.cmi gpr_1717_test.cmj gpr_1717_test.js)
+    (targets gpr_1717_test.cmi gpr_1717_test.cmj gpr_1717_test.cmt gpr_1717_test.js)
     (deps (:inputs gpr_1717_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3146,7 +3146,7 @@
 
 
   (rule
-    (targets gpr_1728_test.cmi gpr_1728_test.cmj gpr_1728_test.js)
+    (targets gpr_1728_test.cmi gpr_1728_test.cmj gpr_1728_test.cmt gpr_1728_test.js)
     (deps (:inputs gpr_1728_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3159,7 +3159,7 @@
 
 
   (rule
-    (targets gpr_1749_test.cmi gpr_1749_test.cmj gpr_1749_test.js)
+    (targets gpr_1749_test.cmi gpr_1749_test.cmj gpr_1749_test.cmt gpr_1749_test.js)
     (deps (:inputs gpr_1749_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3172,7 +3172,7 @@
 
 
   (rule
-    (targets gpr_1759_test.cmi gpr_1759_test.cmj gpr_1759_test.js)
+    (targets gpr_1759_test.cmi gpr_1759_test.cmj gpr_1759_test.cmt gpr_1759_test.js)
     (deps (:inputs gpr_1759_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3185,7 +3185,7 @@
 
 
   (rule
-    (targets gpr_1760_test.cmi gpr_1760_test.cmj gpr_1760_test.js)
+    (targets gpr_1760_test.cmi gpr_1760_test.cmj gpr_1760_test.cmt gpr_1760_test.js)
     (deps (:inputs gpr_1760_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3198,7 +3198,7 @@
 
 
   (rule
-    (targets gpr_1762_test.cmi gpr_1762_test.cmj gpr_1762_test.js)
+    (targets gpr_1762_test.cmi gpr_1762_test.cmj gpr_1762_test.cmt gpr_1762_test.js)
     (deps (:inputs gpr_1762_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3211,7 +3211,7 @@
 
 
   (rule
-    (targets gpr_1817_test.cmi gpr_1817_test.cmj gpr_1817_test.js)
+    (targets gpr_1817_test.cmi gpr_1817_test.cmj gpr_1817_test.cmt gpr_1817_test.js)
     (deps (:inputs gpr_1817_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3224,7 +3224,7 @@
 
 
   (rule
-    (targets gpr_1822_test.cmi gpr_1822_test.cmj gpr_1822_test.js)
+    (targets gpr_1822_test.cmi gpr_1822_test.cmj gpr_1822_test.cmt gpr_1822_test.js)
     (deps (:inputs gpr_1822_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3237,7 +3237,7 @@
 
 
   (rule
-    (targets gpr_1891_test.cmi gpr_1891_test.cmj gpr_1891_test.js)
+    (targets gpr_1891_test.cmi gpr_1891_test.cmj gpr_1891_test.cmt gpr_1891_test.js)
     (deps (:inputs gpr_1891_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3250,7 +3250,7 @@
 
 
   (rule
-    (targets gpr_1943_test.cmi gpr_1943_test.cmj gpr_1943_test.js)
+    (targets gpr_1943_test.cmi gpr_1943_test.cmj gpr_1943_test.cmt gpr_1943_test.js)
     (deps (:inputs gpr_1943_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3263,7 +3263,7 @@
 
 
   (rule
-    (targets gpr_1946_test.cmi gpr_1946_test.cmj gpr_1946_test.js)
+    (targets gpr_1946_test.cmi gpr_1946_test.cmj gpr_1946_test.cmt gpr_1946_test.js)
     (deps (:inputs gpr_1946_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3276,7 +3276,7 @@
 
 
   (rule
-    (targets gpr_2250_test.cmi gpr_2250_test.cmj gpr_2250_test.js)
+    (targets gpr_2250_test.cmi gpr_2250_test.cmj gpr_2250_test.cmt gpr_2250_test.js)
     (deps (:inputs gpr_2250_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3289,7 +3289,7 @@
 
 
   (rule
-    (targets gpr_2316_test.cmi gpr_2316_test.cmj gpr_2316_test.js)
+    (targets gpr_2316_test.cmi gpr_2316_test.cmj gpr_2316_test.cmt gpr_2316_test.js)
     (deps (:inputs gpr_2316_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3302,7 +3302,7 @@
 
 
   (rule
-    (targets gpr_2352_test.cmi gpr_2352_test.cmj gpr_2352_test.js)
+    (targets gpr_2352_test.cmi gpr_2352_test.cmj gpr_2352_test.cmt gpr_2352_test.js)
     (deps (:inputs gpr_2352_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3315,7 +3315,7 @@
 
 
   (rule
-    (targets gpr_2413_test.cmi gpr_2413_test.cmj gpr_2413_test.js)
+    (targets gpr_2413_test.cmi gpr_2413_test.cmj gpr_2413_test.cmt gpr_2413_test.js)
     (deps (:inputs gpr_2413_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3328,7 +3328,7 @@
 
 
   (rule
-    (targets gpr_2474.cmi gpr_2474.cmj gpr_2474.js)
+    (targets gpr_2474.cmi gpr_2474.cmj gpr_2474.cmt gpr_2474.js)
     (deps (:inputs gpr_2474.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3341,7 +3341,7 @@
 
 
   (rule
-    (targets gpr_2487.cmi gpr_2487.cmj gpr_2487.js)
+    (targets gpr_2487.cmi gpr_2487.cmj gpr_2487.cmt gpr_2487.js)
     (deps (:inputs gpr_2487.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3354,7 +3354,7 @@
 
 
   (rule
-    (targets gpr_2503_test.cmi gpr_2503_test.cmj gpr_2503_test.js)
+    (targets gpr_2503_test.cmi gpr_2503_test.cmj gpr_2503_test.cmt gpr_2503_test.js)
     (deps (:inputs gpr_2503_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3367,7 +3367,7 @@
 
 
   (rule
-    (targets gpr_2608_test.cmi gpr_2608_test.cmj gpr_2608_test.js)
+    (targets gpr_2608_test.cmi gpr_2608_test.cmj gpr_2608_test.cmt gpr_2608_test.js)
     (deps (:inputs gpr_2608_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3380,7 +3380,7 @@
 
 
   (rule
-    (targets gpr_2614_test.cmi gpr_2614_test.cmj gpr_2614_test.js)
+    (targets gpr_2614_test.cmi gpr_2614_test.cmj gpr_2614_test.cmt gpr_2614_test.js)
     (deps (:inputs gpr_2614_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3393,7 +3393,7 @@
 
 
   (rule
-    (targets gpr_2633_test.cmi gpr_2633_test.cmj gpr_2633_test.js)
+    (targets gpr_2633_test.cmi gpr_2633_test.cmj gpr_2633_test.cmt gpr_2633_test.js)
     (deps (:inputs gpr_2633_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3406,7 +3406,7 @@
 
 
   (rule
-    (targets gpr_2642_test.cmi gpr_2642_test.cmj gpr_2642_test.js)
+    (targets gpr_2642_test.cmi gpr_2642_test.cmj gpr_2642_test.cmt gpr_2642_test.js)
     (deps (:inputs gpr_2642_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3419,7 +3419,7 @@
 
 
   (rule
-    (targets gpr_2652_test.cmi gpr_2652_test.cmj gpr_2652_test.js)
+    (targets gpr_2652_test.cmi gpr_2652_test.cmj gpr_2652_test.cmt gpr_2652_test.js)
     (deps (:inputs gpr_2652_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3432,7 +3432,7 @@
 
 
   (rule
-    (targets gpr_2682_test.cmi gpr_2682_test.cmj gpr_2682_test.js)
+    (targets gpr_2682_test.cmi gpr_2682_test.cmj gpr_2682_test.cmt gpr_2682_test.js)
     (deps (:inputs gpr_2682_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3445,7 +3445,7 @@
 
 
   (rule
-    (targets gpr_2700_test.cmi gpr_2700_test.cmj gpr_2700_test.js)
+    (targets gpr_2700_test.cmi gpr_2700_test.cmj gpr_2700_test.cmt gpr_2700_test.js)
     (deps (:inputs gpr_2700_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3458,7 +3458,7 @@
 
 
   (rule
-    (targets gpr_2731_test.cmi gpr_2731_test.cmj gpr_2731_test.js)
+    (targets gpr_2731_test.cmi gpr_2731_test.cmj gpr_2731_test.cmt gpr_2731_test.js)
     (deps (:inputs gpr_2731_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3471,7 +3471,7 @@
 
 
   (rule
-    (targets gpr_2789_test.cmi gpr_2789_test.cmj gpr_2789_test.js)
+    (targets gpr_2789_test.cmi gpr_2789_test.cmj gpr_2789_test.cmt gpr_2789_test.js)
     (deps (:inputs gpr_2789_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3484,7 +3484,7 @@
 
 
   (rule
-    (targets gpr_2863_test.cmi gpr_2863_test.cmj gpr_2863_test.js)
+    (targets gpr_2863_test.cmi gpr_2863_test.cmj gpr_2863_test.cmt gpr_2863_test.js)
     (deps (:inputs gpr_2863_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3497,7 +3497,7 @@
 
 
   (rule
-    (targets gpr_2931_test.cmi gpr_2931_test.cmj gpr_2931_test.js)
+    (targets gpr_2931_test.cmi gpr_2931_test.cmj gpr_2931_test.cmt gpr_2931_test.js)
     (deps (:inputs gpr_2931_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3510,7 +3510,7 @@
 
 
   (rule
-    (targets gpr_3142_test.cmi gpr_3142_test.cmj gpr_3142_test.js)
+    (targets gpr_3142_test.cmi gpr_3142_test.cmj gpr_3142_test.cmt gpr_3142_test.js)
     (deps (:inputs gpr_3142_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3523,7 +3523,7 @@
 
 
   (rule
-    (targets gpr_3154_test.cmi gpr_3154_test.cmj gpr_3154_test.js)
+    (targets gpr_3154_test.cmi gpr_3154_test.cmj gpr_3154_test.cmt gpr_3154_test.js)
     (deps (:inputs gpr_3154_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3536,7 +3536,7 @@
 
 
   (rule
-    (targets gpr_3209_test.cmi gpr_3209_test.cmj gpr_3209_test.js)
+    (targets gpr_3209_test.cmi gpr_3209_test.cmj gpr_3209_test.cmt gpr_3209_test.js)
     (deps (:inputs gpr_3209_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3549,7 +3549,7 @@
 
 
   (rule
-    (targets gpr_3492_test.cmi gpr_3492_test.cmj gpr_3492_test.js)
+    (targets gpr_3492_test.cmi gpr_3492_test.cmj gpr_3492_test.cmt gpr_3492_test.js)
     (deps (:inputs gpr_3492_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3562,7 +3562,7 @@
 
 
   (rule
-    (targets gpr_3502_test.cmi gpr_3502_test.cmj gpr_3502_test.js)
+    (targets gpr_3502_test.cmi gpr_3502_test.cmj gpr_3502_test.cmt gpr_3502_test.js)
     (deps (:inputs gpr_3502_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3575,7 +3575,7 @@
 
 
   (rule
-    (targets gpr_3519_jsx_test.cmi gpr_3519_jsx_test.cmj gpr_3519_jsx_test.js)
+    (targets gpr_3519_jsx_test.cmi gpr_3519_jsx_test.cmj gpr_3519_jsx_test.cmt gpr_3519_jsx_test.js)
     (deps (:inputs gpr_3519_jsx_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3588,7 +3588,7 @@
 
 
   (rule
-    (targets gpr_3519_test.cmi gpr_3519_test.cmj gpr_3519_test.js)
+    (targets gpr_3519_test.cmi gpr_3519_test.cmj gpr_3519_test.cmt gpr_3519_test.js)
     (deps (:inputs gpr_3519_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3601,7 +3601,7 @@
 
 
   (rule
-    (targets gpr_3536_test.cmi gpr_3536_test.cmj gpr_3536_test.js)
+    (targets gpr_3536_test.cmi gpr_3536_test.cmj gpr_3536_test.cmt gpr_3536_test.js)
     (deps (:inputs gpr_3536_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3614,7 +3614,7 @@
 
 
   (rule
-    (targets gpr_3546_test.cmi gpr_3546_test.cmj gpr_3546_test.js)
+    (targets gpr_3546_test.cmi gpr_3546_test.cmj gpr_3546_test.cmt gpr_3546_test.js)
     (deps (:inputs gpr_3546_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3627,7 +3627,7 @@
 
 
   (rule
-    (targets gpr_3548_test.cmi gpr_3548_test.cmj gpr_3548_test.js)
+    (targets gpr_3548_test.cmi gpr_3548_test.cmj gpr_3548_test.cmt gpr_3548_test.js)
     (deps (:inputs gpr_3548_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3640,7 +3640,7 @@
 
 
   (rule
-    (targets gpr_3549_test.cmi gpr_3549_test.cmj gpr_3549_test.js)
+    (targets gpr_3549_test.cmi gpr_3549_test.cmj gpr_3549_test.cmt gpr_3549_test.js)
     (deps (:inputs gpr_3549_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3653,7 +3653,7 @@
 
 
   (rule
-    (targets gpr_3566_drive_test.cmi gpr_3566_drive_test.cmj gpr_3566_drive_test.js)
+    (targets gpr_3566_drive_test.cmi gpr_3566_drive_test.cmj gpr_3566_drive_test.cmt gpr_3566_drive_test.js)
     (deps (:inputs gpr_3566_drive_test.ml) ../stdlib-412/stdlib.cmj gpr_3566_test.cmj mt.cmj)
 
   (mode
@@ -3666,7 +3666,7 @@
 
 
   (rule
-    (targets gpr_3566_test.cmi gpr_3566_test.cmj gpr_3566_test.js)
+    (targets gpr_3566_test.cmi gpr_3566_test.cmj gpr_3566_test.cmt gpr_3566_test.js)
     (deps (:inputs gpr_3566_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3679,7 +3679,7 @@
 
 
   (rule
-    (targets gpr_3595_test.cmi gpr_3595_test.cmj gpr_3595_test.js)
+    (targets gpr_3595_test.cmi gpr_3595_test.cmj gpr_3595_test.cmt gpr_3595_test.js)
     (deps (:inputs gpr_3595_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3692,7 +3692,7 @@
 
 
   (rule
-    (targets gpr_3609_test.cmi gpr_3609_test.cmj gpr_3609_test.js)
+    (targets gpr_3609_test.cmi gpr_3609_test.cmj gpr_3609_test.cmt gpr_3609_test.js)
     (deps (:inputs gpr_3609_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3705,7 +3705,7 @@
 
 
   (rule
-    (targets gpr_3697_test.cmi gpr_3697_test.cmj gpr_3697_test.js)
+    (targets gpr_3697_test.cmi gpr_3697_test.cmj gpr_3697_test.cmt gpr_3697_test.js)
     (deps (:inputs gpr_3697_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3718,7 +3718,7 @@
 
 
   (rule
-    (targets gpr_373_test.cmi gpr_373_test.cmj gpr_373_test.js)
+    (targets gpr_373_test.cmi gpr_373_test.cmj gpr_373_test.cmt gpr_373_test.js)
     (deps (:inputs gpr_373_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3731,7 +3731,7 @@
 
 
   (rule
-    (targets gpr_3770_test.cmi gpr_3770_test.cmj gpr_3770_test.js)
+    (targets gpr_3770_test.cmi gpr_3770_test.cmj gpr_3770_test.cmt gpr_3770_test.js)
     (deps (:inputs gpr_3770_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3744,7 +3744,7 @@
 
 
   (rule
-    (targets gpr_3852_alias.cmi gpr_3852_alias.cmj gpr_3852_alias.js)
+    (targets gpr_3852_alias.cmi gpr_3852_alias.cmj gpr_3852_alias.cmt gpr_3852_alias.js)
     (deps (:inputs gpr_3852_alias.ml) ../stdlib-412/stdlib.cmj gpr_3852_effect.cmj)
 
   (mode
@@ -3757,7 +3757,7 @@
 
 
   (rule
-    (targets gpr_3852_alias_reify.cmj gpr_3852_alias_reify.js)
+    (targets gpr_3852_alias_reify.cmj gpr_3852_alias_reify.cmt gpr_3852_alias_reify.js)
     (deps (:inputs gpr_3852_alias_reify.ml) ../stdlib-412/stdlib.cmj gpr_3852_alias_reify.cmi gpr_3852_effect.cmj)
 
   (mode
@@ -3770,7 +3770,7 @@
 
 
   (rule
-    (targets gpr_3852_alias_reify.cmi )
+    (targets gpr_3852_alias_reify.cmi gpr_3852_alias_reify.cmti )
     (deps (:inputs gpr_3852_alias_reify.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3783,7 +3783,7 @@
 
 
   (rule
-    (targets gpr_3852_effect.cmi gpr_3852_effect.cmj gpr_3852_effect.js)
+    (targets gpr_3852_effect.cmi gpr_3852_effect.cmj gpr_3852_effect.cmt gpr_3852_effect.js)
     (deps (:inputs gpr_3852_effect.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3796,7 +3796,7 @@
 
 
   (rule
-    (targets gpr_3865.cmi gpr_3865.cmj gpr_3865.js)
+    (targets gpr_3865.cmi gpr_3865.cmj gpr_3865.cmt gpr_3865.js)
     (deps (:inputs gpr_3865.re) ../stdlib-412/stdlib.cmj gpr_3865_bar.cmj gpr_3865_foo.cmj)
 
   (mode
@@ -3809,7 +3809,7 @@
 
 
   (rule
-    (targets gpr_3865_bar.cmi gpr_3865_bar.cmj gpr_3865_bar.js)
+    (targets gpr_3865_bar.cmi gpr_3865_bar.cmj gpr_3865_bar.cmt gpr_3865_bar.js)
     (deps (:inputs gpr_3865_bar.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3822,7 +3822,7 @@
 
 
   (rule
-    (targets gpr_3865_foo.cmi gpr_3865_foo.cmj gpr_3865_foo.js)
+    (targets gpr_3865_foo.cmi gpr_3865_foo.cmj gpr_3865_foo.cmt gpr_3865_foo.js)
     (deps (:inputs gpr_3865_foo.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3835,7 +3835,7 @@
 
 
   (rule
-    (targets gpr_3875_test.cmi gpr_3875_test.cmj gpr_3875_test.js)
+    (targets gpr_3875_test.cmi gpr_3875_test.cmj gpr_3875_test.cmt gpr_3875_test.js)
     (deps (:inputs gpr_3875_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3848,7 +3848,7 @@
 
 
   (rule
-    (targets gpr_3877_test.cmi gpr_3877_test.cmj gpr_3877_test.js)
+    (targets gpr_3877_test.cmi gpr_3877_test.cmj gpr_3877_test.cmt gpr_3877_test.js)
     (deps (:inputs gpr_3877_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3861,7 +3861,7 @@
 
 
   (rule
-    (targets gpr_3895_test.cmi gpr_3895_test.cmj gpr_3895_test.js)
+    (targets gpr_3895_test.cmi gpr_3895_test.cmj gpr_3895_test.cmt gpr_3895_test.js)
     (deps (:inputs gpr_3895_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3874,7 +3874,7 @@
 
 
   (rule
-    (targets gpr_3897_test.cmi gpr_3897_test.cmj gpr_3897_test.js)
+    (targets gpr_3897_test.cmi gpr_3897_test.cmj gpr_3897_test.cmt gpr_3897_test.js)
     (deps (:inputs gpr_3897_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3887,7 +3887,7 @@
 
 
   (rule
-    (targets gpr_3931_test.cmi gpr_3931_test.cmj gpr_3931_test.js)
+    (targets gpr_3931_test.cmi gpr_3931_test.cmj gpr_3931_test.cmt gpr_3931_test.js)
     (deps (:inputs gpr_3931_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3900,7 +3900,7 @@
 
 
   (rule
-    (targets gpr_3980_test.cmi gpr_3980_test.cmj gpr_3980_test.js)
+    (targets gpr_3980_test.cmi gpr_3980_test.cmj gpr_3980_test.cmt gpr_3980_test.js)
     (deps (:inputs gpr_3980_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3913,7 +3913,7 @@
 
 
   (rule
-    (targets gpr_4025_test.cmi gpr_4025_test.cmj gpr_4025_test.js)
+    (targets gpr_4025_test.cmi gpr_4025_test.cmj gpr_4025_test.cmt gpr_4025_test.js)
     (deps (:inputs gpr_4025_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3926,7 +3926,7 @@
 
 
   (rule
-    (targets gpr_405_test.cmj gpr_405_test.js)
+    (targets gpr_405_test.cmj gpr_405_test.cmt gpr_405_test.js)
     (deps (:inputs gpr_405_test.ml) ../stdlib-412/stdlib.cmj gpr_405_test.cmi)
 
   (mode
@@ -3939,7 +3939,7 @@
 
 
   (rule
-    (targets gpr_405_test.cmi )
+    (targets gpr_405_test.cmi gpr_405_test.cmti )
     (deps (:inputs gpr_405_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3952,7 +3952,7 @@
 
 
   (rule
-    (targets gpr_4069_test.cmi gpr_4069_test.cmj gpr_4069_test.js)
+    (targets gpr_4069_test.cmi gpr_4069_test.cmj gpr_4069_test.cmt gpr_4069_test.js)
     (deps (:inputs gpr_4069_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3965,7 +3965,7 @@
 
 
   (rule
-    (targets gpr_4265_test.cmi gpr_4265_test.cmj gpr_4265_test.js)
+    (targets gpr_4265_test.cmi gpr_4265_test.cmj gpr_4265_test.cmt gpr_4265_test.js)
     (deps (:inputs gpr_4265_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -3978,7 +3978,7 @@
 
 
   (rule
-    (targets gpr_4274_test.cmi gpr_4274_test.cmj gpr_4274_test.js)
+    (targets gpr_4274_test.cmi gpr_4274_test.cmj gpr_4274_test.cmt gpr_4274_test.js)
     (deps (:inputs gpr_4274_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -3991,7 +3991,7 @@
 
 
   (rule
-    (targets gpr_4280_test.cmi gpr_4280_test.cmj gpr_4280_test.js)
+    (targets gpr_4280_test.cmi gpr_4280_test.cmj gpr_4280_test.cmt gpr_4280_test.js)
     (deps (:inputs gpr_4280_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4004,7 +4004,7 @@
 
 
   (rule
-    (targets gpr_4407_test.cmi gpr_4407_test.cmj gpr_4407_test.js)
+    (targets gpr_4407_test.cmi gpr_4407_test.cmj gpr_4407_test.cmt gpr_4407_test.js)
     (deps (:inputs gpr_4407_test.ml) ../stdlib-412/stdlib.cmj debug_mode_value.cmj mt.cmj)
 
   (mode
@@ -4017,7 +4017,7 @@
 
 
   (rule
-    (targets gpr_441.cmi gpr_441.cmj gpr_441.js)
+    (targets gpr_441.cmi gpr_441.cmj gpr_441.cmt gpr_441.js)
     (deps (:inputs gpr_441.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4030,7 +4030,7 @@
 
 
   (rule
-    (targets gpr_4442_test.cmi gpr_4442_test.cmj gpr_4442_test.js)
+    (targets gpr_4442_test.cmi gpr_4442_test.cmj gpr_4442_test.cmt gpr_4442_test.js)
     (deps (:inputs gpr_4442_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4043,7 +4043,7 @@
 
 
   (rule
-    (targets gpr_4491_test.cmi gpr_4491_test.cmj gpr_4491_test.js)
+    (targets gpr_4491_test.cmi gpr_4491_test.cmj gpr_4491_test.cmt gpr_4491_test.js)
     (deps (:inputs gpr_4491_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4056,7 +4056,7 @@
 
 
   (rule
-    (targets gpr_4494_test.cmi gpr_4494_test.cmj gpr_4494_test.js)
+    (targets gpr_4494_test.cmi gpr_4494_test.cmj gpr_4494_test.cmt gpr_4494_test.js)
     (deps (:inputs gpr_4494_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4069,7 +4069,7 @@
 
 
   (rule
-    (targets gpr_4519_test.cmi gpr_4519_test.cmj gpr_4519_test.js)
+    (targets gpr_4519_test.cmi gpr_4519_test.cmj gpr_4519_test.cmt gpr_4519_test.js)
     (deps (:inputs gpr_4519_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4082,7 +4082,7 @@
 
 
   (rule
-    (targets gpr_459_test.cmi gpr_459_test.cmj gpr_459_test.js)
+    (targets gpr_459_test.cmi gpr_459_test.cmj gpr_459_test.cmt gpr_459_test.js)
     (deps (:inputs gpr_459_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4095,7 +4095,7 @@
 
 
   (rule
-    (targets gpr_4632.cmi gpr_4632.cmj gpr_4632.js)
+    (targets gpr_4632.cmi gpr_4632.cmj gpr_4632.cmt gpr_4632.js)
     (deps (:inputs gpr_4632.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4108,7 +4108,7 @@
 
 
   (rule
-    (targets gpr_4639_test.cmi gpr_4639_test.cmj gpr_4639_test.js)
+    (targets gpr_4639_test.cmi gpr_4639_test.cmj gpr_4639_test.cmt gpr_4639_test.js)
     (deps (:inputs gpr_4639_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4121,7 +4121,7 @@
 
 
   (rule
-    (targets gpr_4900_test.cmi gpr_4900_test.cmj gpr_4900_test.js)
+    (targets gpr_4900_test.cmi gpr_4900_test.cmj gpr_4900_test.cmt gpr_4900_test.js)
     (deps (:inputs gpr_4900_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4134,7 +4134,7 @@
 
 
   (rule
-    (targets gpr_4924_test.cmi gpr_4924_test.cmj gpr_4924_test.js)
+    (targets gpr_4924_test.cmi gpr_4924_test.cmj gpr_4924_test.cmt gpr_4924_test.js)
     (deps (:inputs gpr_4924_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4147,7 +4147,7 @@
 
 
   (rule
-    (targets gpr_4931.cmi gpr_4931.cmj gpr_4931.js)
+    (targets gpr_4931.cmi gpr_4931.cmj gpr_4931.cmt gpr_4931.js)
     (deps (:inputs gpr_4931.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4160,7 +4160,7 @@
 
 
   (rule
-    (targets gpr_4931_allow.cmi gpr_4931_allow.cmj gpr_4931_allow.js)
+    (targets gpr_4931_allow.cmi gpr_4931_allow.cmj gpr_4931_allow.cmt gpr_4931_allow.js)
     (deps (:inputs gpr_4931_allow.res) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4173,7 +4173,7 @@
 
 
   (rule
-    (targets gpr_5169_test.cmi gpr_5169_test.cmj gpr_5169_test.js)
+    (targets gpr_5169_test.cmi gpr_5169_test.cmj gpr_5169_test.cmt gpr_5169_test.js)
     (deps (:inputs gpr_5169_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4186,7 +4186,7 @@
 
 
   (rule
-    (targets gpr_5280_optimize_test.cmi gpr_5280_optimize_test.cmj gpr_5280_optimize_test.js)
+    (targets gpr_5280_optimize_test.cmi gpr_5280_optimize_test.cmj gpr_5280_optimize_test.cmt gpr_5280_optimize_test.js)
     (deps (:inputs gpr_5280_optimize_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4199,7 +4199,7 @@
 
 
   (rule
-    (targets gpr_5312.cmi gpr_5312.cmj gpr_5312.js)
+    (targets gpr_5312.cmi gpr_5312.cmj gpr_5312.cmt gpr_5312.js)
     (deps (:inputs gpr_5312.res) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4212,7 +4212,7 @@
 
 
   (rule
-    (targets gpr_627_test.cmi gpr_627_test.cmj gpr_627_test.js)
+    (targets gpr_627_test.cmi gpr_627_test.cmj gpr_627_test.cmt gpr_627_test.js)
     (deps (:inputs gpr_627_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4225,7 +4225,7 @@
 
 
   (rule
-    (targets gpr_658.cmi gpr_658.cmj gpr_658.js)
+    (targets gpr_658.cmi gpr_658.cmj gpr_658.cmt gpr_658.js)
     (deps (:inputs gpr_658.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4238,7 +4238,7 @@
 
 
   (rule
-    (targets gpr_858_test.cmi gpr_858_test.cmj gpr_858_test.js)
+    (targets gpr_858_test.cmi gpr_858_test.cmj gpr_858_test.cmt gpr_858_test.js)
     (deps (:inputs gpr_858_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4251,7 +4251,7 @@
 
 
   (rule
-    (targets gpr_858_unit2_test.cmi gpr_858_unit2_test.cmj gpr_858_unit2_test.js)
+    (targets gpr_858_unit2_test.cmi gpr_858_unit2_test.cmj gpr_858_unit2_test.cmt gpr_858_unit2_test.js)
     (deps (:inputs gpr_858_unit2_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4264,7 +4264,7 @@
 
 
   (rule
-    (targets gpr_904_test.cmi gpr_904_test.cmj gpr_904_test.js)
+    (targets gpr_904_test.cmi gpr_904_test.cmj gpr_904_test.cmt gpr_904_test.js)
     (deps (:inputs gpr_904_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4277,7 +4277,7 @@
 
 
   (rule
-    (targets gpr_974_test.cmi gpr_974_test.cmj gpr_974_test.js)
+    (targets gpr_974_test.cmi gpr_974_test.cmj gpr_974_test.cmt gpr_974_test.js)
     (deps (:inputs gpr_974_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4290,7 +4290,7 @@
 
 
   (rule
-    (targets gpr_977_test.cmi gpr_977_test.cmj gpr_977_test.js)
+    (targets gpr_977_test.cmi gpr_977_test.cmj gpr_977_test.cmt gpr_977_test.js)
     (deps (:inputs gpr_977_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4303,7 +4303,7 @@
 
 
   (rule
-    (targets gpr_return_type_unused_attribute.cmi gpr_return_type_unused_attribute.cmj gpr_return_type_unused_attribute.js)
+    (targets gpr_return_type_unused_attribute.cmi gpr_return_type_unused_attribute.cmj gpr_return_type_unused_attribute.cmt gpr_return_type_unused_attribute.js)
     (deps (:inputs gpr_return_type_unused_attribute.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4316,7 +4316,7 @@
 
 
   (rule
-    (targets gray_code_test.cmi gray_code_test.cmj gray_code_test.js)
+    (targets gray_code_test.cmi gray_code_test.cmj gray_code_test.cmt gray_code_test.js)
     (deps (:inputs gray_code_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4329,7 +4329,7 @@
 
 
   (rule
-    (targets guide_for_ext.cmi guide_for_ext.cmj guide_for_ext.js)
+    (targets guide_for_ext.cmi guide_for_ext.cmj guide_for_ext.cmt guide_for_ext.js)
     (deps (:inputs guide_for_ext.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4342,7 +4342,7 @@
 
 
   (rule
-    (targets hamming_test.cmi hamming_test.cmj hamming_test.js)
+    (targets hamming_test.cmi hamming_test.cmj hamming_test.cmt hamming_test.js)
     (deps (:inputs hamming_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4355,7 +4355,7 @@
 
 
   (rule
-    (targets hash_collision_test.cmi hash_collision_test.cmj hash_collision_test.js)
+    (targets hash_collision_test.cmi hash_collision_test.cmj hash_collision_test.cmt hash_collision_test.js)
     (deps (:inputs hash_collision_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4368,7 +4368,7 @@
 
 
   (rule
-    (targets hash_sugar_desugar.cmj hash_sugar_desugar.js)
+    (targets hash_sugar_desugar.cmj hash_sugar_desugar.cmt hash_sugar_desugar.js)
     (deps (:inputs hash_sugar_desugar.ml) ../stdlib-412/stdlib.cmj hash_sugar_desugar.cmi)
 
   (mode
@@ -4381,7 +4381,7 @@
 
 
   (rule
-    (targets hash_sugar_desugar.cmi )
+    (targets hash_sugar_desugar.cmi hash_sugar_desugar.cmti )
     (deps (:inputs hash_sugar_desugar.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4394,7 +4394,7 @@
 
 
   (rule
-    (targets hash_test.cmi hash_test.cmj hash_test.js)
+    (targets hash_test.cmi hash_test.cmj hash_test.cmt hash_test.js)
     (deps (:inputs hash_test.ml) ../stdlib-412/stdlib.cmj mt.cmj mt_global.cmj)
 
   (mode
@@ -4407,7 +4407,7 @@
 
 
   (rule
-    (targets hashtbl_test.cmi hashtbl_test.cmj hashtbl_test.js)
+    (targets hashtbl_test.cmi hashtbl_test.cmj hashtbl_test.cmt hashtbl_test.js)
     (deps (:inputs hashtbl_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4420,7 +4420,7 @@
 
 
   (rule
-    (targets hello.foo.cmi hello.foo.cmj hello.foo.js)
+    (targets hello.foo.cmi hello.foo.cmj hello.foo.cmt hello.foo.js)
     (deps (:inputs hello.foo.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4433,7 +4433,7 @@
 
 
   (rule
-    (targets hello_res.cmj hello_res.js)
+    (targets hello_res.cmj hello_res.cmt hello_res.js)
     (deps (:inputs hello_res.res) ../stdlib-412/stdlib.cmj hello_res.cmi)
 
   (mode
@@ -4446,7 +4446,7 @@
 
 
   (rule
-    (targets hello_res.cmi )
+    (targets hello_res.cmi hello_res.cmti )
     (deps (:inputs hello_res.resi) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4459,7 +4459,7 @@
 
 
   (rule
-    (targets http_types.cmi http_types.cmj http_types.js)
+    (targets http_types.cmi http_types.cmj http_types.cmt http_types.js)
     (deps (:inputs http_types.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4472,7 +4472,7 @@
 
 
   (rule
-    (targets if_used_test.cmi if_used_test.cmj if_used_test.js)
+    (targets if_used_test.cmi if_used_test.cmj if_used_test.cmt if_used_test.js)
     (deps (:inputs if_used_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4485,7 +4485,7 @@
 
 
   (rule
-    (targets ignore_test.cmi ignore_test.cmj ignore_test.js)
+    (targets ignore_test.cmi ignore_test.cmj ignore_test.cmt ignore_test.js)
     (deps (:inputs ignore_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4498,7 +4498,7 @@
 
 
   (rule
-    (targets imm_map_bench.cmi imm_map_bench.cmj imm_map_bench.js)
+    (targets imm_map_bench.cmi imm_map_bench.cmj imm_map_bench.cmt imm_map_bench.js)
     (deps (:inputs imm_map_bench.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4511,7 +4511,7 @@
 
 
   (rule
-    (targets include_side_effect.cmi include_side_effect.cmj include_side_effect.js)
+    (targets include_side_effect.cmi include_side_effect.cmj include_side_effect.cmt include_side_effect.js)
     (deps (:inputs include_side_effect.ml) ../stdlib-412/stdlib.cmj side_effect.cmj)
 
   (mode
@@ -4524,7 +4524,7 @@
 
 
   (rule
-    (targets include_side_effect_free.cmi include_side_effect_free.cmj include_side_effect_free.js)
+    (targets include_side_effect_free.cmi include_side_effect_free.cmj include_side_effect_free.cmt include_side_effect_free.js)
     (deps (:inputs include_side_effect_free.ml) ../stdlib-412/stdlib.cmj side_effect_free.cmj)
 
   (mode
@@ -4537,7 +4537,7 @@
 
 
   (rule
-    (targets incomplete_toplevel_test.cmi incomplete_toplevel_test.cmj incomplete_toplevel_test.js)
+    (targets incomplete_toplevel_test.cmi incomplete_toplevel_test.cmj incomplete_toplevel_test.cmt incomplete_toplevel_test.js)
     (deps (:inputs incomplete_toplevel_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4550,7 +4550,7 @@
 
 
   (rule
-    (targets infer_type_test.cmj infer_type_test.js)
+    (targets infer_type_test.cmj infer_type_test.cmt infer_type_test.js)
     (deps (:inputs infer_type_test.ml) ../stdlib-412/stdlib.cmj infer_type_test.cmi)
 
   (mode
@@ -4563,7 +4563,7 @@
 
 
   (rule
-    (targets infer_type_test.cmi )
+    (targets infer_type_test.cmi infer_type_test.cmti )
     (deps (:inputs infer_type_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4576,7 +4576,7 @@
 
 
   (rule
-    (targets inline_const.cmj inline_const.js)
+    (targets inline_const.cmj inline_const.cmt inline_const.js)
     (deps (:inputs inline_const.ml) ../stdlib-412/stdlib.cmj inline_const.cmi)
 
   (mode
@@ -4589,7 +4589,7 @@
 
 
   (rule
-    (targets inline_const.cmi )
+    (targets inline_const.cmi inline_const.cmti )
     (deps (:inputs inline_const.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4602,7 +4602,7 @@
 
 
   (rule
-    (targets inline_const_test.cmi inline_const_test.cmj inline_const_test.js)
+    (targets inline_const_test.cmi inline_const_test.cmj inline_const_test.cmt inline_const_test.js)
     (deps (:inputs inline_const_test.ml) ../stdlib-412/stdlib.cmj inline_const.cmj mt.cmj)
 
   (mode
@@ -4615,7 +4615,7 @@
 
 
   (rule
-    (targets inline_edge_cases.cmj inline_edge_cases.js)
+    (targets inline_edge_cases.cmj inline_edge_cases.cmt inline_edge_cases.js)
     (deps (:inputs inline_edge_cases.ml) ../stdlib-412/stdlib.cmj inline_edge_cases.cmi)
 
   (mode
@@ -4628,7 +4628,7 @@
 
 
   (rule
-    (targets inline_edge_cases.cmi )
+    (targets inline_edge_cases.cmi inline_edge_cases.cmti )
     (deps (:inputs inline_edge_cases.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4641,7 +4641,7 @@
 
 
   (rule
-    (targets inline_map2_test.cmi inline_map2_test.cmj inline_map2_test.js)
+    (targets inline_map2_test.cmi inline_map2_test.cmj inline_map2_test.cmt inline_map2_test.js)
     (deps (:inputs inline_map2_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4654,7 +4654,7 @@
 
 
   (rule
-    (targets inline_map_demo.cmi inline_map_demo.cmj inline_map_demo.js)
+    (targets inline_map_demo.cmi inline_map_demo.cmj inline_map_demo.cmt inline_map_demo.js)
     (deps (:inputs inline_map_demo.res) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4667,7 +4667,7 @@
 
 
   (rule
-    (targets inline_map_test.cmj inline_map_test.js)
+    (targets inline_map_test.cmj inline_map_test.cmt inline_map_test.js)
     (deps (:inputs inline_map_test.ml) ../stdlib-412/stdlib.cmj inline_map_test.cmi mt.cmj)
 
   (mode
@@ -4680,7 +4680,7 @@
 
 
   (rule
-    (targets inline_map_test.cmi )
+    (targets inline_map_test.cmi inline_map_test.cmti )
     (deps (:inputs inline_map_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4693,7 +4693,7 @@
 
 
   (rule
-    (targets inline_record_test.cmi inline_record_test.cmj inline_record_test.js)
+    (targets inline_record_test.cmi inline_record_test.cmj inline_record_test.cmt inline_record_test.js)
     (deps (:inputs inline_record_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4706,7 +4706,7 @@
 
 
   (rule
-    (targets inline_regression_test.cmi inline_regression_test.cmj inline_regression_test.js)
+    (targets inline_regression_test.cmi inline_regression_test.cmj inline_regression_test.cmt inline_regression_test.js)
     (deps (:inputs inline_regression_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4719,7 +4719,7 @@
 
 
   (rule
-    (targets inline_string_test.cmi inline_string_test.cmj inline_string_test.js)
+    (targets inline_string_test.cmi inline_string_test.cmj inline_string_test.cmt inline_string_test.js)
     (deps (:inputs inline_string_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4732,7 +4732,7 @@
 
 
   (rule
-    (targets inner_call.cmi inner_call.cmj inner_call.js)
+    (targets inner_call.cmi inner_call.cmj inner_call.cmt inner_call.js)
     (deps (:inputs inner_call.ml) ../stdlib-412/stdlib.cmj inner_define.cmj)
 
   (mode
@@ -4745,7 +4745,7 @@
 
 
   (rule
-    (targets inner_define.cmj inner_define.js)
+    (targets inner_define.cmj inner_define.cmt inner_define.js)
     (deps (:inputs inner_define.ml) ../stdlib-412/stdlib.cmj inner_define.cmi)
 
   (mode
@@ -4758,7 +4758,7 @@
 
 
   (rule
-    (targets inner_define.cmi )
+    (targets inner_define.cmi inner_define.cmti )
     (deps (:inputs inner_define.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4771,7 +4771,7 @@
 
 
   (rule
-    (targets inner_unused.cmi inner_unused.cmj inner_unused.js)
+    (targets inner_unused.cmi inner_unused.cmj inner_unused.cmt inner_unused.js)
     (deps (:inputs inner_unused.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4784,7 +4784,7 @@
 
 
   (rule
-    (targets installation_test.cmi installation_test.cmj installation_test.js)
+    (targets installation_test.cmi installation_test.cmj installation_test.cmt installation_test.js)
     (deps (:inputs installation_test.ml) ../stdlib-412/stdlib.cmj app_root_finder.cmj mt.cmj)
 
   (mode
@@ -4797,7 +4797,7 @@
 
 
   (rule
-    (targets int32_test.cmi int32_test.cmj int32_test.js)
+    (targets int32_test.cmi int32_test.cmj int32_test.cmt int32_test.js)
     (deps (:inputs int32_test.ml) ../stdlib-412/stdlib.cmj ext_array_test.cmj mt.cmj)
 
   (mode
@@ -4810,7 +4810,7 @@
 
 
   (rule
-    (targets int64_mul_div_test.cmi int64_mul_div_test.cmj int64_mul_div_test.js)
+    (targets int64_mul_div_test.cmi int64_mul_div_test.cmj int64_mul_div_test.cmt int64_mul_div_test.js)
     (deps (:inputs int64_mul_div_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4823,7 +4823,7 @@
 
 
   (rule
-    (targets int64_string_bench.cmi int64_string_bench.cmj int64_string_bench.js)
+    (targets int64_string_bench.cmi int64_string_bench.cmj int64_string_bench.cmt int64_string_bench.js)
     (deps (:inputs int64_string_bench.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4836,7 +4836,7 @@
 
 
   (rule
-    (targets int64_string_test.cmi int64_string_test.cmj int64_string_test.js)
+    (targets int64_string_test.cmi int64_string_test.cmj int64_string_test.cmt int64_string_test.js)
     (deps (:inputs int64_string_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4849,7 +4849,7 @@
 
 
   (rule
-    (targets int64_test.cmi int64_test.cmj int64_test.js)
+    (targets int64_test.cmi int64_test.cmj int64_test.cmt int64_test.js)
     (deps (:inputs int64_test.ml) ../stdlib-412/stdlib.cmj ext_array_test.cmj mt.cmj)
 
   (mode
@@ -4862,7 +4862,7 @@
 
 
   (rule
-    (targets int_hashtbl_test.cmi int_hashtbl_test.cmj int_hashtbl_test.js)
+    (targets int_hashtbl_test.cmi int_hashtbl_test.cmj int_hashtbl_test.cmt int_hashtbl_test.js)
     (deps (:inputs int_hashtbl_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4875,7 +4875,7 @@
 
 
   (rule
-    (targets int_map.cmi int_map.cmj int_map.js)
+    (targets int_map.cmi int_map.cmj int_map.cmt int_map.js)
     (deps (:inputs int_map.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4888,7 +4888,7 @@
 
 
   (rule
-    (targets int_overflow_test.cmi int_overflow_test.cmj int_overflow_test.js)
+    (targets int_overflow_test.cmi int_overflow_test.cmj int_overflow_test.cmt int_overflow_test.js)
     (deps (:inputs int_overflow_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4901,7 +4901,7 @@
 
 
   (rule
-    (targets int_switch_test.cmi int_switch_test.cmj int_switch_test.js)
+    (targets int_switch_test.cmi int_switch_test.cmj int_switch_test.cmt int_switch_test.js)
     (deps (:inputs int_switch_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4914,7 +4914,7 @@
 
 
   (rule
-    (targets internal_unused_test.cmi internal_unused_test.cmj internal_unused_test.js)
+    (targets internal_unused_test.cmi internal_unused_test.cmj internal_unused_test.cmt internal_unused_test.js)
     (deps (:inputs internal_unused_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4927,7 +4927,7 @@
 
 
   (rule
-    (targets io_test.cmi io_test.cmj io_test.js)
+    (targets io_test.cmi io_test.cmj io_test.cmt io_test.js)
     (deps (:inputs io_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -4940,7 +4940,7 @@
 
 
   (rule
-    (targets js_array_test.cmi js_array_test.cmj js_array_test.js)
+    (targets js_array_test.cmi js_array_test.cmj js_array_test.cmt js_array_test.js)
     (deps (:inputs js_array_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4953,7 +4953,7 @@
 
 
   (rule
-    (targets js_bool_test.cmi js_bool_test.cmj js_bool_test.js)
+    (targets js_bool_test.cmi js_bool_test.cmj js_bool_test.cmt js_bool_test.js)
     (deps (:inputs js_bool_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4966,7 +4966,7 @@
 
 
   (rule
-    (targets js_cast_test.cmi js_cast_test.cmj js_cast_test.js)
+    (targets js_cast_test.cmi js_cast_test.cmj js_cast_test.cmt js_cast_test.js)
     (deps (:inputs js_cast_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4979,7 +4979,7 @@
 
 
   (rule
-    (targets js_date_test.cmi js_date_test.cmj js_date_test.js)
+    (targets js_date_test.cmi js_date_test.cmj js_date_test.cmt js_date_test.js)
     (deps (:inputs js_date_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -4992,7 +4992,7 @@
 
 
   (rule
-    (targets js_dict_test.cmi js_dict_test.cmj js_dict_test.js)
+    (targets js_dict_test.cmi js_dict_test.cmj js_dict_test.cmt js_dict_test.js)
     (deps (:inputs js_dict_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5005,7 +5005,7 @@
 
 
   (rule
-    (targets js_exception_catch_test.cmi js_exception_catch_test.cmj js_exception_catch_test.js)
+    (targets js_exception_catch_test.cmi js_exception_catch_test.cmj js_exception_catch_test.cmt js_exception_catch_test.js)
     (deps (:inputs js_exception_catch_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5018,7 +5018,7 @@
 
 
   (rule
-    (targets js_float_test.cmi js_float_test.cmj js_float_test.js)
+    (targets js_float_test.cmi js_float_test.cmj js_float_test.cmt js_float_test.js)
     (deps (:inputs js_float_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5031,7 +5031,7 @@
 
 
   (rule
-    (targets js_global_test.cmi js_global_test.cmj js_global_test.js)
+    (targets js_global_test.cmi js_global_test.cmj js_global_test.cmt js_global_test.js)
     (deps (:inputs js_global_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5044,7 +5044,7 @@
 
 
   (rule
-    (targets js_int_test.cmi js_int_test.cmj js_int_test.js)
+    (targets js_int_test.cmi js_int_test.cmj js_int_test.cmt js_int_test.js)
     (deps (:inputs js_int_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5057,7 +5057,7 @@
 
 
   (rule
-    (targets js_json_test.cmi js_json_test.cmj js_json_test.js)
+    (targets js_json_test.cmi js_json_test.cmj js_json_test.cmt js_json_test.js)
     (deps (:inputs js_json_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5070,7 +5070,7 @@
 
 
   (rule
-    (targets js_list_test.cmi js_list_test.cmj js_list_test.js)
+    (targets js_list_test.cmi js_list_test.cmj js_list_test.cmt js_list_test.js)
     (deps (:inputs js_list_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5083,7 +5083,7 @@
 
 
   (rule
-    (targets js_math_test.cmi js_math_test.cmj js_math_test.js)
+    (targets js_math_test.cmi js_math_test.cmj js_math_test.cmt js_math_test.js)
     (deps (:inputs js_math_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5096,7 +5096,7 @@
 
 
   (rule
-    (targets js_null_test.cmi js_null_test.cmj js_null_test.js)
+    (targets js_null_test.cmi js_null_test.cmj js_null_test.cmt js_null_test.js)
     (deps (:inputs js_null_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5109,7 +5109,7 @@
 
 
   (rule
-    (targets js_null_undefined_test.cmi js_null_undefined_test.cmj js_null_undefined_test.js)
+    (targets js_null_undefined_test.cmi js_null_undefined_test.cmj js_null_undefined_test.cmt js_null_undefined_test.js)
     (deps (:inputs js_null_undefined_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5122,7 +5122,7 @@
 
 
   (rule
-    (targets js_nullable_test.cmi js_nullable_test.cmj js_nullable_test.js)
+    (targets js_nullable_test.cmi js_nullable_test.cmj js_nullable_test.cmt js_nullable_test.js)
     (deps (:inputs js_nullable_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5135,7 +5135,7 @@
 
 
   (rule
-    (targets js_obj_test.cmi js_obj_test.cmj js_obj_test.js)
+    (targets js_obj_test.cmi js_obj_test.cmj js_obj_test.cmt js_obj_test.js)
     (deps (:inputs js_obj_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5148,7 +5148,7 @@
 
 
   (rule
-    (targets js_option_test.cmi js_option_test.cmj js_option_test.js)
+    (targets js_option_test.cmi js_option_test.cmj js_option_test.cmt js_option_test.js)
     (deps (:inputs js_option_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5161,7 +5161,7 @@
 
 
   (rule
-    (targets js_promise_basic_test.cmi js_promise_basic_test.cmj js_promise_basic_test.js)
+    (targets js_promise_basic_test.cmi js_promise_basic_test.cmj js_promise_basic_test.cmt js_promise_basic_test.js)
     (deps (:inputs js_promise_basic_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5174,7 +5174,7 @@
 
 
   (rule
-    (targets js_re_test.cmi js_re_test.cmj js_re_test.js)
+    (targets js_re_test.cmi js_re_test.cmj js_re_test.cmt js_re_test.js)
     (deps (:inputs js_re_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5187,7 +5187,7 @@
 
 
   (rule
-    (targets js_string_test.cmi js_string_test.cmj js_string_test.js)
+    (targets js_string_test.cmi js_string_test.cmj js_string_test.cmt js_string_test.js)
     (deps (:inputs js_string_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5200,7 +5200,7 @@
 
 
   (rule
-    (targets js_typed_array_test.cmi js_typed_array_test.cmj js_typed_array_test.js)
+    (targets js_typed_array_test.cmi js_typed_array_test.cmj js_typed_array_test.cmt js_typed_array_test.js)
     (deps (:inputs js_typed_array_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5213,7 +5213,7 @@
 
 
   (rule
-    (targets js_undefined_test.cmi js_undefined_test.cmj js_undefined_test.js)
+    (targets js_undefined_test.cmi js_undefined_test.cmj js_undefined_test.cmt js_undefined_test.js)
     (deps (:inputs js_undefined_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5226,7 +5226,7 @@
 
 
   (rule
-    (targets js_val.cmi js_val.cmj js_val.js)
+    (targets js_val.cmi js_val.cmj js_val.cmt js_val.js)
     (deps (:inputs js_val.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5239,7 +5239,7 @@
 
 
   (rule
-    (targets jsoo_400_test.cmi jsoo_400_test.cmj jsoo_400_test.js)
+    (targets jsoo_400_test.cmi jsoo_400_test.cmj jsoo_400_test.cmt jsoo_400_test.js)
     (deps (:inputs jsoo_400_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5252,7 +5252,7 @@
 
 
   (rule
-    (targets jsoo_485_test.cmi jsoo_485_test.cmj jsoo_485_test.js)
+    (targets jsoo_485_test.cmi jsoo_485_test.cmj jsoo_485_test.cmt jsoo_485_test.js)
     (deps (:inputs jsoo_485_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5265,7 +5265,7 @@
 
 
   (rule
-    (targets key_word_property.cmi key_word_property.cmj key_word_property.js)
+    (targets key_word_property.cmi key_word_property.cmj key_word_property.cmt key_word_property.js)
     (deps (:inputs key_word_property.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5278,7 +5278,7 @@
 
 
   (rule
-    (targets key_word_property2.cmi key_word_property2.cmj key_word_property2.js)
+    (targets key_word_property2.cmi key_word_property2.cmj key_word_property2.cmt key_word_property2.js)
     (deps (:inputs key_word_property2.ml) ../stdlib-412/stdlib.cmj export_keyword.cmj)
 
   (mode
@@ -5291,7 +5291,7 @@
 
 
   (rule
-    (targets key_word_property_plus_test.cmi key_word_property_plus_test.cmj key_word_property_plus_test.js)
+    (targets key_word_property_plus_test.cmi key_word_property_plus_test.cmj key_word_property_plus_test.cmt key_word_property_plus_test.js)
     (deps (:inputs key_word_property_plus_test.ml) ../stdlib-412/stdlib.cmj global_mangles.cmj mt.cmj)
 
   (mode
@@ -5304,7 +5304,7 @@
 
 
   (rule
-    (targets label_uncurry.cmi label_uncurry.cmj label_uncurry.js)
+    (targets label_uncurry.cmi label_uncurry.cmj label_uncurry.cmt label_uncurry.js)
     (deps (:inputs label_uncurry.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5317,7 +5317,7 @@
 
 
   (rule
-    (targets large_integer_pat.cmi large_integer_pat.cmj large_integer_pat.js)
+    (targets large_integer_pat.cmi large_integer_pat.cmj large_integer_pat.cmt large_integer_pat.js)
     (deps (:inputs large_integer_pat.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5330,7 +5330,7 @@
 
 
   (rule
-    (targets large_obj_test.cmi large_obj_test.cmj large_obj_test.js)
+    (targets large_obj_test.cmi large_obj_test.cmj large_obj_test.cmt large_obj_test.js)
     (deps (:inputs large_obj_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5343,7 +5343,7 @@
 
 
   (rule
-    (targets large_record_duplication_test.cmi large_record_duplication_test.cmj large_record_duplication_test.js)
+    (targets large_record_duplication_test.cmi large_record_duplication_test.cmj large_record_duplication_test.cmt large_record_duplication_test.js)
     (deps (:inputs large_record_duplication_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5356,7 +5356,7 @@
 
 
   (rule
-    (targets largest_int_flow.cmi largest_int_flow.cmj largest_int_flow.js)
+    (targets largest_int_flow.cmi largest_int_flow.cmj largest_int_flow.cmt largest_int_flow.js)
     (deps (:inputs largest_int_flow.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5369,7 +5369,7 @@
 
 
   (rule
-    (targets lazy_demo.cmi lazy_demo.cmj lazy_demo.js)
+    (targets lazy_demo.cmi lazy_demo.cmj lazy_demo.cmt lazy_demo.js)
     (deps (:inputs lazy_demo.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5382,7 +5382,7 @@
 
 
   (rule
-    (targets lazy_test.cmi lazy_test.cmj lazy_test.js)
+    (targets lazy_test.cmi lazy_test.cmj lazy_test.cmt lazy_test.js)
     (deps (:inputs lazy_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5395,7 +5395,7 @@
 
 
   (rule
-    (targets lexer_test.cmi lexer_test.cmj lexer_test.js)
+    (targets lexer_test.cmi lexer_test.cmj lexer_test.cmt lexer_test.js)
     (deps (:inputs lexer_test.ml) ../stdlib-412/stdlib.cmj arith_lexer.cmj arith_parser.cmj arith_syntax.cmj mt.cmj number_lexer.cmj)
 
   (mode
@@ -5408,7 +5408,7 @@
 
 
   (rule
-    (targets lib_js_test.cmi lib_js_test.cmj lib_js_test.js)
+    (targets lib_js_test.cmi lib_js_test.cmj lib_js_test.cmt lib_js_test.js)
     (deps (:inputs lib_js_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5421,7 +5421,7 @@
 
 
   (rule
-    (targets libarg_test.cmi libarg_test.cmj libarg_test.js)
+    (targets libarg_test.cmi libarg_test.cmj libarg_test.cmt libarg_test.js)
     (deps (:inputs libarg_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5434,7 +5434,7 @@
 
 
   (rule
-    (targets libqueue_test.cmi libqueue_test.cmj libqueue_test.js)
+    (targets libqueue_test.cmi libqueue_test.cmj libqueue_test.cmt libqueue_test.js)
     (deps (:inputs libqueue_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5447,7 +5447,7 @@
 
 
   (rule
-    (targets limits_test.cmi limits_test.cmj limits_test.js)
+    (targets limits_test.cmi limits_test.cmj limits_test.cmt limits_test.js)
     (deps (:inputs limits_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5460,7 +5460,7 @@
 
 
   (rule
-    (targets list_stack.cmi list_stack.cmj list_stack.js)
+    (targets list_stack.cmi list_stack.cmj list_stack.cmt list_stack.js)
     (deps (:inputs list_stack.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5473,7 +5473,7 @@
 
 
   (rule
-    (targets list_test.cmi list_test.cmj list_test.js)
+    (targets list_test.cmi list_test.cmj list_test.cmt list_test.js)
     (deps (:inputs list_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5486,7 +5486,7 @@
 
 
   (rule
-    (targets local_class_type.cmi local_class_type.cmj local_class_type.js)
+    (targets local_class_type.cmi local_class_type.cmj local_class_type.cmt local_class_type.js)
     (deps (:inputs local_class_type.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5499,7 +5499,7 @@
 
 
   (rule
-    (targets local_exception_test.cmi local_exception_test.cmj local_exception_test.js)
+    (targets local_exception_test.cmi local_exception_test.cmj local_exception_test.cmt local_exception_test.js)
     (deps (:inputs local_exception_test.ml) ../stdlib-412/stdlib.cmj a.cmj b.cmj)
 
   (mode
@@ -5512,7 +5512,7 @@
 
 
   (rule
-    (targets loop_regression_test.cmi loop_regression_test.cmj loop_regression_test.js)
+    (targets loop_regression_test.cmi loop_regression_test.cmj loop_regression_test.cmt loop_regression_test.js)
     (deps (:inputs loop_regression_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5525,7 +5525,7 @@
 
 
   (rule
-    (targets loop_suites_test.cmi loop_suites_test.cmj loop_suites_test.js)
+    (targets loop_suites_test.cmi loop_suites_test.cmj loop_suites_test.cmt loop_suites_test.js)
     (deps (:inputs loop_suites_test.ml) ../stdlib-412/stdlib.cmj for_loop_test.cmj mt.cmj)
 
   (mode
@@ -5538,7 +5538,7 @@
 
 
   (rule
-    (targets map_find_test.cmi map_find_test.cmj map_find_test.js)
+    (targets map_find_test.cmi map_find_test.cmj map_find_test.cmt map_find_test.js)
     (deps (:inputs map_find_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5551,7 +5551,7 @@
 
 
   (rule
-    (targets map_test.cmj map_test.js)
+    (targets map_test.cmj map_test.cmt map_test.js)
     (deps (:inputs map_test.ml) ../stdlib-412/stdlib.cmj map_test.cmi mt.cmj)
 
   (mode
@@ -5564,7 +5564,7 @@
 
 
   (rule
-    (targets map_test.cmi )
+    (targets map_test.cmi map_test.cmti )
     (deps (:inputs map_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5577,7 +5577,7 @@
 
 
   (rule
-    (targets mario_game.cmi mario_game.cmj mario_game.js)
+    (targets mario_game.cmi mario_game.cmj  mario_game.js)
     (deps (:inputs mario_game.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5590,7 +5590,7 @@
 
 
   (rule
-    (targets mel_267_test.cmi mel_267_test.cmj mel_267_test.js)
+    (targets mel_267_test.cmi mel_267_test.cmj mel_267_test.cmt mel_267_test.js)
     (deps (:inputs mel_267_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5603,7 +5603,7 @@
 
 
   (rule
-    (targets method_chain.cmi method_chain.cmj method_chain.js)
+    (targets method_chain.cmi method_chain.cmj method_chain.cmt method_chain.js)
     (deps (:inputs method_chain.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5616,7 +5616,7 @@
 
 
   (rule
-    (targets method_name_test.cmi method_name_test.cmj method_name_test.js)
+    (targets method_name_test.cmi method_name_test.cmj method_name_test.cmt method_name_test.js)
     (deps (:inputs method_name_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5629,7 +5629,7 @@
 
 
   (rule
-    (targets method_string_name.cmi method_string_name.cmj method_string_name.js)
+    (targets method_string_name.cmi method_string_name.cmj method_string_name.cmt method_string_name.js)
     (deps (:inputs method_string_name.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5642,7 +5642,7 @@
 
 
   (rule
-    (targets minimal_test.cmi minimal_test.cmj minimal_test.js)
+    (targets minimal_test.cmi minimal_test.cmj minimal_test.cmt minimal_test.js)
     (deps (:inputs minimal_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5655,7 +5655,7 @@
 
 
   (rule
-    (targets miss_colon_test.cmi miss_colon_test.cmj miss_colon_test.js)
+    (targets miss_colon_test.cmi miss_colon_test.cmj miss_colon_test.cmt miss_colon_test.js)
     (deps (:inputs miss_colon_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5668,7 +5668,7 @@
 
 
   (rule
-    (targets mock_mt.cmi mock_mt.cmj mock_mt.js)
+    (targets mock_mt.cmi mock_mt.cmj mock_mt.cmt mock_mt.js)
     (deps (:inputs mock_mt.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5681,7 +5681,7 @@
 
 
   (rule
-    (targets module_alias_test.cmi module_alias_test.cmj module_alias_test.js)
+    (targets module_alias_test.cmi module_alias_test.cmj module_alias_test.cmt module_alias_test.js)
     (deps (:inputs module_alias_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5694,7 +5694,7 @@
 
 
   (rule
-    (targets module_as_class_ffi.cmi module_as_class_ffi.cmj module_as_class_ffi.js)
+    (targets module_as_class_ffi.cmi module_as_class_ffi.cmj module_as_class_ffi.cmt module_as_class_ffi.js)
     (deps (:inputs module_as_class_ffi.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5707,7 +5707,7 @@
 
 
   (rule
-    (targets module_as_function.cmi module_as_function.cmj module_as_function.js)
+    (targets module_as_function.cmi module_as_function.cmj module_as_function.cmt module_as_function.js)
     (deps (:inputs module_as_function.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5720,7 +5720,7 @@
 
 
   (rule
-    (targets module_equality_stdlib_test.cmi module_equality_stdlib_test.cmj module_equality_stdlib_test.js)
+    (targets module_equality_stdlib_test.cmi module_equality_stdlib_test.cmj module_equality_stdlib_test.cmt module_equality_stdlib_test.js)
     (deps (:inputs module_equality_stdlib_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5733,7 +5733,7 @@
 
 
   (rule
-    (targets module_missing_conversion.cmi module_missing_conversion.cmj module_missing_conversion.js)
+    (targets module_missing_conversion.cmi module_missing_conversion.cmj module_missing_conversion.cmt module_missing_conversion.js)
     (deps (:inputs module_missing_conversion.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5746,7 +5746,7 @@
 
 
   (rule
-    (targets module_parameter_test.cmi module_parameter_test.cmj module_parameter_test.js)
+    (targets module_parameter_test.cmi module_parameter_test.cmj module_parameter_test.cmt module_parameter_test.js)
     (deps (:inputs module_parameter_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5759,7 +5759,7 @@
 
 
   (rule
-    (targets module_splice_test.cmi module_splice_test.cmj module_splice_test.js)
+    (targets module_splice_test.cmi module_splice_test.cmj module_splice_test.cmt module_splice_test.js)
     (deps (:inputs module_splice_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5772,7 +5772,7 @@
 
 
   (rule
-    (targets more_poly_variant_test.cmi more_poly_variant_test.cmj more_poly_variant_test.js)
+    (targets more_poly_variant_test.cmi more_poly_variant_test.cmj more_poly_variant_test.cmt more_poly_variant_test.js)
     (deps (:inputs more_poly_variant_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5785,7 +5785,7 @@
 
 
   (rule
-    (targets more_uncurry.cmi more_uncurry.cmj more_uncurry.js)
+    (targets more_uncurry.cmi more_uncurry.cmj more_uncurry.cmt more_uncurry.js)
     (deps (:inputs more_uncurry.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5798,7 +5798,7 @@
 
 
   (rule
-    (targets mpr_6033_test.cmi mpr_6033_test.cmj mpr_6033_test.js)
+    (targets mpr_6033_test.cmi mpr_6033_test.cmj mpr_6033_test.cmt mpr_6033_test.js)
     (deps (:inputs mpr_6033_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5811,7 +5811,7 @@
 
 
   (rule
-    (targets mt.cmj mt.js)
+    (targets mt.cmj mt.cmt mt.js)
     (deps (:inputs mt.ml) ../stdlib-412/stdlib.cmj mt.cmi)
 
   (mode
@@ -5824,7 +5824,7 @@
 
 
   (rule
-    (targets mt.cmi )
+    (targets mt.cmi mt.cmti )
     (deps (:inputs mt.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5837,7 +5837,7 @@
 
 
   (rule
-    (targets mt_global.cmj mt_global.js)
+    (targets mt_global.cmj mt_global.cmt mt_global.js)
     (deps (:inputs mt_global.ml) ../stdlib-412/stdlib.cmj mt.cmj mt_global.cmi)
 
   (mode
@@ -5850,7 +5850,7 @@
 
 
   (rule
-    (targets mt_global.cmi )
+    (targets mt_global.cmi mt_global.cmti )
     (deps (:inputs mt_global.mli) ../stdlib-412/stdlib.cmj mt.cmi)
 
   (mode
@@ -5863,7 +5863,7 @@
 
 
   (rule
-    (targets mutable_obj_test.cmi mutable_obj_test.cmj mutable_obj_test.js)
+    (targets mutable_obj_test.cmi mutable_obj_test.cmj mutable_obj_test.cmt mutable_obj_test.js)
     (deps (:inputs mutable_obj_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5876,7 +5876,7 @@
 
 
   (rule
-    (targets mutable_uncurry_test.cmi mutable_uncurry_test.cmj mutable_uncurry_test.js)
+    (targets mutable_uncurry_test.cmi mutable_uncurry_test.cmj mutable_uncurry_test.cmt mutable_uncurry_test.js)
     (deps (:inputs mutable_uncurry_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5889,7 +5889,7 @@
 
 
   (rule
-    (targets mutual_non_recursive_type.cmi mutual_non_recursive_type.cmj mutual_non_recursive_type.js)
+    (targets mutual_non_recursive_type.cmi mutual_non_recursive_type.cmj mutual_non_recursive_type.cmt mutual_non_recursive_type.js)
     (deps (:inputs mutual_non_recursive_type.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5902,7 +5902,7 @@
 
 
   (rule
-    (targets name_mangle_test.cmi name_mangle_test.cmj name_mangle_test.js)
+    (targets name_mangle_test.cmi name_mangle_test.cmj name_mangle_test.cmt name_mangle_test.js)
     (deps (:inputs name_mangle_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -5915,7 +5915,7 @@
 
 
   (rule
-    (targets nativeint.cmi nativeint.cmj nativeint.js)
+    (targets nativeint.cmi nativeint.cmj nativeint.cmt nativeint.js)
     (deps (:inputs nativeint.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5928,7 +5928,7 @@
 
 
   (rule
-    (targets nested_include.cmi nested_include.cmj nested_include.js)
+    (targets nested_include.cmi nested_include.cmj nested_include.cmt nested_include.js)
     (deps (:inputs nested_include.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5941,7 +5941,7 @@
 
 
   (rule
-    (targets nested_module_alias.cmi nested_module_alias.cmj nested_module_alias.js)
+    (targets nested_module_alias.cmi nested_module_alias.cmj nested_module_alias.cmt nested_module_alias.js)
     (deps (:inputs nested_module_alias.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5954,7 +5954,7 @@
 
 
   (rule
-    (targets nested_obj_literal.cmi nested_obj_literal.cmj nested_obj_literal.js)
+    (targets nested_obj_literal.cmi nested_obj_literal.cmj nested_obj_literal.cmt nested_obj_literal.js)
     (deps (:inputs nested_obj_literal.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5967,7 +5967,7 @@
 
 
   (rule
-    (targets nested_obj_test.cmi nested_obj_test.cmj nested_obj_test.js)
+    (targets nested_obj_test.cmi nested_obj_test.cmj nested_obj_test.cmt nested_obj_test.js)
     (deps (:inputs nested_obj_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5980,7 +5980,7 @@
 
 
   (rule
-    (targets nested_pattern_match_test.cmi nested_pattern_match_test.cmj nested_pattern_match_test.js)
+    (targets nested_pattern_match_test.cmi nested_pattern_match_test.cmj nested_pattern_match_test.cmt nested_pattern_match_test.js)
     (deps (:inputs nested_pattern_match_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -5993,7 +5993,7 @@
 
 
   (rule
-    (targets noassert.cmi noassert.cmj noassert.js)
+    (targets noassert.cmi noassert.cmj noassert.cmt noassert.js)
     (deps (:inputs noassert.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6006,7 +6006,7 @@
 
 
   (rule
-    (targets node_fs_test.cmi node_fs_test.cmj node_fs_test.js)
+    (targets node_fs_test.cmi node_fs_test.cmj node_fs_test.cmt node_fs_test.js)
     (deps (:inputs node_fs_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6019,7 +6019,7 @@
 
 
   (rule
-    (targets node_path_test.cmi node_path_test.cmj node_path_test.js)
+    (targets node_path_test.cmi node_path_test.cmj node_path_test.cmt node_path_test.js)
     (deps (:inputs node_path_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6032,7 +6032,7 @@
 
 
   (rule
-    (targets null_list_test.cmi null_list_test.cmj null_list_test.js)
+    (targets null_list_test.cmi null_list_test.cmj null_list_test.cmt null_list_test.js)
     (deps (:inputs null_list_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6045,7 +6045,7 @@
 
 
   (rule
-    (targets number_lexer.cmi number_lexer.cmj number_lexer.js)
+    (targets number_lexer.cmi number_lexer.cmj number_lexer.cmt number_lexer.js)
     (deps (:inputs number_lexer.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6058,7 +6058,7 @@
 
 
   (rule
-    (targets obj_curry_test.cmi obj_curry_test.cmj obj_curry_test.js)
+    (targets obj_curry_test.cmi obj_curry_test.cmj obj_curry_test.cmt obj_curry_test.js)
     (deps (:inputs obj_curry_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6071,7 +6071,7 @@
 
 
   (rule
-    (targets obj_literal_ppx.cmi obj_literal_ppx.cmj obj_literal_ppx.js)
+    (targets obj_literal_ppx.cmi obj_literal_ppx.cmj obj_literal_ppx.cmt obj_literal_ppx.js)
     (deps (:inputs obj_literal_ppx.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6084,7 +6084,7 @@
 
 
   (rule
-    (targets obj_literal_ppx_test.cmi obj_literal_ppx_test.cmj obj_literal_ppx_test.js)
+    (targets obj_literal_ppx_test.cmi obj_literal_ppx_test.cmj obj_literal_ppx_test.cmt obj_literal_ppx_test.js)
     (deps (:inputs obj_literal_ppx_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6097,7 +6097,7 @@
 
 
   (rule
-    (targets obj_magic_test.cmi obj_magic_test.cmj obj_magic_test.js)
+    (targets obj_magic_test.cmi obj_magic_test.cmj obj_magic_test.cmt obj_magic_test.js)
     (deps (:inputs obj_magic_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6110,7 +6110,7 @@
 
 
   (rule
-    (targets obj_repr_test.cmi obj_repr_test.cmj obj_repr_test.js)
+    (targets obj_repr_test.cmi obj_repr_test.cmj obj_repr_test.cmt obj_repr_test.js)
     (deps (:inputs obj_repr_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6123,7 +6123,7 @@
 
 
   (rule
-    (targets obj_test.cmi obj_test.cmj obj_test.js)
+    (targets obj_test.cmi obj_test.cmj obj_test.cmt obj_test.js)
     (deps (:inputs obj_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6136,7 +6136,7 @@
 
 
   (rule
-    (targets obj_type_test.cmi obj_type_test.cmj obj_type_test.js)
+    (targets obj_type_test.cmi obj_type_test.cmj obj_type_test.cmt obj_type_test.js)
     (deps (:inputs obj_type_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6149,7 +6149,7 @@
 
 
   (rule
-    (targets ocaml_414_upgrade_test.cmi ocaml_414_upgrade_test.cmj ocaml_414_upgrade_test.js)
+    (targets ocaml_414_upgrade_test.cmi ocaml_414_upgrade_test.cmj ocaml_414_upgrade_test.cmt ocaml_414_upgrade_test.js)
     (deps (:inputs ocaml_414_upgrade_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6162,7 +6162,7 @@
 
 
   (rule
-    (targets ocaml_parsetree_test.cmj ocaml_parsetree_test.js)
+    (targets ocaml_parsetree_test.cmj  ocaml_parsetree_test.js)
     (deps (:inputs ocaml_parsetree_test.ml) ../stdlib-412/stdlib.cmj nativeint.cmj ocaml_parsetree_test.cmi)
 
   (mode
@@ -6175,7 +6175,7 @@
 
 
   (rule
-    (targets ocaml_parsetree_test.cmi )
+    (targets ocaml_parsetree_test.cmi  )
     (deps (:inputs ocaml_parsetree_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6188,7 +6188,7 @@
 
 
   (rule
-    (targets ocaml_proto_test.cmj ocaml_proto_test.js)
+    (targets ocaml_proto_test.cmj  ocaml_proto_test.js)
     (deps (:inputs ocaml_proto_test.ml) ../stdlib-412/stdlib.cmj mt.cmj ocaml_proto_test.cmi)
 
   (mode
@@ -6201,7 +6201,7 @@
 
 
   (rule
-    (targets ocaml_proto_test.cmi )
+    (targets ocaml_proto_test.cmi  )
     (deps (:inputs ocaml_proto_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6214,7 +6214,7 @@
 
 
   (rule
-    (targets ocaml_re_test.cmi ocaml_re_test.cmj ocaml_re_test.js)
+    (targets ocaml_re_test.cmi ocaml_re_test.cmj  ocaml_re_test.js)
     (deps (:inputs ocaml_re_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6227,7 +6227,7 @@
 
 
   (rule
-    (targets ocaml_typedtree_test.cmj ocaml_typedtree_test.js)
+    (targets ocaml_typedtree_test.cmj  ocaml_typedtree_test.js)
     (deps (:inputs ocaml_typedtree_test.ml) ../stdlib-412/stdlib.cmj arity.cmj mt.cmj nativeint.cmj ocaml_typedtree_test.cmi)
 
   (mode
@@ -6240,7 +6240,7 @@
 
 
   (rule
-    (targets ocaml_typedtree_test.cmi )
+    (targets ocaml_typedtree_test.cmi  )
     (deps (:inputs ocaml_typedtree_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6253,7 +6253,7 @@
 
 
   (rule
-    (targets of_string_test.cmi of_string_test.cmj of_string_test.js)
+    (targets of_string_test.cmi of_string_test.cmj of_string_test.cmt of_string_test.js)
     (deps (:inputs of_string_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6266,7 +6266,7 @@
 
 
   (rule
-    (targets offset.cmi offset.cmj offset.js)
+    (targets offset.cmi offset.cmj offset.cmt offset.js)
     (deps (:inputs offset.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6279,7 +6279,7 @@
 
 
   (rule
-    (targets oo_js_test_date.cmi oo_js_test_date.cmj oo_js_test_date.js)
+    (targets oo_js_test_date.cmi oo_js_test_date.cmj oo_js_test_date.cmt oo_js_test_date.js)
     (deps (:inputs oo_js_test_date.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6292,7 +6292,7 @@
 
 
   (rule
-    (targets opr_3576_test.cmi opr_3576_test.cmj opr_3576_test.js)
+    (targets opr_3576_test.cmi opr_3576_test.cmj opr_3576_test.cmt opr_3576_test.js)
     (deps (:inputs opr_3576_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6305,7 +6305,7 @@
 
 
   (rule
-    (targets opr_4560_test.cmi opr_4560_test.cmj opr_4560_test.js)
+    (targets opr_4560_test.cmi opr_4560_test.cmj opr_4560_test.cmt opr_4560_test.js)
     (deps (:inputs opr_4560_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6318,7 +6318,7 @@
 
 
   (rule
-    (targets option_encoding_test.cmi option_encoding_test.cmj option_encoding_test.js)
+    (targets option_encoding_test.cmi option_encoding_test.cmj option_encoding_test.cmt option_encoding_test.js)
     (deps (:inputs option_encoding_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6331,7 +6331,7 @@
 
 
   (rule
-    (targets option_repr_test.cmi option_repr_test.cmj option_repr_test.js)
+    (targets option_repr_test.cmi option_repr_test.cmj option_repr_test.cmt option_repr_test.js)
     (deps (:inputs option_repr_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6344,7 +6344,7 @@
 
 
   (rule
-    (targets optional_ffi_test.cmi optional_ffi_test.cmj optional_ffi_test.js)
+    (targets optional_ffi_test.cmi optional_ffi_test.cmj optional_ffi_test.cmt optional_ffi_test.js)
     (deps (:inputs optional_ffi_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6357,7 +6357,7 @@
 
 
   (rule
-    (targets optional_regression_test.cmi optional_regression_test.cmj optional_regression_test.js)
+    (targets optional_regression_test.cmi optional_regression_test.cmj optional_regression_test.cmt optional_regression_test.js)
     (deps (:inputs optional_regression_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6370,7 +6370,7 @@
 
 
   (rule
-    (targets parser_api.cmi parser_api.cmj parser_api.js)
+    (targets parser_api.cmi parser_api.cmj  parser_api.js)
     (deps (:inputs parser_api.ml) ../stdlib-412/stdlib.cmj nativeint.cmj)
 
   (mode
@@ -6383,7 +6383,7 @@
 
 
   (rule
-    (targets parser_api_test.cmi parser_api_test.cmj parser_api_test.js)
+    (targets parser_api_test.cmi parser_api_test.cmj parser_api_test.cmt parser_api_test.js)
     (deps (:inputs parser_api_test.ml) ../stdlib-412/stdlib.cmj mt.cmj parser_api.cmj)
 
   (mode
@@ -6396,7 +6396,7 @@
 
 
   (rule
-    (targets pipe_send_readline.cmi pipe_send_readline.cmj pipe_send_readline.js)
+    (targets pipe_send_readline.cmi pipe_send_readline.cmj pipe_send_readline.cmt pipe_send_readline.js)
     (deps (:inputs pipe_send_readline.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6409,7 +6409,7 @@
 
 
   (rule
-    (targets pipe_syntax.cmi pipe_syntax.cmj pipe_syntax.js)
+    (targets pipe_syntax.cmi pipe_syntax.cmj pipe_syntax.cmt pipe_syntax.js)
     (deps (:inputs pipe_syntax.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6422,7 +6422,7 @@
 
 
   (rule
-    (targets poly_empty_array.cmi poly_empty_array.cmj poly_empty_array.js)
+    (targets poly_empty_array.cmi poly_empty_array.cmj poly_empty_array.cmt poly_empty_array.js)
     (deps (:inputs poly_empty_array.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6435,7 +6435,7 @@
 
 
   (rule
-    (targets poly_type.cmi poly_type.cmj poly_type.js)
+    (targets poly_type.cmi poly_type.cmj poly_type.cmt poly_type.js)
     (deps (:inputs poly_type.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6448,7 +6448,7 @@
 
 
   (rule
-    (targets poly_variant_test.cmj poly_variant_test.js)
+    (targets poly_variant_test.cmj poly_variant_test.cmt poly_variant_test.js)
     (deps (:inputs poly_variant_test.ml) ../stdlib-412/stdlib.cmj mt.cmj poly_variant_test.cmi)
 
   (mode
@@ -6461,7 +6461,7 @@
 
 
   (rule
-    (targets poly_variant_test.cmi )
+    (targets poly_variant_test.cmi poly_variant_test.cmti )
     (deps (:inputs poly_variant_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6474,7 +6474,7 @@
 
 
   (rule
-    (targets polymorphic_raw_test.cmi polymorphic_raw_test.cmj polymorphic_raw_test.js)
+    (targets polymorphic_raw_test.cmi polymorphic_raw_test.cmj polymorphic_raw_test.cmt polymorphic_raw_test.js)
     (deps (:inputs polymorphic_raw_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6487,7 +6487,7 @@
 
 
   (rule
-    (targets polymorphism_test.cmj polymorphism_test.js)
+    (targets polymorphism_test.cmj polymorphism_test.cmt polymorphism_test.js)
     (deps (:inputs polymorphism_test.ml) ../stdlib-412/stdlib.cmj polymorphism_test.cmi)
 
   (mode
@@ -6500,7 +6500,7 @@
 
 
   (rule
-    (targets polymorphism_test.cmi )
+    (targets polymorphism_test.cmi polymorphism_test.cmti )
     (deps (:inputs polymorphism_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6513,7 +6513,7 @@
 
 
   (rule
-    (targets polyvar_convert.cmi polyvar_convert.cmj polyvar_convert.js)
+    (targets polyvar_convert.cmi polyvar_convert.cmj polyvar_convert.cmt polyvar_convert.js)
     (deps (:inputs polyvar_convert.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6526,7 +6526,7 @@
 
 
   (rule
-    (targets polyvar_test.cmi polyvar_test.cmj polyvar_test.js)
+    (targets polyvar_test.cmi polyvar_test.cmj polyvar_test.cmt polyvar_test.js)
     (deps (:inputs polyvar_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6539,7 +6539,7 @@
 
 
   (rule
-    (targets ppx_apply_test.cmi ppx_apply_test.cmj ppx_apply_test.js)
+    (targets ppx_apply_test.cmi ppx_apply_test.cmj ppx_apply_test.cmt ppx_apply_test.js)
     (deps (:inputs ppx_apply_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6552,7 +6552,7 @@
 
 
   (rule
-    (targets ppx_this_obj_field.cmi ppx_this_obj_field.cmj ppx_this_obj_field.js)
+    (targets ppx_this_obj_field.cmi ppx_this_obj_field.cmj ppx_this_obj_field.cmt ppx_this_obj_field.js)
     (deps (:inputs ppx_this_obj_field.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6565,7 +6565,7 @@
 
 
   (rule
-    (targets ppx_this_obj_test.cmi ppx_this_obj_test.cmj ppx_this_obj_test.js)
+    (targets ppx_this_obj_test.cmi ppx_this_obj_test.cmj ppx_this_obj_test.cmt ppx_this_obj_test.js)
     (deps (:inputs ppx_this_obj_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6578,7 +6578,7 @@
 
 
   (rule
-    (targets pq_test.cmi pq_test.cmj pq_test.js)
+    (targets pq_test.cmi pq_test.cmj pq_test.cmt pq_test.js)
     (deps (:inputs pq_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6591,7 +6591,7 @@
 
 
   (rule
-    (targets pr6726.cmi pr6726.cmj pr6726.js)
+    (targets pr6726.cmi pr6726.cmj pr6726.cmt pr6726.js)
     (deps (:inputs pr6726.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6604,7 +6604,7 @@
 
 
   (rule
-    (targets pr_regression_test.cmi pr_regression_test.cmj pr_regression_test.js)
+    (targets pr_regression_test.cmi pr_regression_test.cmj pr_regression_test.cmt pr_regression_test.js)
     (deps (:inputs pr_regression_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6617,7 +6617,7 @@
 
 
   (rule
-    (targets prepend_data_ffi.cmi prepend_data_ffi.cmj prepend_data_ffi.js)
+    (targets prepend_data_ffi.cmi prepend_data_ffi.cmj prepend_data_ffi.cmt prepend_data_ffi.js)
     (deps (:inputs prepend_data_ffi.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6630,7 +6630,7 @@
 
 
   (rule
-    (targets primitive_reg_test.cmi primitive_reg_test.cmj primitive_reg_test.js)
+    (targets primitive_reg_test.cmi primitive_reg_test.cmj primitive_reg_test.cmt primitive_reg_test.js)
     (deps (:inputs primitive_reg_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6643,7 +6643,7 @@
 
 
   (rule
-    (targets print_alpha_test.cmi print_alpha_test.cmj print_alpha_test.js)
+    (targets print_alpha_test.cmi print_alpha_test.cmj print_alpha_test.cmt print_alpha_test.js)
     (deps (:inputs print_alpha_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6656,7 +6656,7 @@
 
 
   (rule
-    (targets printf_sim.cmi printf_sim.cmj printf_sim.js)
+    (targets printf_sim.cmi printf_sim.cmj printf_sim.cmt printf_sim.js)
     (deps (:inputs printf_sim.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6669,7 +6669,7 @@
 
 
   (rule
-    (targets printf_test.cmi printf_test.cmj printf_test.js)
+    (targets printf_test.cmi printf_test.cmj printf_test.cmt printf_test.js)
     (deps (:inputs printf_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6682,7 +6682,7 @@
 
 
   (rule
-    (targets promise.cmi promise.cmj promise.js)
+    (targets promise.cmi promise.cmj promise.cmt promise.js)
     (deps (:inputs promise.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6695,7 +6695,7 @@
 
 
   (rule
-    (targets promise_catch_test.cmi promise_catch_test.cmj promise_catch_test.js)
+    (targets promise_catch_test.cmi promise_catch_test.cmj promise_catch_test.cmt promise_catch_test.js)
     (deps (:inputs promise_catch_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6708,7 +6708,7 @@
 
 
   (rule
-    (targets qcc.cmi qcc.cmj qcc.js)
+    (targets qcc.cmi qcc.cmj qcc.cmt qcc.js)
     (deps (:inputs qcc.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6721,7 +6721,7 @@
 
 
   (rule
-    (targets queue_test.cmi queue_test.cmj queue_test.js)
+    (targets queue_test.cmi queue_test.cmj queue_test.cmt queue_test.js)
     (deps (:inputs queue_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -6734,7 +6734,7 @@
 
 
   (rule
-    (targets random_test.cmi random_test.cmj random_test.js)
+    (targets random_test.cmi random_test.cmj random_test.cmt random_test.js)
     (deps (:inputs random_test.ml) ../stdlib-412/stdlib.cmj mt.cmj mt_global.cmj)
 
   (mode
@@ -6747,7 +6747,7 @@
 
 
   (rule
-    (targets raw_hash_tbl_bench.cmi raw_hash_tbl_bench.cmj raw_hash_tbl_bench.js)
+    (targets raw_hash_tbl_bench.cmi raw_hash_tbl_bench.cmj raw_hash_tbl_bench.cmt raw_hash_tbl_bench.js)
     (deps (:inputs raw_hash_tbl_bench.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6760,7 +6760,7 @@
 
 
   (rule
-    (targets raw_output_test.cmi raw_output_test.cmj raw_output_test.js)
+    (targets raw_output_test.cmi raw_output_test.cmj raw_output_test.cmt raw_output_test.js)
     (deps (:inputs raw_output_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6773,7 +6773,7 @@
 
 
   (rule
-    (targets raw_pure_test.cmi raw_pure_test.cmj raw_pure_test.js)
+    (targets raw_pure_test.cmi raw_pure_test.cmj raw_pure_test.cmt raw_pure_test.js)
     (deps (:inputs raw_pure_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6786,7 +6786,7 @@
 
 
   (rule
-    (targets rbset.cmi rbset.cmj rbset.js)
+    (targets rbset.cmi rbset.cmj rbset.cmt rbset.js)
     (deps (:inputs rbset.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6799,7 +6799,7 @@
 
 
   (rule
-    (targets re_first_test.cmi re_first_test.cmj re_first_test.js)
+    (targets re_first_test.cmi re_first_test.cmj re_first_test.cmt re_first_test.js)
     (deps (:inputs re_first_test.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6812,7 +6812,7 @@
 
 
   (rule
-    (targets react.cmi react.cmj react.js)
+    (targets react.cmi react.cmj react.cmt react.js)
     (deps (:inputs react.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6825,7 +6825,7 @@
 
 
   (rule
-    (targets reactDOMRe.cmi reactDOMRe.cmj reactDOMRe.js)
+    (targets reactDOMRe.cmi reactDOMRe.cmj reactDOMRe.cmt reactDOMRe.js)
     (deps (:inputs reactDOMRe.re) ../stdlib-412/stdlib.cmj react.cmj reactEvent.cmj reasonReact.cmj)
 
   (mode
@@ -6838,7 +6838,7 @@
 
 
   (rule
-    (targets reactDOMServerRe.cmi reactDOMServerRe.cmj reactDOMServerRe.js)
+    (targets reactDOMServerRe.cmi reactDOMServerRe.cmj reactDOMServerRe.cmt reactDOMServerRe.js)
     (deps (:inputs reactDOMServerRe.re) ../stdlib-412/stdlib.cmj react.cmj)
 
   (mode
@@ -6851,7 +6851,7 @@
 
 
   (rule
-    (targets reactEvent.cmj reactEvent.js)
+    (targets reactEvent.cmj reactEvent.cmt reactEvent.js)
     (deps (:inputs reactEvent.re) ../stdlib-412/stdlib.cmj reactEvent.cmi)
 
   (mode
@@ -6864,7 +6864,7 @@
 
 
   (rule
-    (targets reactEvent.cmi )
+    (targets reactEvent.cmi reactEvent.cmti )
     (deps (:inputs reactEvent.rei) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6877,7 +6877,7 @@
 
 
   (rule
-    (targets reactEventRe.cmj reactEventRe.js)
+    (targets reactEventRe.cmj reactEventRe.cmt reactEventRe.js)
     (deps (:inputs reactEventRe.re) ../stdlib-412/stdlib.cmj reactEvent.cmj reactEventRe.cmi)
 
   (mode
@@ -6890,7 +6890,7 @@
 
 
   (rule
-    (targets reactEventRe.cmi )
+    (targets reactEventRe.cmi reactEventRe.cmti )
     (deps (:inputs reactEventRe.rei) ../stdlib-412/stdlib.cmj reactEvent.cmi)
 
   (mode
@@ -6903,7 +6903,7 @@
 
 
   (rule
-    (targets reactTestUtils.cmj reactTestUtils.js)
+    (targets reactTestUtils.cmj reactTestUtils.cmt reactTestUtils.js)
     (deps (:inputs reactTestUtils.re) ../stdlib-412/stdlib.cmj react.cmj reactTestUtils.cmi)
 
   (mode
@@ -6916,7 +6916,7 @@
 
 
   (rule
-    (targets reactTestUtils.cmi )
+    (targets reactTestUtils.cmi reactTestUtils.cmti )
     (deps (:inputs reactTestUtils.rei) ../stdlib-412/stdlib.cmj react.cmi)
 
   (mode
@@ -6929,7 +6929,7 @@
 
 
   (rule
-    (targets reactjs_ppx_custom.cmi reactjs_ppx_custom.cmj reactjs_ppx_custom.js)
+    (targets reactjs_ppx_custom.cmi reactjs_ppx_custom.cmj reactjs_ppx_custom.cmt reactjs_ppx_custom.js)
     (deps (:inputs reactjs_ppx_custom.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -6942,7 +6942,7 @@
 
 
   (rule
-    (targets reasonReact.cmj reasonReact.js)
+    (targets reasonReact.cmj reasonReact.cmt reasonReact.js)
     (deps (:inputs reasonReact.re) ../stdlib-412/stdlib.cmj react.cmj reasonReact.cmi reasonReactOptimizedCreateClass.cmj reasonReactRouter.cmj)
 
   (mode
@@ -6955,7 +6955,7 @@
 
 
   (rule
-    (targets reasonReact.cmi )
+    (targets reasonReact.cmi reasonReact.cmti )
     (deps (:inputs reasonReact.rei) ../stdlib-412/stdlib.cmj react.cmi reasonReactRouter.cmi)
 
   (mode
@@ -6968,7 +6968,7 @@
 
 
   (rule
-    (targets reasonReactCompat.cmj reasonReactCompat.js)
+    (targets reasonReactCompat.cmj reasonReactCompat.cmt reasonReactCompat.js)
     (deps (:inputs reasonReactCompat.re) ../stdlib-412/stdlib.cmj react.cmj reasonReact.cmj reasonReactCompat.cmi)
 
   (mode
@@ -6981,7 +6981,7 @@
 
 
   (rule
-    (targets reasonReactCompat.cmi )
+    (targets reasonReactCompat.cmi reasonReactCompat.cmti )
     (deps (:inputs reasonReactCompat.rei) ../stdlib-412/stdlib.cmj react.cmi reasonReact.cmi)
 
   (mode
@@ -6994,7 +6994,7 @@
 
 
   (rule
-    (targets reasonReactOptimizedCreateClass.cmi reasonReactOptimizedCreateClass.cmj reasonReactOptimizedCreateClass.js)
+    (targets reasonReactOptimizedCreateClass.cmi reasonReactOptimizedCreateClass.cmj reasonReactOptimizedCreateClass.cmt reasonReactOptimizedCreateClass.js)
     (deps (:inputs reasonReactOptimizedCreateClass.re) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7007,7 +7007,7 @@
 
 
   (rule
-    (targets reasonReactRouter.cmj reasonReactRouter.js)
+    (targets reasonReactRouter.cmj reasonReactRouter.cmt reasonReactRouter.js)
     (deps (:inputs reasonReactRouter.re) ../stdlib-412/stdlib.cmj react.cmj reasonReactRouter.cmi)
 
   (mode
@@ -7020,7 +7020,7 @@
 
 
   (rule
-    (targets reasonReactRouter.cmi )
+    (targets reasonReactRouter.cmi reasonReactRouter.cmti )
     (deps (:inputs reasonReactRouter.rei) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7033,7 +7033,7 @@
 
 
   (rule
-    (targets rebind_module.cmi rebind_module.cmj rebind_module.js)
+    (targets rebind_module.cmi rebind_module.cmj rebind_module.cmt rebind_module.js)
     (deps (:inputs rebind_module.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7046,7 +7046,7 @@
 
 
   (rule
-    (targets rebind_module_test.cmi rebind_module_test.cmj rebind_module_test.js)
+    (targets rebind_module_test.cmi rebind_module_test.cmj rebind_module_test.cmt rebind_module_test.js)
     (deps (:inputs rebind_module_test.ml) ../stdlib-412/stdlib.cmj rebind_module.cmj)
 
   (mode
@@ -7059,7 +7059,7 @@
 
 
   (rule
-    (targets rec_fun_test.cmi rec_fun_test.cmj rec_fun_test.js)
+    (targets rec_fun_test.cmi rec_fun_test.cmj rec_fun_test.cmt rec_fun_test.js)
     (deps (:inputs rec_fun_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7072,7 +7072,7 @@
 
 
   (rule
-    (targets rec_module_opt.cmi rec_module_opt.cmj rec_module_opt.js)
+    (targets rec_module_opt.cmi rec_module_opt.cmj rec_module_opt.cmt rec_module_opt.js)
     (deps (:inputs rec_module_opt.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7085,7 +7085,7 @@
 
 
   (rule
-    (targets rec_module_test.cmi rec_module_test.cmj rec_module_test.js)
+    (targets rec_module_test.cmi rec_module_test.cmj rec_module_test.cmt rec_module_test.js)
     (deps (:inputs rec_module_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7098,7 +7098,7 @@
 
 
   (rule
-    (targets rec_value_test.cmi rec_value_test.cmj rec_value_test.js)
+    (targets rec_value_test.cmi rec_value_test.cmj rec_value_test.cmt rec_value_test.js)
     (deps (:inputs rec_value_test.ml) ../stdlib-412/stdlib.cmj a.cmj b.cmj mt.cmj)
 
   (mode
@@ -7111,7 +7111,7 @@
 
 
   (rule
-    (targets record_debug_test.cmi record_debug_test.cmj record_debug_test.js)
+    (targets record_debug_test.cmi record_debug_test.cmj record_debug_test.cmt record_debug_test.js)
     (deps (:inputs record_debug_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7124,7 +7124,7 @@
 
 
   (rule
-    (targets record_extension_test.cmi record_extension_test.cmj record_extension_test.js)
+    (targets record_extension_test.cmi record_extension_test.cmj record_extension_test.cmt record_extension_test.js)
     (deps (:inputs record_extension_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7137,7 +7137,7 @@
 
 
   (rule
-    (targets record_name_test.cmi record_name_test.cmj record_name_test.js)
+    (targets record_name_test.cmi record_name_test.cmj record_name_test.cmt record_name_test.js)
     (deps (:inputs record_name_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7150,7 +7150,7 @@
 
 
   (rule
-    (targets record_with_test.cmi record_with_test.cmj record_with_test.js)
+    (targets record_with_test.cmi record_with_test.cmj record_with_test.cmt record_with_test.js)
     (deps (:inputs record_with_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7163,7 +7163,7 @@
 
 
   (rule
-    (targets recursive_module.cmi recursive_module.cmj recursive_module.js)
+    (targets recursive_module.cmi recursive_module.cmj recursive_module.cmt recursive_module.js)
     (deps (:inputs recursive_module.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7176,7 +7176,7 @@
 
 
   (rule
-    (targets recursive_module_test.cmi recursive_module_test.cmj recursive_module_test.js)
+    (targets recursive_module_test.cmi recursive_module_test.cmj recursive_module_test.cmt recursive_module_test.js)
     (deps (:inputs recursive_module_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7189,7 +7189,7 @@
 
 
   (rule
-    (targets recursive_react_component.cmi recursive_react_component.cmj recursive_react_component.js)
+    (targets recursive_react_component.cmi recursive_react_component.cmj recursive_react_component.cmt recursive_react_component.js)
     (deps (:inputs recursive_react_component.re) ../stdlib-412/stdlib.cmj react.cmj)
 
   (mode
@@ -7202,7 +7202,7 @@
 
 
   (rule
-    (targets recursive_records_test.cmi recursive_records_test.cmj recursive_records_test.js)
+    (targets recursive_records_test.cmi recursive_records_test.cmj recursive_records_test.cmt recursive_records_test.js)
     (deps (:inputs recursive_records_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7215,7 +7215,7 @@
 
 
   (rule
-    (targets recursive_unbound_module_test.cmi recursive_unbound_module_test.cmj recursive_unbound_module_test.js)
+    (targets recursive_unbound_module_test.cmi recursive_unbound_module_test.cmj recursive_unbound_module_test.cmt recursive_unbound_module_test.js)
     (deps (:inputs recursive_unbound_module_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7228,7 +7228,7 @@
 
 
   (rule
-    (targets regression_print.cmi regression_print.cmj regression_print.js)
+    (targets regression_print.cmi regression_print.cmj regression_print.cmt regression_print.js)
     (deps (:inputs regression_print.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7241,7 +7241,7 @@
 
 
   (rule
-    (targets relative_path.cmi relative_path.cmj relative_path.js)
+    (targets relative_path.cmi relative_path.cmj relative_path.cmt relative_path.js)
     (deps (:inputs relative_path.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7254,7 +7254,7 @@
 
 
   (rule
-    (targets return_check.cmi return_check.cmj return_check.js)
+    (targets return_check.cmi return_check.cmj return_check.cmt return_check.js)
     (deps (:inputs return_check.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7267,7 +7267,7 @@
 
 
   (rule
-    (targets runtime_encoding_test.cmi runtime_encoding_test.cmj runtime_encoding_test.js)
+    (targets runtime_encoding_test.cmi runtime_encoding_test.cmj runtime_encoding_test.cmt runtime_encoding_test.js)
     (deps (:inputs runtime_encoding_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7280,7 +7280,7 @@
 
 
   (rule
-    (targets scanf_io.cmi scanf_io.cmj scanf_io.js)
+    (targets scanf_io.cmi scanf_io.cmj scanf_io.cmt scanf_io.js)
     (deps (:inputs scanf_io.ml) ../stdlib-412/stdlib.cmj testing.cmj)
 
   (mode
@@ -7293,7 +7293,7 @@
 
 
   (rule
-    (targets scanf_reference_error_regression_test.cmj scanf_reference_error_regression_test.js)
+    (targets scanf_reference_error_regression_test.cmj scanf_reference_error_regression_test.cmt scanf_reference_error_regression_test.js)
     (deps (:inputs scanf_reference_error_regression_test.ml) ../stdlib-412/stdlib.cmj mt.cmj mt_global.cmj scanf_reference_error_regression_test.cmi)
 
   (mode
@@ -7306,7 +7306,7 @@
 
 
   (rule
-    (targets scanf_reference_error_regression_test.cmi )
+    (targets scanf_reference_error_regression_test.cmi scanf_reference_error_regression_test.cmti )
     (deps (:inputs scanf_reference_error_regression_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7319,7 +7319,7 @@
 
 
   (rule
-    (targets scanf_test.cmi scanf_test.cmj scanf_test.js)
+    (targets scanf_test.cmi scanf_test.cmj scanf_test.cmt scanf_test.js)
     (deps (:inputs scanf_test.ml) ../stdlib-412/stdlib.cmj mt.cmj mt_global.cmj)
 
   (mode
@@ -7332,7 +7332,7 @@
 
 
   (rule
-    (targets set_gen.cmi set_gen.cmj set_gen.js)
+    (targets set_gen.cmi set_gen.cmj set_gen.cmt set_gen.js)
     (deps (:inputs set_gen.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7345,7 +7345,7 @@
 
 
   (rule
-    (targets sexp.cmj sexp.js)
+    (targets sexp.cmj sexp.cmt sexp.js)
     (deps (:inputs sexp.ml) ../stdlib-412/stdlib.cmj sexp.cmi)
 
   (mode
@@ -7358,7 +7358,7 @@
 
 
   (rule
-    (targets sexp.cmi )
+    (targets sexp.cmi sexp.cmti )
     (deps (:inputs sexp.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7371,7 +7371,7 @@
 
 
   (rule
-    (targets sexpm.cmj sexpm.js)
+    (targets sexpm.cmj sexpm.cmt sexpm.js)
     (deps (:inputs sexpm.ml) ../stdlib-412/stdlib.cmj sexpm.cmi)
 
   (mode
@@ -7384,7 +7384,7 @@
 
 
   (rule
-    (targets sexpm.cmi )
+    (targets sexpm.cmi sexpm.cmti )
     (deps (:inputs sexpm.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7397,7 +7397,7 @@
 
 
   (rule
-    (targets sexpm_test.cmi sexpm_test.cmj sexpm_test.js)
+    (targets sexpm_test.cmi sexpm_test.cmj sexpm_test.cmt sexpm_test.js)
     (deps (:inputs sexpm_test.ml) ../stdlib-412/stdlib.cmj mt.cmj sexpm.cmj)
 
   (mode
@@ -7410,7 +7410,7 @@
 
 
   (rule
-    (targets side_effect.cmi side_effect.cmj side_effect.js)
+    (targets side_effect.cmi side_effect.cmj side_effect.cmt side_effect.js)
     (deps (:inputs side_effect.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7423,7 +7423,7 @@
 
 
   (rule
-    (targets side_effect_free.cmi side_effect_free.cmj side_effect_free.js)
+    (targets side_effect_free.cmi side_effect_free.cmj side_effect_free.cmt side_effect_free.js)
     (deps (:inputs side_effect_free.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7436,7 +7436,7 @@
 
 
   (rule
-    (targets simple_derive_test.cmj simple_derive_test.js)
+    (targets simple_derive_test.cmj simple_derive_test.cmt simple_derive_test.js)
     (deps (:inputs simple_derive_test.ml) ../stdlib-412/stdlib.cmj a.cmj b.cmj simple_derive_test.cmi)
 
   (mode
@@ -7449,7 +7449,7 @@
 
 
   (rule
-    (targets simple_derive_test.cmi )
+    (targets simple_derive_test.cmi simple_derive_test.cmti )
     (deps (:inputs simple_derive_test.mli) ../stdlib-412/stdlib.cmj a.cmi b.cmi)
 
   (mode
@@ -7462,7 +7462,7 @@
 
 
   (rule
-    (targets simple_derive_use.cmj simple_derive_use.js)
+    (targets simple_derive_use.cmj simple_derive_use.cmt simple_derive_use.js)
     (deps (:inputs simple_derive_use.ml) ../stdlib-412/stdlib.cmj simple_derive_test.cmj simple_derive_use.cmi)
 
   (mode
@@ -7475,7 +7475,7 @@
 
 
   (rule
-    (targets simple_derive_use.cmi )
+    (targets simple_derive_use.cmi simple_derive_use.cmti )
     (deps (:inputs simple_derive_use.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7488,7 +7488,7 @@
 
 
   (rule
-    (targets simple_lexer_test.cmi simple_lexer_test.cmj simple_lexer_test.js)
+    (targets simple_lexer_test.cmi simple_lexer_test.cmj simple_lexer_test.cmt simple_lexer_test.js)
     (deps (:inputs simple_lexer_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7501,7 +7501,7 @@
 
 
   (rule
-    (targets simplify_lambda_632o.cmi simplify_lambda_632o.cmj simplify_lambda_632o.js)
+    (targets simplify_lambda_632o.cmi simplify_lambda_632o.cmj simplify_lambda_632o.cmt simplify_lambda_632o.js)
     (deps (:inputs simplify_lambda_632o.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7514,7 +7514,7 @@
 
 
   (rule
-    (targets single_module_alias.cmi single_module_alias.cmj single_module_alias.js)
+    (targets single_module_alias.cmi single_module_alias.cmj single_module_alias.cmt single_module_alias.js)
     (deps (:inputs single_module_alias.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7527,7 +7527,7 @@
 
 
   (rule
-    (targets singular_unit_test.cmi singular_unit_test.cmj singular_unit_test.js)
+    (targets singular_unit_test.cmi singular_unit_test.cmj singular_unit_test.cmt singular_unit_test.js)
     (deps (:inputs singular_unit_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7540,7 +7540,7 @@
 
 
   (rule
-    (targets small_inline_test.cmi small_inline_test.cmj small_inline_test.js)
+    (targets small_inline_test.cmi small_inline_test.cmj small_inline_test.cmt small_inline_test.js)
     (deps (:inputs small_inline_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7553,7 +7553,7 @@
 
 
   (rule
-    (targets splice_test.cmi splice_test.cmj splice_test.js)
+    (targets splice_test.cmi splice_test.cmj splice_test.cmt splice_test.js)
     (deps (:inputs splice_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7566,7 +7566,7 @@
 
 
   (rule
-    (targets sprintf_reg_test.cmi sprintf_reg_test.cmj sprintf_reg_test.js)
+    (targets sprintf_reg_test.cmi sprintf_reg_test.cmj sprintf_reg_test.cmt sprintf_reg_test.js)
     (deps (:inputs sprintf_reg_test.ml) ../stdlib-412/stdlib.cmj mt.cmj mt_global.cmj)
 
   (mode
@@ -7579,7 +7579,7 @@
 
 
   (rule
-    (targets stack_comp_test.cmi stack_comp_test.cmj stack_comp_test.js)
+    (targets stack_comp_test.cmi stack_comp_test.cmj stack_comp_test.cmt stack_comp_test.js)
     (deps (:inputs stack_comp_test.ml) ../stdlib-412/stdlib.cmj mt.cmj mt_global.cmj)
 
   (mode
@@ -7592,7 +7592,7 @@
 
 
   (rule
-    (targets stack_test.cmi stack_test.cmj stack_test.js)
+    (targets stack_test.cmi stack_test.cmj stack_test.cmt stack_test.js)
     (deps (:inputs stack_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7605,7 +7605,7 @@
 
 
   (rule
-    (targets stream_parser_test.cmi stream_parser_test.cmj stream_parser_test.js)
+    (targets stream_parser_test.cmi stream_parser_test.cmj stream_parser_test.cmt stream_parser_test.js)
     (deps (:inputs stream_parser_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7618,7 +7618,7 @@
 
 
   (rule
-    (targets string_bound_get_test.cmi string_bound_get_test.cmj string_bound_get_test.js)
+    (targets string_bound_get_test.cmi string_bound_get_test.cmj string_bound_get_test.cmt string_bound_get_test.js)
     (deps (:inputs string_bound_get_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7631,7 +7631,7 @@
 
 
   (rule
-    (targets string_get_set_test.cmi string_get_set_test.cmj string_get_set_test.js)
+    (targets string_get_set_test.cmi string_get_set_test.cmj string_get_set_test.cmt string_get_set_test.js)
     (deps (:inputs string_get_set_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7644,7 +7644,7 @@
 
 
   (rule
-    (targets string_interp_test.cmi string_interp_test.cmj string_interp_test.js)
+    (targets string_interp_test.cmi string_interp_test.cmj string_interp_test.cmt string_interp_test.js)
     (deps (:inputs string_interp_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7657,7 +7657,7 @@
 
 
   (rule
-    (targets string_literal_print_test.cmi string_literal_print_test.cmj string_literal_print_test.js)
+    (targets string_literal_print_test.cmi string_literal_print_test.cmj string_literal_print_test.cmt string_literal_print_test.js)
     (deps (:inputs string_literal_print_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7670,7 +7670,7 @@
 
 
   (rule
-    (targets string_runtime_test.cmi string_runtime_test.cmj string_runtime_test.js)
+    (targets string_runtime_test.cmi string_runtime_test.cmj string_runtime_test.cmt string_runtime_test.js)
     (deps (:inputs string_runtime_test.ml) ../stdlib-412/stdlib.cmj mt.cmj test_char.cmj)
 
   (mode
@@ -7683,7 +7683,7 @@
 
 
   (rule
-    (targets string_set.cmi string_set.cmj string_set.js)
+    (targets string_set.cmi string_set.cmj string_set.cmt string_set.js)
     (deps (:inputs string_set.ml) ../stdlib-412/stdlib.cmj set_gen.cmj)
 
   (mode
@@ -7696,7 +7696,7 @@
 
 
   (rule
-    (targets string_set_test.cmi string_set_test.cmj string_set_test.js)
+    (targets string_set_test.cmi string_set_test.cmj string_set_test.cmt string_set_test.js)
     (deps (:inputs string_set_test.ml) ../stdlib-412/stdlib.cmj mt.cmj string_set.cmj)
 
   (mode
@@ -7709,7 +7709,7 @@
 
 
   (rule
-    (targets string_test.cmi string_test.cmj string_test.js)
+    (targets string_test.cmi string_test.cmj string_test.cmt string_test.js)
     (deps (:inputs string_test.ml) ../stdlib-412/stdlib.cmj ext_string_test.cmj mt.cmj)
 
   (mode
@@ -7722,7 +7722,7 @@
 
 
   (rule
-    (targets string_unicode_test.cmi string_unicode_test.cmj string_unicode_test.js)
+    (targets string_unicode_test.cmi string_unicode_test.cmj string_unicode_test.cmt string_unicode_test.js)
     (deps (:inputs string_unicode_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7735,7 +7735,7 @@
 
 
   (rule
-    (targets stringmatch_test.cmi stringmatch_test.cmj stringmatch_test.js)
+    (targets stringmatch_test.cmi stringmatch_test.cmj stringmatch_test.cmt stringmatch_test.js)
     (deps (:inputs stringmatch_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7748,7 +7748,7 @@
 
 
   (rule
-    (targets submodule.cmi submodule.cmj submodule.js)
+    (targets submodule.cmi submodule.cmj submodule.cmt submodule.js)
     (deps (:inputs submodule.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7761,7 +7761,7 @@
 
 
   (rule
-    (targets submodule_call.cmi submodule_call.cmj submodule_call.js)
+    (targets submodule_call.cmi submodule_call.cmj submodule_call.cmt submodule_call.js)
     (deps (:inputs submodule_call.ml) ../stdlib-412/stdlib.cmj submodule.cmj)
 
   (mode
@@ -7774,7 +7774,7 @@
 
 
   (rule
-    (targets swap_test.cmi swap_test.cmj swap_test.js)
+    (targets swap_test.cmi swap_test.cmj swap_test.cmt swap_test.js)
     (deps (:inputs swap_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7787,7 +7787,7 @@
 
 
   (rule
-    (targets switch_case_test.cmi switch_case_test.cmj switch_case_test.js)
+    (targets switch_case_test.cmi switch_case_test.cmj switch_case_test.cmt switch_case_test.js)
     (deps (:inputs switch_case_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7800,7 +7800,7 @@
 
 
   (rule
-    (targets tailcall_inline_test.cmi tailcall_inline_test.cmj tailcall_inline_test.js)
+    (targets tailcall_inline_test.cmi tailcall_inline_test.cmj tailcall_inline_test.cmt tailcall_inline_test.js)
     (deps (:inputs tailcall_inline_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7813,7 +7813,7 @@
 
 
   (rule
-    (targets test.cmi test.cmj test.js)
+    (targets test.cmi test.cmj test.cmt test.js)
     (deps (:inputs test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7826,7 +7826,7 @@
 
 
   (rule
-    (targets test_alias.cmi test_alias.cmj test_alias.js)
+    (targets test_alias.cmi test_alias.cmj test_alias.cmt test_alias.js)
     (deps (:inputs test_alias.ml) ../stdlib-412/stdlib.cmj test_global_print.cmj)
 
   (mode
@@ -7839,7 +7839,7 @@
 
 
   (rule
-    (targets test_ari.cmi test_ari.cmj test_ari.js)
+    (targets test_ari.cmi test_ari.cmj test_ari.cmt test_ari.js)
     (deps (:inputs test_ari.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7852,7 +7852,7 @@
 
 
   (rule
-    (targets test_array.cmi test_array.cmj test_array.js)
+    (targets test_array.cmi test_array.cmj test_array.cmt test_array.js)
     (deps (:inputs test_array.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7865,7 +7865,7 @@
 
 
   (rule
-    (targets test_array_append.cmi test_array_append.cmj test_array_append.js)
+    (targets test_array_append.cmi test_array_append.cmj test_array_append.cmt test_array_append.js)
     (deps (:inputs test_array_append.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7878,7 +7878,7 @@
 
 
   (rule
-    (targets test_array_primitive.cmi test_array_primitive.cmj test_array_primitive.js)
+    (targets test_array_primitive.cmi test_array_primitive.cmj test_array_primitive.cmt test_array_primitive.js)
     (deps (:inputs test_array_primitive.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7891,7 +7891,7 @@
 
 
   (rule
-    (targets test_bool_equal.cmi test_bool_equal.cmj test_bool_equal.js)
+    (targets test_bool_equal.cmi test_bool_equal.cmj test_bool_equal.cmt test_bool_equal.js)
     (deps (:inputs test_bool_equal.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7904,7 +7904,7 @@
 
 
   (rule
-    (targets test_bs_this.cmi test_bs_this.cmj test_bs_this.js)
+    (targets test_bs_this.cmi test_bs_this.cmj test_bs_this.cmt test_bs_this.js)
     (deps (:inputs test_bs_this.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7917,7 +7917,7 @@
 
 
   (rule
-    (targets test_bug.cmi test_bug.cmj test_bug.js)
+    (targets test_bug.cmi test_bug.cmj test_bug.cmt test_bug.js)
     (deps (:inputs test_bug.ml) ../stdlib-412/stdlib.cmj test_char.cmj)
 
   (mode
@@ -7930,7 +7930,7 @@
 
 
   (rule
-    (targets test_bytes.cmi test_bytes.cmj test_bytes.js)
+    (targets test_bytes.cmi test_bytes.cmj test_bytes.cmt test_bytes.js)
     (deps (:inputs test_bytes.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7943,7 +7943,7 @@
 
 
   (rule
-    (targets test_case_opt_collision.cmi test_case_opt_collision.cmj test_case_opt_collision.js)
+    (targets test_case_opt_collision.cmi test_case_opt_collision.cmj test_case_opt_collision.cmt test_case_opt_collision.js)
     (deps (:inputs test_case_opt_collision.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -7956,7 +7956,7 @@
 
 
   (rule
-    (targets test_case_set.cmi test_case_set.cmj test_case_set.js)
+    (targets test_case_set.cmi test_case_set.cmj test_case_set.cmt test_case_set.js)
     (deps (:inputs test_case_set.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7969,7 +7969,7 @@
 
 
   (rule
-    (targets test_char.cmi test_char.cmj test_char.js)
+    (targets test_char.cmi test_char.cmj test_char.cmt test_char.js)
     (deps (:inputs test_char.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7982,7 +7982,7 @@
 
 
   (rule
-    (targets test_closure.cmi test_closure.cmj test_closure.js)
+    (targets test_closure.cmi test_closure.cmj test_closure.cmt test_closure.js)
     (deps (:inputs test_closure.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -7995,7 +7995,7 @@
 
 
   (rule
-    (targets test_common.cmi test_common.cmj test_common.js)
+    (targets test_common.cmi test_common.cmj test_common.cmt test_common.js)
     (deps (:inputs test_common.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8008,7 +8008,7 @@
 
 
   (rule
-    (targets test_const_elim.cmi test_const_elim.cmj test_const_elim.js)
+    (targets test_const_elim.cmi test_const_elim.cmj test_const_elim.cmt test_const_elim.js)
     (deps (:inputs test_const_elim.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8021,7 +8021,7 @@
 
 
   (rule
-    (targets test_const_propogate.cmi test_const_propogate.cmj test_const_propogate.js)
+    (targets test_const_propogate.cmi test_const_propogate.cmj test_const_propogate.cmt test_const_propogate.js)
     (deps (:inputs test_const_propogate.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8034,7 +8034,7 @@
 
 
   (rule
-    (targets test_cpp.cmi test_cpp.cmj test_cpp.js)
+    (targets test_cpp.cmi test_cpp.cmj test_cpp.cmt test_cpp.js)
     (deps (:inputs test_cpp.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8047,7 +8047,7 @@
 
 
   (rule
-    (targets test_cps.cmi test_cps.cmj test_cps.js)
+    (targets test_cps.cmi test_cps.cmj test_cps.cmt test_cps.js)
     (deps (:inputs test_cps.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8060,7 +8060,7 @@
 
 
   (rule
-    (targets test_demo.cmi test_demo.cmj test_demo.js)
+    (targets test_demo.cmi test_demo.cmj test_demo.cmt test_demo.js)
     (deps (:inputs test_demo.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8073,7 +8073,7 @@
 
 
   (rule
-    (targets test_dup_param.cmi test_dup_param.cmj test_dup_param.js)
+    (targets test_dup_param.cmi test_dup_param.cmj test_dup_param.cmt test_dup_param.js)
     (deps (:inputs test_dup_param.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8086,7 +8086,7 @@
 
 
   (rule
-    (targets test_eq.cmi test_eq.cmj test_eq.js)
+    (targets test_eq.cmi test_eq.cmj test_eq.cmt test_eq.js)
     (deps (:inputs test_eq.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8099,7 +8099,7 @@
 
 
   (rule
-    (targets test_exception.cmi test_exception.cmj test_exception.js)
+    (targets test_exception.cmi test_exception.cmj test_exception.cmt test_exception.js)
     (deps (:inputs test_exception.ml) ../stdlib-412/stdlib.cmj test_common.cmj)
 
   (mode
@@ -8112,7 +8112,7 @@
 
 
   (rule
-    (targets test_exception_escape.cmi test_exception_escape.cmj test_exception_escape.js)
+    (targets test_exception_escape.cmi test_exception_escape.cmj test_exception_escape.cmt test_exception_escape.js)
     (deps (:inputs test_exception_escape.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8125,7 +8125,7 @@
 
 
   (rule
-    (targets test_export2.cmi test_export2.cmj test_export2.js)
+    (targets test_export2.cmi test_export2.cmj test_export2.cmt test_export2.js)
     (deps (:inputs test_export2.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8138,7 +8138,7 @@
 
 
   (rule
-    (targets test_external.cmi test_external.cmj test_external.js)
+    (targets test_external.cmi test_external.cmj test_external.cmt test_external.js)
     (deps (:inputs test_external.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8151,7 +8151,7 @@
 
 
   (rule
-    (targets test_external_unit.cmi test_external_unit.cmj test_external_unit.js)
+    (targets test_external_unit.cmi test_external_unit.cmj test_external_unit.cmt test_external_unit.js)
     (deps (:inputs test_external_unit.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8164,7 +8164,7 @@
 
 
   (rule
-    (targets test_ffi.cmi test_ffi.cmj test_ffi.js)
+    (targets test_ffi.cmi test_ffi.cmj test_ffi.cmt test_ffi.js)
     (deps (:inputs test_ffi.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8177,7 +8177,7 @@
 
 
   (rule
-    (targets test_fib.cmi test_fib.cmj test_fib.js)
+    (targets test_fib.cmi test_fib.cmj test_fib.cmt test_fib.js)
     (deps (:inputs test_fib.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8190,7 +8190,7 @@
 
 
   (rule
-    (targets test_filename.cmi test_filename.cmj test_filename.js)
+    (targets test_filename.cmi test_filename.cmj test_filename.cmt test_filename.js)
     (deps (:inputs test_filename.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8203,7 +8203,7 @@
 
 
   (rule
-    (targets test_for_loop.cmi test_for_loop.cmj test_for_loop.js)
+    (targets test_for_loop.cmi test_for_loop.cmj test_for_loop.cmt test_for_loop.js)
     (deps (:inputs test_for_loop.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8216,7 +8216,7 @@
 
 
   (rule
-    (targets test_for_map.cmi test_for_map.cmj test_for_map.js)
+    (targets test_for_map.cmi test_for_map.cmj test_for_map.cmt test_for_map.js)
     (deps (:inputs test_for_map.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8229,7 +8229,7 @@
 
 
   (rule
-    (targets test_for_map2.cmj test_for_map2.js)
+    (targets test_for_map2.cmj test_for_map2.cmt test_for_map2.js)
     (deps (:inputs test_for_map2.ml) ../stdlib-412/stdlib.cmj int_map.cmj test_for_map2.cmi)
 
   (mode
@@ -8242,7 +8242,7 @@
 
 
   (rule
-    (targets test_for_map2.cmi )
+    (targets test_for_map2.cmi test_for_map2.cmti )
     (deps (:inputs test_for_map2.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8255,7 +8255,7 @@
 
 
   (rule
-    (targets test_format.cmi test_format.cmj test_format.js)
+    (targets test_format.cmi test_format.cmj test_format.cmt test_format.js)
     (deps (:inputs test_format.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8268,7 +8268,7 @@
 
 
   (rule
-    (targets test_formatter.cmi test_formatter.cmj test_formatter.js)
+    (targets test_formatter.cmi test_formatter.cmj test_formatter.cmt test_formatter.js)
     (deps (:inputs test_formatter.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8281,7 +8281,7 @@
 
 
   (rule
-    (targets test_functor_dead_code.cmi test_functor_dead_code.cmj test_functor_dead_code.js)
+    (targets test_functor_dead_code.cmi test_functor_dead_code.cmj test_functor_dead_code.cmt test_functor_dead_code.js)
     (deps (:inputs test_functor_dead_code.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8294,7 +8294,7 @@
 
 
   (rule
-    (targets test_generative_module.cmi test_generative_module.cmj test_generative_module.js)
+    (targets test_generative_module.cmi test_generative_module.cmj test_generative_module.cmt test_generative_module.js)
     (deps (:inputs test_generative_module.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8307,7 +8307,7 @@
 
 
   (rule
-    (targets test_global_print.cmi test_global_print.cmj test_global_print.js)
+    (targets test_global_print.cmi test_global_print.cmj test_global_print.cmt test_global_print.js)
     (deps (:inputs test_global_print.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8320,7 +8320,7 @@
 
 
   (rule
-    (targets test_google_closure.cmi test_google_closure.cmj test_google_closure.js)
+    (targets test_google_closure.cmi test_google_closure.cmj test_google_closure.cmt test_google_closure.js)
     (deps (:inputs test_google_closure.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8333,7 +8333,7 @@
 
 
   (rule
-    (targets test_http_server.cmj test_http_server.js)
+    (targets test_http_server.cmj test_http_server.cmt test_http_server.js)
     (deps (:inputs test_http_server.ml) ../stdlib-412/stdlib.cmj http_types.cmj test_http_server.cmi)
 
   (mode
@@ -8346,7 +8346,7 @@
 
 
   (rule
-    (targets test_http_server.cmi )
+    (targets test_http_server.cmi test_http_server.cmti )
     (deps (:inputs test_http_server.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8359,7 +8359,7 @@
 
 
   (rule
-    (targets test_include.cmi test_include.cmj test_include.js)
+    (targets test_include.cmi test_include.cmj test_include.cmt test_include.js)
     (deps (:inputs test_include.ml) ../stdlib-412/stdlib.cmj test_order.cmj)
 
   (mode
@@ -8372,7 +8372,7 @@
 
 
   (rule
-    (targets test_incomplete.cmi test_incomplete.cmj test_incomplete.js)
+    (targets test_incomplete.cmi test_incomplete.cmj test_incomplete.cmt test_incomplete.js)
     (deps (:inputs test_incomplete.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8385,7 +8385,7 @@
 
 
   (rule
-    (targets test_incr_ref.cmi test_incr_ref.cmj test_incr_ref.js)
+    (targets test_incr_ref.cmi test_incr_ref.cmj test_incr_ref.cmt test_incr_ref.js)
     (deps (:inputs test_incr_ref.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8398,7 +8398,7 @@
 
 
   (rule
-    (targets test_index.cmi test_index.cmj test_index.js)
+    (targets test_index.cmi test_index.cmj test_index.cmt test_index.js)
     (deps (:inputs test_index.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8411,7 +8411,7 @@
 
 
   (rule
-    (targets test_int_map_find.cmi test_int_map_find.cmj test_int_map_find.js)
+    (targets test_int_map_find.cmi test_int_map_find.cmj test_int_map_find.cmt test_int_map_find.js)
     (deps (:inputs test_int_map_find.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8424,7 +8424,7 @@
 
 
   (rule
-    (targets test_internalOO.cmi test_internalOO.cmj test_internalOO.js)
+    (targets test_internalOO.cmi test_internalOO.cmj test_internalOO.cmt test_internalOO.js)
     (deps (:inputs test_internalOO.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8437,7 +8437,7 @@
 
 
   (rule
-    (targets test_is_js.cmj test_is_js.js)
+    (targets test_is_js.cmj test_is_js.cmt test_is_js.js)
     (deps (:inputs test_is_js.ml) ../stdlib-412/stdlib.cmj mt.cmj test_is_js.cmi)
 
   (mode
@@ -8450,7 +8450,7 @@
 
 
   (rule
-    (targets test_is_js.cmi )
+    (targets test_is_js.cmi test_is_js.cmti )
     (deps (:inputs test_is_js.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8463,7 +8463,7 @@
 
 
   (rule
-    (targets test_js_ffi.cmi test_js_ffi.cmj test_js_ffi.js)
+    (targets test_js_ffi.cmi test_js_ffi.cmj test_js_ffi.cmt test_js_ffi.js)
     (deps (:inputs test_js_ffi.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8476,7 +8476,7 @@
 
 
   (rule
-    (targets test_let.cmi test_let.cmj test_let.js)
+    (targets test_let.cmi test_let.cmj test_let.cmt test_let.js)
     (deps (:inputs test_let.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8489,7 +8489,7 @@
 
 
   (rule
-    (targets test_list.cmi test_list.cmj test_list.js)
+    (targets test_list.cmi test_list.cmj test_list.cmt test_list.js)
     (deps (:inputs test_list.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8502,7 +8502,7 @@
 
 
   (rule
-    (targets test_literal.cmi test_literal.cmj test_literal.js)
+    (targets test_literal.cmi test_literal.cmj test_literal.cmt test_literal.js)
     (deps (:inputs test_literal.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8515,7 +8515,7 @@
 
 
   (rule
-    (targets test_literals.cmi test_literals.cmj test_literals.js)
+    (targets test_literals.cmi test_literals.cmj test_literals.cmt test_literals.js)
     (deps (:inputs test_literals.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8528,7 +8528,7 @@
 
 
   (rule
-    (targets test_match_exception.cmi test_match_exception.cmj test_match_exception.js)
+    (targets test_match_exception.cmi test_match_exception.cmj test_match_exception.cmt test_match_exception.js)
     (deps (:inputs test_match_exception.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8541,7 +8541,7 @@
 
 
   (rule
-    (targets test_mutliple.cmi test_mutliple.cmj test_mutliple.js)
+    (targets test_mutliple.cmi test_mutliple.cmj test_mutliple.cmt test_mutliple.js)
     (deps (:inputs test_mutliple.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8554,7 +8554,7 @@
 
 
   (rule
-    (targets test_nat64.cmi test_nat64.cmj test_nat64.js)
+    (targets test_nat64.cmi test_nat64.cmj test_nat64.cmt test_nat64.js)
     (deps (:inputs test_nat64.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8567,7 +8567,7 @@
 
 
   (rule
-    (targets test_nested_let.cmi test_nested_let.cmj test_nested_let.js)
+    (targets test_nested_let.cmi test_nested_let.cmj test_nested_let.cmt test_nested_let.js)
     (deps (:inputs test_nested_let.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8580,7 +8580,7 @@
 
 
   (rule
-    (targets test_nested_print.cmi test_nested_print.cmj test_nested_print.js)
+    (targets test_nested_print.cmi test_nested_print.cmj test_nested_print.cmt test_nested_print.js)
     (deps (:inputs test_nested_print.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8593,7 +8593,7 @@
 
 
   (rule
-    (targets test_non_export.cmi test_non_export.cmj test_non_export.js)
+    (targets test_non_export.cmi test_non_export.cmj test_non_export.cmt test_non_export.js)
     (deps (:inputs test_non_export.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8606,7 +8606,7 @@
 
 
   (rule
-    (targets test_nullary.cmi test_nullary.cmj test_nullary.js)
+    (targets test_nullary.cmi test_nullary.cmj test_nullary.cmt test_nullary.js)
     (deps (:inputs test_nullary.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8619,7 +8619,7 @@
 
 
   (rule
-    (targets test_obj.cmi test_obj.cmj test_obj.js)
+    (targets test_obj.cmi test_obj.cmj test_obj.cmt test_obj.js)
     (deps (:inputs test_obj.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8632,7 +8632,7 @@
 
 
   (rule
-    (targets test_obj_simple_ffi.cmi test_obj_simple_ffi.cmj test_obj_simple_ffi.js)
+    (targets test_obj_simple_ffi.cmi test_obj_simple_ffi.cmj test_obj_simple_ffi.cmt test_obj_simple_ffi.js)
     (deps (:inputs test_obj_simple_ffi.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8645,7 +8645,7 @@
 
 
   (rule
-    (targets test_order.cmi test_order.cmj test_order.js)
+    (targets test_order.cmi test_order.cmj test_order.cmt test_order.js)
     (deps (:inputs test_order.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8658,7 +8658,7 @@
 
 
   (rule
-    (targets test_order_tailcall.cmi test_order_tailcall.cmj test_order_tailcall.js)
+    (targets test_order_tailcall.cmi test_order_tailcall.cmj test_order_tailcall.cmt test_order_tailcall.js)
     (deps (:inputs test_order_tailcall.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8671,7 +8671,7 @@
 
 
   (rule
-    (targets test_other_exn.cmi test_other_exn.cmj test_other_exn.js)
+    (targets test_other_exn.cmi test_other_exn.cmj test_other_exn.cmt test_other_exn.js)
     (deps (:inputs test_other_exn.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8684,7 +8684,7 @@
 
 
   (rule
-    (targets test_pack.cmi test_pack.cmj test_pack.js)
+    (targets test_pack.cmi test_pack.cmj test_pack.cmt test_pack.js)
     (deps (:inputs test_pack.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8697,7 +8697,7 @@
 
 
   (rule
-    (targets test_per.cmi test_per.cmj test_per.js)
+    (targets test_per.cmi test_per.cmj test_per.cmt test_per.js)
     (deps (:inputs test_per.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8710,7 +8710,7 @@
 
 
   (rule
-    (targets test_pervasive.cmi test_pervasive.cmj test_pervasive.js)
+    (targets test_pervasive.cmi test_pervasive.cmj test_pervasive.cmt test_pervasive.js)
     (deps (:inputs test_pervasive.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8723,7 +8723,7 @@
 
 
   (rule
-    (targets test_pervasives2.cmi test_pervasives2.cmj test_pervasives2.js)
+    (targets test_pervasives2.cmi test_pervasives2.cmj test_pervasives2.cmt test_pervasives2.js)
     (deps (:inputs test_pervasives2.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8736,7 +8736,7 @@
 
 
   (rule
-    (targets test_pervasives3.cmi test_pervasives3.cmj test_pervasives3.js)
+    (targets test_pervasives3.cmi test_pervasives3.cmj test_pervasives3.cmt test_pervasives3.js)
     (deps (:inputs test_pervasives3.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8749,7 +8749,7 @@
 
 
   (rule
-    (targets test_primitive.cmi test_primitive.cmj test_primitive.js)
+    (targets test_primitive.cmi test_primitive.cmj test_primitive.cmt test_primitive.js)
     (deps (:inputs test_primitive.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8762,7 +8762,7 @@
 
 
   (rule
-    (targets test_promise_bind.cmi test_promise_bind.cmj test_promise_bind.js)
+    (targets test_promise_bind.cmi test_promise_bind.cmj test_promise_bind.cmt test_promise_bind.js)
     (deps (:inputs test_promise_bind.ml) ../stdlib-412/stdlib.cmj promise.cmj)
 
   (mode
@@ -8775,7 +8775,7 @@
 
 
   (rule
-    (targets test_ramification.cmi test_ramification.cmj test_ramification.js)
+    (targets test_ramification.cmi test_ramification.cmj test_ramification.cmt test_ramification.js)
     (deps (:inputs test_ramification.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8788,7 +8788,7 @@
 
 
   (rule
-    (targets test_react.cmi test_react.cmj test_react.js)
+    (targets test_react.cmi test_react.cmj test_react.cmt test_react.js)
     (deps (:inputs test_react.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8801,7 +8801,7 @@
 
 
   (rule
-    (targets test_react_case.cmi test_react_case.cmj test_react_case.js)
+    (targets test_react_case.cmi test_react_case.cmj test_react_case.cmt test_react_case.js)
     (deps (:inputs test_react_case.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8814,7 +8814,7 @@
 
 
   (rule
-    (targets test_regex.cmi test_regex.cmj test_regex.js)
+    (targets test_regex.cmi test_regex.cmj test_regex.cmt test_regex.js)
     (deps (:inputs test_regex.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8827,7 +8827,7 @@
 
 
   (rule
-    (targets test_require.cmi test_require.cmj test_require.js)
+    (targets test_require.cmi test_require.cmj test_require.cmt test_require.js)
     (deps (:inputs test_require.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8840,7 +8840,7 @@
 
 
   (rule
-    (targets test_runtime_encoding.cmi test_runtime_encoding.cmj test_runtime_encoding.js)
+    (targets test_runtime_encoding.cmi test_runtime_encoding.cmj test_runtime_encoding.cmt test_runtime_encoding.js)
     (deps (:inputs test_runtime_encoding.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8853,7 +8853,7 @@
 
 
   (rule
-    (targets test_scope.cmi test_scope.cmj test_scope.js)
+    (targets test_scope.cmi test_scope.cmj test_scope.cmt test_scope.js)
     (deps (:inputs test_scope.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8866,7 +8866,7 @@
 
 
   (rule
-    (targets test_seq.cmi test_seq.cmj test_seq.js)
+    (targets test_seq.cmi test_seq.cmj test_seq.cmt test_seq.js)
     (deps (:inputs test_seq.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8879,7 +8879,7 @@
 
 
   (rule
-    (targets test_set.cmi test_set.cmj test_set.js)
+    (targets test_set.cmi test_set.cmj test_set.cmt test_set.js)
     (deps (:inputs test_set.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8892,7 +8892,7 @@
 
 
   (rule
-    (targets test_side_effect_functor.cmi test_side_effect_functor.cmj test_side_effect_functor.js)
+    (targets test_side_effect_functor.cmi test_side_effect_functor.cmj test_side_effect_functor.cmt test_side_effect_functor.js)
     (deps (:inputs test_side_effect_functor.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8905,7 +8905,7 @@
 
 
   (rule
-    (targets test_simple_include.cmi test_simple_include.cmj test_simple_include.js)
+    (targets test_simple_include.cmi test_simple_include.cmj test_simple_include.cmt test_simple_include.js)
     (deps (:inputs test_simple_include.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8918,7 +8918,7 @@
 
 
   (rule
-    (targets test_simple_obj.cmi test_simple_obj.cmj test_simple_obj.js)
+    (targets test_simple_obj.cmi test_simple_obj.cmj test_simple_obj.cmt test_simple_obj.js)
     (deps (:inputs test_simple_obj.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8931,7 +8931,7 @@
 
 
   (rule
-    (targets test_simple_pattern_match.cmi test_simple_pattern_match.cmj test_simple_pattern_match.js)
+    (targets test_simple_pattern_match.cmi test_simple_pattern_match.cmj test_simple_pattern_match.cmt test_simple_pattern_match.js)
     (deps (:inputs test_simple_pattern_match.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8944,7 +8944,7 @@
 
 
   (rule
-    (targets test_simple_ref.cmi test_simple_ref.cmj test_simple_ref.js)
+    (targets test_simple_ref.cmi test_simple_ref.cmj test_simple_ref.cmt test_simple_ref.js)
     (deps (:inputs test_simple_ref.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8957,7 +8957,7 @@
 
 
   (rule
-    (targets test_simple_tailcall.cmi test_simple_tailcall.cmj test_simple_tailcall.js)
+    (targets test_simple_tailcall.cmi test_simple_tailcall.cmj test_simple_tailcall.cmt test_simple_tailcall.js)
     (deps (:inputs test_simple_tailcall.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8970,7 +8970,7 @@
 
 
   (rule
-    (targets test_small.cmi test_small.cmj test_small.js)
+    (targets test_small.cmi test_small.cmj test_small.cmt test_small.js)
     (deps (:inputs test_small.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8983,7 +8983,7 @@
 
 
   (rule
-    (targets test_sprintf.cmi test_sprintf.cmj test_sprintf.js)
+    (targets test_sprintf.cmi test_sprintf.cmj test_sprintf.cmt test_sprintf.js)
     (deps (:inputs test_sprintf.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -8996,7 +8996,7 @@
 
 
   (rule
-    (targets test_stack.cmi test_stack.cmj test_stack.js)
+    (targets test_stack.cmi test_stack.cmj test_stack.cmt test_stack.js)
     (deps (:inputs test_stack.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9009,7 +9009,7 @@
 
 
   (rule
-    (targets test_static_catch_ident.cmi test_static_catch_ident.cmj test_static_catch_ident.js)
+    (targets test_static_catch_ident.cmi test_static_catch_ident.cmj test_static_catch_ident.cmt test_static_catch_ident.js)
     (deps (:inputs test_static_catch_ident.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9022,7 +9022,7 @@
 
 
   (rule
-    (targets test_string.cmi test_string.cmj test_string.js)
+    (targets test_string.cmi test_string.cmj test_string.cmt test_string.js)
     (deps (:inputs test_string.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9035,7 +9035,7 @@
 
 
   (rule
-    (targets test_string_case.cmi test_string_case.cmj test_string_case.js)
+    (targets test_string_case.cmi test_string_case.cmj test_string_case.cmt test_string_case.js)
     (deps (:inputs test_string_case.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9048,7 +9048,7 @@
 
 
   (rule
-    (targets test_string_const.cmi test_string_const.cmj test_string_const.js)
+    (targets test_string_const.cmi test_string_const.cmj test_string_const.cmt test_string_const.js)
     (deps (:inputs test_string_const.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9061,7 +9061,7 @@
 
 
   (rule
-    (targets test_string_map.cmi test_string_map.cmj test_string_map.js)
+    (targets test_string_map.cmi test_string_map.cmj test_string_map.cmt test_string_map.js)
     (deps (:inputs test_string_map.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9074,7 +9074,7 @@
 
 
   (rule
-    (targets test_string_switch.cmi test_string_switch.cmj test_string_switch.js)
+    (targets test_string_switch.cmi test_string_switch.cmj test_string_switch.cmt test_string_switch.js)
     (deps (:inputs test_string_switch.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9087,7 +9087,7 @@
 
 
   (rule
-    (targets test_switch.cmi test_switch.cmj test_switch.js)
+    (targets test_switch.cmi test_switch.cmj test_switch.cmt test_switch.js)
     (deps (:inputs test_switch.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9100,7 +9100,7 @@
 
 
   (rule
-    (targets test_trywith.cmi test_trywith.cmj test_trywith.js)
+    (targets test_trywith.cmi test_trywith.cmj test_trywith.cmt test_trywith.js)
     (deps (:inputs test_trywith.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9113,7 +9113,7 @@
 
 
   (rule
-    (targets test_tuple.cmi test_tuple.cmj test_tuple.js)
+    (targets test_tuple.cmi test_tuple.cmj test_tuple.cmt test_tuple.js)
     (deps (:inputs test_tuple.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9126,7 +9126,7 @@
 
 
   (rule
-    (targets test_tuple_destructring.cmi test_tuple_destructring.cmj test_tuple_destructring.js)
+    (targets test_tuple_destructring.cmi test_tuple_destructring.cmj test_tuple_destructring.cmt test_tuple_destructring.js)
     (deps (:inputs test_tuple_destructring.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9139,7 +9139,7 @@
 
 
   (rule
-    (targets test_type_based_arity.cmi test_type_based_arity.cmj test_type_based_arity.js)
+    (targets test_type_based_arity.cmi test_type_based_arity.cmj test_type_based_arity.cmt test_type_based_arity.js)
     (deps (:inputs test_type_based_arity.ml) ../stdlib-412/stdlib.cmj abstract_type.cmj)
 
   (mode
@@ -9152,7 +9152,7 @@
 
 
   (rule
-    (targets test_u.cmi test_u.cmj test_u.js)
+    (targets test_u.cmi test_u.cmj test_u.cmt test_u.js)
     (deps (:inputs test_u.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9165,7 +9165,7 @@
 
 
   (rule
-    (targets test_unsafe_cmp.cmi test_unsafe_cmp.cmj test_unsafe_cmp.js)
+    (targets test_unsafe_cmp.cmi test_unsafe_cmp.cmj test_unsafe_cmp.cmt test_unsafe_cmp.js)
     (deps (:inputs test_unsafe_cmp.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9178,7 +9178,7 @@
 
 
   (rule
-    (targets test_unsafe_obj_ffi.cmj test_unsafe_obj_ffi.js)
+    (targets test_unsafe_obj_ffi.cmj test_unsafe_obj_ffi.cmt test_unsafe_obj_ffi.js)
     (deps (:inputs test_unsafe_obj_ffi.ml) ../stdlib-412/stdlib.cmj test_unsafe_obj_ffi.cmi)
 
   (mode
@@ -9191,7 +9191,7 @@
 
 
   (rule
-    (targets test_unsafe_obj_ffi.cmi )
+    (targets test_unsafe_obj_ffi.cmi test_unsafe_obj_ffi.cmti )
     (deps (:inputs test_unsafe_obj_ffi.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9204,7 +9204,7 @@
 
 
   (rule
-    (targets test_unsafe_obj_ffi_ppx.cmj test_unsafe_obj_ffi_ppx.js)
+    (targets test_unsafe_obj_ffi_ppx.cmj test_unsafe_obj_ffi_ppx.cmt test_unsafe_obj_ffi_ppx.js)
     (deps (:inputs test_unsafe_obj_ffi_ppx.ml) ../stdlib-412/stdlib.cmj test_unsafe_obj_ffi_ppx.cmi)
 
   (mode
@@ -9217,7 +9217,7 @@
 
 
   (rule
-    (targets test_unsafe_obj_ffi_ppx.cmi )
+    (targets test_unsafe_obj_ffi_ppx.cmi test_unsafe_obj_ffi_ppx.cmti )
     (deps (:inputs test_unsafe_obj_ffi_ppx.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9230,7 +9230,7 @@
 
 
   (rule
-    (targets test_unsupported_primitive.cmi test_unsupported_primitive.cmj test_unsupported_primitive.js)
+    (targets test_unsupported_primitive.cmi test_unsupported_primitive.cmj test_unsupported_primitive.cmt test_unsupported_primitive.js)
     (deps (:inputs test_unsupported_primitive.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9243,7 +9243,7 @@
 
 
   (rule
-    (targets test_while_closure.cmi test_while_closure.cmj test_while_closure.js)
+    (targets test_while_closure.cmi test_while_closure.cmj test_while_closure.cmt test_while_closure.js)
     (deps (:inputs test_while_closure.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9256,7 +9256,7 @@
 
 
   (rule
-    (targets test_while_side_effect.cmi test_while_side_effect.cmj test_while_side_effect.js)
+    (targets test_while_side_effect.cmi test_while_side_effect.cmj test_while_side_effect.cmt test_while_side_effect.js)
     (deps (:inputs test_while_side_effect.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9269,7 +9269,7 @@
 
 
   (rule
-    (targets test_zero_nullable.cmi test_zero_nullable.cmj test_zero_nullable.js)
+    (targets test_zero_nullable.cmi test_zero_nullable.cmj test_zero_nullable.cmt test_zero_nullable.js)
     (deps (:inputs test_zero_nullable.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9282,7 +9282,7 @@
 
 
   (rule
-    (targets testing.cmj testing.js)
+    (targets testing.cmj testing.cmt testing.js)
     (deps (:inputs testing.ml) ../stdlib-412/stdlib.cmj testing.cmi)
 
   (mode
@@ -9295,7 +9295,7 @@
 
 
   (rule
-    (targets testing.cmi )
+    (targets testing.cmi testing.cmti )
     (deps (:inputs testing.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9308,7 +9308,7 @@
 
 
   (rule
-    (targets tfloat_record_test.cmi tfloat_record_test.cmj tfloat_record_test.js)
+    (targets tfloat_record_test.cmi tfloat_record_test.cmj tfloat_record_test.cmt tfloat_record_test.js)
     (deps (:inputs tfloat_record_test.ml) ../stdlib-412/stdlib.cmj float_array.cmj float_record.cmj mt.cmj mt_global.cmj)
 
   (mode
@@ -9321,7 +9321,7 @@
 
 
   (rule
-    (targets then_mangle_test.cmi then_mangle_test.cmj then_mangle_test.js)
+    (targets then_mangle_test.cmi then_mangle_test.cmj then_mangle_test.cmt then_mangle_test.js)
     (deps (:inputs then_mangle_test.res) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9334,7 +9334,7 @@
 
 
   (rule
-    (targets ticker.cmi ticker.cmj ticker.js)
+    (targets ticker.cmi ticker.cmj ticker.cmt ticker.js)
     (deps (:inputs ticker.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9347,7 +9347,7 @@
 
 
   (rule
-    (targets to_string_test.cmi to_string_test.cmj to_string_test.js)
+    (targets to_string_test.cmi to_string_test.cmj to_string_test.cmt to_string_test.js)
     (deps (:inputs to_string_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9360,7 +9360,7 @@
 
 
   (rule
-    (targets topsort_test.cmi topsort_test.cmj topsort_test.js)
+    (targets topsort_test.cmi topsort_test.cmj topsort_test.cmt topsort_test.js)
     (deps (:inputs topsort_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9373,7 +9373,7 @@
 
 
   (rule
-    (targets tramp_fib.cmi tramp_fib.cmj tramp_fib.js)
+    (targets tramp_fib.cmi tramp_fib.cmj tramp_fib.cmt tramp_fib.js)
     (deps (:inputs tramp_fib.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9386,7 +9386,7 @@
 
 
   (rule
-    (targets tscanf_test.cmi tscanf_test.cmj tscanf_test.js)
+    (targets tscanf_test.cmi tscanf_test.cmj tscanf_test.cmt tscanf_test.js)
     (deps (:inputs tscanf_test.ml) ../stdlib-412/stdlib.cmj mt.cmj mt_global.cmj testing.cmj)
 
   (mode
@@ -9399,7 +9399,7 @@
 
 
   (rule
-    (targets tuple_alloc.cmi tuple_alloc.cmj tuple_alloc.js)
+    (targets tuple_alloc.cmi tuple_alloc.cmj tuple_alloc.cmt tuple_alloc.js)
     (deps (:inputs tuple_alloc.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9412,7 +9412,7 @@
 
 
   (rule
-    (targets type_disambiguate.cmi type_disambiguate.cmj type_disambiguate.js)
+    (targets type_disambiguate.cmi type_disambiguate.cmj type_disambiguate.cmt type_disambiguate.js)
     (deps (:inputs type_disambiguate.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9425,7 +9425,7 @@
 
 
   (rule
-    (targets typeof_test.cmi typeof_test.cmj typeof_test.js)
+    (targets typeof_test.cmi typeof_test.cmj typeof_test.cmt typeof_test.js)
     (deps (:inputs typeof_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9438,7 +9438,7 @@
 
 
   (rule
-    (targets ui_defs.cmi )
+    (targets ui_defs.cmi ui_defs.cmti )
     (deps (:inputs ui_defs.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9451,7 +9451,7 @@
 
 
   (rule
-    (targets unboxed_attribute.cmi unboxed_attribute.cmj unboxed_attribute.js)
+    (targets unboxed_attribute.cmi unboxed_attribute.cmj unboxed_attribute.cmt unboxed_attribute.js)
     (deps (:inputs unboxed_attribute.res) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9464,7 +9464,7 @@
 
 
   (rule
-    (targets unboxed_attribute_test.cmi unboxed_attribute_test.cmj unboxed_attribute_test.js)
+    (targets unboxed_attribute_test.cmi unboxed_attribute_test.cmj unboxed_attribute_test.cmt unboxed_attribute_test.js)
     (deps (:inputs unboxed_attribute_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9477,7 +9477,7 @@
 
 
   (rule
-    (targets unboxed_crash.cmi unboxed_crash.cmj unboxed_crash.js)
+    (targets unboxed_crash.cmi unboxed_crash.cmj unboxed_crash.cmt unboxed_crash.js)
     (deps (:inputs unboxed_crash.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9490,7 +9490,7 @@
 
 
   (rule
-    (targets unboxed_use_case.cmj unboxed_use_case.js)
+    (targets unboxed_use_case.cmj unboxed_use_case.cmt unboxed_use_case.js)
     (deps (:inputs unboxed_use_case.ml) ../stdlib-412/stdlib.cmj unboxed_use_case.cmi)
 
   (mode
@@ -9503,7 +9503,7 @@
 
 
   (rule
-    (targets unboxed_use_case.cmi )
+    (targets unboxed_use_case.cmi unboxed_use_case.cmti )
     (deps (:inputs unboxed_use_case.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9516,7 +9516,7 @@
 
 
   (rule
-    (targets uncurry_external_test.cmi uncurry_external_test.cmj uncurry_external_test.js)
+    (targets uncurry_external_test.cmi uncurry_external_test.cmj uncurry_external_test.cmt uncurry_external_test.js)
     (deps (:inputs uncurry_external_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9529,7 +9529,7 @@
 
 
   (rule
-    (targets uncurry_glob_test.cmi uncurry_glob_test.cmj uncurry_glob_test.js)
+    (targets uncurry_glob_test.cmi uncurry_glob_test.cmj uncurry_glob_test.cmt uncurry_glob_test.js)
     (deps (:inputs uncurry_glob_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9542,7 +9542,7 @@
 
 
   (rule
-    (targets uncurry_method.cmi uncurry_method.cmj uncurry_method.js)
+    (targets uncurry_method.cmi uncurry_method.cmj uncurry_method.cmt uncurry_method.js)
     (deps (:inputs uncurry_method.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9555,7 +9555,7 @@
 
 
   (rule
-    (targets uncurry_test.cmj uncurry_test.js)
+    (targets uncurry_test.cmj uncurry_test.cmt uncurry_test.js)
     (deps (:inputs uncurry_test.ml) ../stdlib-412/stdlib.cmj uncurry_test.cmi)
 
   (mode
@@ -9568,7 +9568,7 @@
 
 
   (rule
-    (targets uncurry_test.cmi )
+    (targets uncurry_test.cmi uncurry_test.cmti )
     (deps (:inputs uncurry_test.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9581,7 +9581,7 @@
 
 
   (rule
-    (targets undef_regression2_test.cmi undef_regression2_test.cmj undef_regression2_test.js)
+    (targets undef_regression2_test.cmi undef_regression2_test.cmj undef_regression2_test.cmt undef_regression2_test.js)
     (deps (:inputs undef_regression2_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9594,7 +9594,7 @@
 
 
   (rule
-    (targets undef_regression_test.cmi undef_regression_test.cmj undef_regression_test.js)
+    (targets undef_regression_test.cmi undef_regression_test.cmj undef_regression_test.cmt undef_regression_test.js)
     (deps (:inputs undef_regression_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9607,7 +9607,7 @@
 
 
   (rule
-    (targets undefine_conditional.cmi undefine_conditional.cmj undefine_conditional.js)
+    (targets undefine_conditional.cmi undefine_conditional.cmj undefine_conditional.cmt undefine_conditional.js)
     (deps (:inputs undefine_conditional.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9620,7 +9620,7 @@
 
 
   (rule
-    (targets unicode_type_error.cmi unicode_type_error.cmj unicode_type_error.js)
+    (targets unicode_type_error.cmi unicode_type_error.cmj unicode_type_error.cmt unicode_type_error.js)
     (deps (:inputs unicode_type_error.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9633,7 +9633,7 @@
 
 
   (rule
-    (targets unit_undefined_test.cmi unit_undefined_test.cmj unit_undefined_test.js)
+    (targets unit_undefined_test.cmi unit_undefined_test.cmj unit_undefined_test.cmt unit_undefined_test.js)
     (deps (:inputs unit_undefined_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9646,7 +9646,7 @@
 
 
   (rule
-    (targets unitest_string.cmi unitest_string.cmj unitest_string.js)
+    (targets unitest_string.cmi unitest_string.cmj unitest_string.cmt unitest_string.js)
     (deps (:inputs unitest_string.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9659,7 +9659,7 @@
 
 
   (rule
-    (targets unsafe_full_apply_primitive.cmi unsafe_full_apply_primitive.cmj unsafe_full_apply_primitive.js)
+    (targets unsafe_full_apply_primitive.cmi unsafe_full_apply_primitive.cmj unsafe_full_apply_primitive.cmt unsafe_full_apply_primitive.js)
     (deps (:inputs unsafe_full_apply_primitive.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9672,7 +9672,7 @@
 
 
   (rule
-    (targets unsafe_obj_external.cmi unsafe_obj_external.cmj unsafe_obj_external.js)
+    (targets unsafe_obj_external.cmi unsafe_obj_external.cmj unsafe_obj_external.cmt unsafe_obj_external.js)
     (deps (:inputs unsafe_obj_external.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9685,7 +9685,7 @@
 
 
   (rule
-    (targets unsafe_ppx_test.cmi unsafe_ppx_test.cmj unsafe_ppx_test.js)
+    (targets unsafe_ppx_test.cmi unsafe_ppx_test.cmj unsafe_ppx_test.cmt unsafe_ppx_test.js)
     (deps (:inputs unsafe_ppx_test.ml) ../stdlib-412/stdlib.cmj ffi_js_test.cmj mt.cmj)
 
   (mode
@@ -9698,7 +9698,7 @@
 
 
   (rule
-    (targets unsafe_this.cmj unsafe_this.js)
+    (targets unsafe_this.cmj unsafe_this.cmt unsafe_this.js)
     (deps (:inputs unsafe_this.ml) ../stdlib-412/stdlib.cmj unsafe_this.cmi)
 
   (mode
@@ -9711,7 +9711,7 @@
 
 
   (rule
-    (targets unsafe_this.cmi )
+    (targets unsafe_this.cmi unsafe_this.cmti )
     (deps (:inputs unsafe_this.mli) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9724,7 +9724,7 @@
 
 
   (rule
-    (targets update_record_test.cmi update_record_test.cmj update_record_test.js)
+    (targets update_record_test.cmi update_record_test.cmj update_record_test.cmt update_record_test.js)
     (deps (:inputs update_record_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9737,7 +9737,7 @@
 
 
   (rule
-    (targets utf8_decode_test.cmi utf8_decode_test.cmj utf8_decode_test.js)
+    (targets utf8_decode_test.cmi utf8_decode_test.cmj utf8_decode_test.cmt utf8_decode_test.js)
     (deps (:inputs utf8_decode_test.ml) ../stdlib-412/stdlib.cmj mt.cmj)
 
   (mode
@@ -9750,7 +9750,7 @@
 
 
   (rule
-    (targets variant.cmi variant.cmj variant.js)
+    (targets variant.cmi variant.cmj variant.cmt variant.js)
     (deps (:inputs variant.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9763,7 +9763,7 @@
 
 
   (rule
-    (targets watch_test.cmi watch_test.cmj watch_test.js)
+    (targets watch_test.cmi watch_test.cmj watch_test.cmt watch_test.js)
     (deps (:inputs watch_test.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9776,7 +9776,7 @@
 
 
   (rule
-    (targets webpack_config.cmi webpack_config.cmj webpack_config.js)
+    (targets webpack_config.cmi webpack_config.cmj webpack_config.cmt webpack_config.js)
     (deps (:inputs webpack_config.ml) ../stdlib-412/stdlib.cmj)
 
   (mode
@@ -9789,7 +9789,7 @@
 
 
   (rule
-    (targets es6_import.cmi es6_import.cmj es6_import.js es6_import.mjs)
+    (targets es6_import.cmi es6_import.cmj es6_import.cmt es6_import.js es6_import.mjs)
     (deps (:inputs es6_import.ml) ../stdlib-412/stdlib.cmj es6_export.cmj)
 
   (mode
@@ -9802,7 +9802,7 @@
 
 
   (rule
-    (targets es6_export.cmi es6_export.cmj es6_export.js es6_export.mjs)
+    (targets es6_export.cmi es6_export.cmj es6_export.cmt es6_export.js es6_export.mjs)
     (deps (:inputs es6_export.ml) ../stdlib-412/stdlib.cmj)
 
   (mode

--- a/scripts/ninja.js
+++ b/scripts/ninja.js
@@ -606,6 +606,17 @@ function scanFileTargets(allTargets, collIn) {
   return coll;
 }
 
+/* These test files have a `-bs-no-bin-annot` flag */
+const bin_annot_exclusions = [
+  'mario_game',
+  'ocaml_re_test',
+  'ocaml_proto_test',
+  'flow_parser_reg_test',
+  'parser_api',
+  'ocaml_parsetree_test',
+  'ocaml_typedtree_test'
+]
+
 function generateDune(depsMap, allTargets, bscFlags, deps = [], promoteExt = null) {
   /**
    * @type {string[]}
@@ -614,6 +625,8 @@ function generateDune(depsMap, allTargets, bscFlags, deps = [], promoteExt = nul
   allTargets.forEach((x, mod) => {
     let output_cmj = mod + ".cmj";
     let output_cmi = mod + ".cmi";
+    let output_cmt = bin_annot_exclusions.includes(mod) ? "" : mod + ".cmt";
+    let output_cmti = bin_annot_exclusions.includes(mod) ? "" : mod + ".cmti";
     let input_ml = mod + ".ml";
     let input_mli = mod + ".mli";
     let input_re = mod + ".re";
@@ -636,33 +649,33 @@ function generateDune(depsMap, allTargets, bscFlags, deps = [], promoteExt = nul
     };
     switch (x) {
       case "HAS_BOTH":
-        mk([output_cmj], [input_ml], ruleCC_cmi);
-        mk([output_cmi], [input_mli]);
+        mk([output_cmj, output_cmt], [input_ml], ruleCC_cmi);
+        mk([output_cmi, output_cmti], [input_mli]);
         break;
       case "HAS_BOTH_RE":
-        mk([output_cmj], [input_re], ruleCC_cmi);
-        mk([output_cmi], [input_rei], ruleCC);
+        mk([output_cmj, output_cmt], [input_re], ruleCC_cmi);
+        mk([output_cmi, output_cmti], [input_rei], ruleCC);
         break;
       case "HAS_BOTH_RES":
-        mk([output_cmj], [input_res], ruleCC_cmi);
-        mk([output_cmi], [input_resi], ruleCC);
+        mk([output_cmj, output_cmt], [input_res], ruleCC_cmi);
+        mk([output_cmi, output_cmti], [input_resi], ruleCC);
         break;
       case "HAS_RE":
-        mk([output_cmi, output_cmj], [input_re], ruleCC);
+        mk([output_cmi, output_cmj, output_cmt], [input_re], ruleCC);
         break;
       case "HAS_RES":
-        mk([output_cmi, output_cmj], [input_res], ruleCC);
+        mk([output_cmi, output_cmj, output_cmt], [input_res], ruleCC);
         break;
       case "HAS_ML":
-        mk([output_cmi, output_cmj], [input_ml]);
+        mk([output_cmi, output_cmj, output_cmt], [input_ml], ruleCC);
         break;
       case "HAS_REI":
-        mk([output_cmi], [input_rei], ruleCC);
+        mk([output_cmi, output_cmti], [input_rei], ruleCC);
       case "HAS_RESI":
-        mk([output_cmi], [input_resi], ruleCC);
+        mk([output_cmi, output_cmti], [input_resi], ruleCC);
         break;
       case "HAS_MLI":
-        mk([output_cmi], [input_mli]);
+        mk([output_cmi, output_cmti], [input_mli], ruleCC);
         break;
     }
   });


### PR DESCRIPTION
- in `.merlin`, emit a real path, rather than a symlink + relative path 
- generate `.cmt` and `.cmti` build artifacts in the melange codebase