### PR TITLE
`mel` cleanup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1653867233,
-        "narHash": "sha256-M5dr7ZT1AbURGixK9fLWnZLD4F9O5cY9mHnJtfk5oTI=",
+        "lastModified": 1654150159,
+        "narHash": "sha256-/SbOxDGuJr+aQHtBg+V5J+3OV+/gU/cZVOlEl8/kzG4=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "a1d46c5c2c9b23f43ebb21fadbe5c7e9a95e9cd1",
+        "rev": "70165a4922ed0f4819fac34ee4879604d754af6e",
         "type": "github"
       },
       "original": {
@@ -38,17 +38,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1653750779,
-        "narHash": "sha256-yQ5bsgAnUMS/MB2uRi+RANcXtlNENYp5+CZNvDVGxFo=",
+        "lastModified": 1654012153,
+        "narHash": "sha256-In+gfoH2Tnf/UmpzeuGlfuexU2EC4QIelBsm2zMK5AE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa66e6d444f37c80d973d75fd3e0d28e286d8ea4",
+        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa66e6d444f37c80d973d75fd3e0d28e286d8ea4",
+        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
         "type": "github"
       }
     },

--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -78,7 +78,7 @@ let rel_include_dirs ~per_proj_dir ~cur_dir ?namespace source_dirs =
   let source_dirs = Ext_list.map source_dirs relativize_single in
   let dirs =
     if namespace = None then source_dirs
-    else relativize_single Bsb_config.lib_bs :: source_dirs
+    else relativize_single Bsb_config.artifacts_dir :: source_dirs
     (*working dir is [lib/bs] we include this path to have namespace mapping*)
   in
   include_dirs dirs

--- a/jscomp/bsb/bsb_clean.ml
+++ b/jscomp/bsb/bsb_clean.ml
@@ -48,7 +48,7 @@ let clean_bs_garbage proj_dir =
   try
     Bsb_parse_sources.clean_re_js proj_dir;
     (* clean re.js files*)
-    Ext_list.iter Bsb_config.all_lib_artifacts try_remove;
+    Ext_list.iter Bsb_config.all_intermediate_artifacts try_remove;
 
     try_revise_dune (proj_dir // Literals.dune);
     try_remove (proj_dir // Literals.dune_mel)

--- a/jscomp/bsb/bsb_config.ml
+++ b/jscomp/bsb/bsb_config.ml
@@ -22,14 +22,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 let ( // ) = Ext_path.combine
-let lib_lit = Literals.lib
-let lib_js = lib_lit // "js"
-let lib_ocaml = lib_lit // "ocaml"
-let lib_bs = Literals.melange_eobjs_dir
-let lib_es6 = lib_lit // "es6"
-let lib_es6_global = lib_lit // "es6_global"
-let all_lib_artifacts = [ lib_js; lib_ocaml; lib_bs; lib_es6; lib_es6_global ]
-let rev_lib_bs = ".."
+let artifacts_dir = Literals.melange_eobjs_dir
+let all_intermediate_artifacts = [ artifacts_dir ]
 
 let dune_build_dir =
   lazy
@@ -37,14 +31,4 @@ let dune_build_dir =
     | Some value -> value // "default"
     | None -> "_build" // "default")
 
-(* lib/js, lib/es6, lib/es6_global *)
-let top_prefix_of_format (x : Ext_module_system.t) =
-  match x with
-  | NodeJS -> lib_js
-  | Es6 -> lib_es6
-  | Es6_global -> lib_es6_global
-
-let rev_lib_bs_prefix p = rev_lib_bs // p
-let ocaml_bin_install_prefix p = lib_ocaml // p
-let proj_rel path = rev_lib_bs // path
 let ppx_exe = "ppx.exe"

--- a/jscomp/bsb/bsb_config.mli
+++ b/jscomp/bsb/bsb_config.mli
@@ -22,20 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-val ocaml_bin_install_prefix : string -> string
-val proj_rel : string -> string
-val lib_lit : string
-val lib_js : string
-val lib_bs : string
-val lib_es6 : string
-val lib_es6_global : string
-val all_lib_artifacts : string list
-
-(* we need generate path relative to [lib/bs] directory in the opposite direction *)
-val rev_lib_bs_prefix : string -> string
-
-val top_prefix_of_format : Ext_module_system.t -> string
-(** default not install, only when -make-world, its dependencies will be installed  *)
-
+val artifacts_dir : string
+val all_intermediate_artifacts : string list
 val dune_build_dir : string Lazy.t
 val ppx_exe : string

--- a/jscomp/bsb/bsb_config_parse.ml
+++ b/jscomp/bsb/bsb_config_parse.ml
@@ -351,13 +351,20 @@ let rec interpret_json
             ~cut_generators
             ~namespace
             sources in
+
+        begin match map.?(Bsb_build_schemas.bs_external_includes) with
+        | Some _ ->
+          Bsb_log.warn "@{<warning>Warning:@} `%s` is not supported in Melange and will be ignored@."
+          Bsb_build_schemas.bs_external_includes;
+        | None -> ()
+        end;
+
         {
           dir = per_proj_dir;
           gentype_config;
           package_name ;
           namespace ;
           warning = extract_warning map;
-          external_includes = extract_string_list map Bsb_build_schemas.bs_external_includes;
           bsc_flags = extract_string_list map Bsb_build_schemas.bsc_flags ;
           ppx_config = extract_ppx map ~cwd:per_proj_dir Bsb_build_schemas.ppx_flags;
           pp_file = pp_flags ;
@@ -401,7 +408,7 @@ and extract_dependencies ~package_kind (map : json_map) cwd (field : string )
        interpret_json ~package_kind ~per_proj_dir:dep.package_path
      in
      let ns_incl =
-       Ext_option.map namespace (fun _ -> dep.package_path // Bsb_config.lib_bs)
+       Ext_option.map namespace (fun _ -> dep.package_path // Bsb_config.artifacts_dir)
      in
      let dirs = Ext_list.filter_map files (fun ({ Bsb_file_groups.dir; is_dev; _ } as group) ->
         if not is_dev && not (Bsb_file_groups.is_empty group) then

--- a/jscomp/bsb/bsb_config_types.mli
+++ b/jscomp/bsb/bsb_config_types.mli
@@ -44,7 +44,6 @@ type t = {
   (* [captial-package] *)
   namespace : string option;
   (* CapitalPackage *)
-  external_includes : string list;
   bsc_flags : string list;
   ppx_config : ppx_config;
   pp_file : string option;

--- a/jscomp/bsb/bsb_db_encode.ml
+++ b/jscomp/bsb/bsb_db_encode.ml
@@ -104,9 +104,9 @@ let encode (dbs : Bsb_db.t) buf =
    this operation seems affordable
 *)
 let write_build_cache ~proj_dir (bs_files : Bsb_db.t) : unit =
-  let lib_artifacts_dir = Bsb_config.lib_bs in
   let oc =
-    open_out_bin Ext_path.(proj_dir // lib_artifacts_dir // bsbuild_cache)
+    open_out_bin
+      Ext_path.(proj_dir // Bsb_config.artifacts_dir // bsbuild_cache)
   in
   let buf = Ext_buffer.create 100_000 in
   encode bs_files buf;

--- a/jscomp/bsb/bsb_merlin_gen.ml
+++ b/jscomp/bsb/bsb_merlin_gen.ml
@@ -80,9 +80,8 @@ let output_merlin_namespace buffer ns=
   match ns with
   | None -> ()
   | Some x ->
-    let lib_artifacts_dir = Bsb_config.lib_bs in
     Buffer.add_string buffer merlin_b ;
-    Buffer.add_string buffer lib_artifacts_dir ;
+    Buffer.add_string buffer Bsb_config.artifacts_dir ;
     Buffer.add_string buffer merlin_flg ;
     Buffer.add_string buffer "-open ";
     Buffer.add_string buffer x
@@ -139,7 +138,6 @@ let merlin_file_gen ~per_proj_dir:(per_proj_dir:string)
       bs_dev_dependencies;
       bsc_flags;
       built_in_dependency;
-      external_includes;
       reason_react_jsx ;
       namespace;
       package_name = _;
@@ -183,12 +181,6 @@ let merlin_file_gen ~per_proj_dir:(per_proj_dir:string)
             (match opt with Jsx_v3 -> 3)
        )
       );
-    Ext_list.iter external_includes (fun path ->
-        Buffer.add_string buffer merlin_s ;
-        Buffer.add_string buffer path ;
-        Buffer.add_string buffer merlin_b;
-        Buffer.add_string buffer path ;
-      );
     if built_in_dependency then (
       let paths =
 #ifndef BS_RELEASE_BUILD
@@ -207,7 +199,6 @@ let merlin_file_gen ~per_proj_dir:(per_proj_dir:string)
     Ext_list.iter bs_dependencies (package_merlin buffer ~dune_build_dir);
     (**TODO: shall we generate .merlin for dev packages ?*)
     Ext_list.iter bs_dev_dependencies (package_merlin buffer ~dune_build_dir);
-    let lib_artifacts_dir = Bsb_config.lib_bs in
     Ext_list.iter res_files.files (fun x ->
         if not (Bsb_file_groups.is_empty x) then
           begin
@@ -218,7 +209,7 @@ let merlin_file_gen ~per_proj_dir:(per_proj_dir:string)
           end;
       ) ;
     Buffer.add_string buffer merlin_b;
-    Buffer.add_string buffer (per_proj_dir // dune_build_dir // lib_artifacts_dir) ;
+    Buffer.add_string buffer (per_proj_dir // dune_build_dir // Bsb_config.artifacts_dir) ;
     Buffer.add_string buffer "\n";
     revise_merlin (per_proj_dir // merlin) buffer
   end

--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -91,10 +91,10 @@ let emit_module_build (rules : Bsb_ninja_rule.builtin)
   in
   let filename_sans_extension = module_info.name_sans_extension in
   let input_impl =
-    Bsb_config.proj_rel (filename_sans_extension ^ config.impl)
+    Format.asprintf "%s%s" (basename filename_sans_extension) config.impl
   in
   let input_intf =
-    Bsb_config.proj_rel (filename_sans_extension ^ config.intf)
+    Format.asprintf "%s%s" (basename filename_sans_extension) config.intf
   in
   let output_ast = filename_sans_extension ^ Literals.suffix_ast in
   let output_iast = filename_sans_extension ^ Literals.suffix_iast in
@@ -106,7 +106,7 @@ let emit_module_build (rules : Bsb_ninja_rule.builtin)
   let output_iast = rel_proj_dir // (intf_dir // basename output_iast) in
   let ppx_deps =
     if ppx_config.Bsb_config_types.ppxlib <> [] then
-      [ rel_proj_dir // Literals.melange_eobjs_dir // Bsb_config.ppx_exe ]
+      [ rel_proj_dir // Bsb_config.artifacts_dir // Bsb_config.ppx_exe ]
     else []
   in
   let output_d =
@@ -123,7 +123,7 @@ let emit_module_build (rules : Bsb_ninja_rule.builtin)
   let maybe_gentype_deps =
     Option.map
       (fun _ ->
-        [ rel_proj_dir // Bsb_config.lib_bs // Literals.sourcedirs_meta ])
+        [ rel_proj_dir // Bsb_config.artifacts_dir // Literals.sourcedirs_meta ])
       gentype_config
   in
   let output_js =
@@ -133,9 +133,8 @@ let emit_module_build (rules : Bsb_ninja_rule.builtin)
   if which <> `intf then (
     Bsb_ninja_targets.output_build cur_dir buf
       ~implicit_deps:(Option.value ~default:[] maybe_gentype_deps @ ppx_deps)
-      ~outputs:[ output_ast ]
-      ~inputs:[ basename input_impl ]
-      ~rule:rules.build_ast ~error_syntax_kind;
+      ~outputs:[ output_ast ] ~inputs:[ input_impl ] ~rule:rules.build_ast
+      ~error_syntax_kind;
 
     Bsb_ninja_targets.output_build cur_dir buf ~outputs:[ output_d ]
       ~inputs:
@@ -146,7 +145,7 @@ let emit_module_build (rules : Bsb_ninja_rule.builtin)
     | Some ns ->
         [
           Ext_path.rel_normalized_absolute_path ~from:(per_proj_dir // cur_dir)
-            (per_proj_dir // Bsb_config.lib_bs)
+            (per_proj_dir // Bsb_config.artifacts_dir)
           // (ns ^ Literals.suffix_cmi);
         ]
     | None -> []
@@ -166,9 +165,8 @@ let emit_module_build (rules : Bsb_ninja_rule.builtin)
   in
   if has_intf_file && which <> `impl then (
     Bsb_ninja_targets.output_build cur_dir buf ~outputs:[ output_iast ]
-      ~implicit_deps:ppx_deps
-      ~inputs:[ basename input_intf ]
-      ~rule:rules.build_ast ~error_syntax_kind;
+      ~implicit_deps:ppx_deps ~inputs:[ input_intf ] ~rule:rules.build_ast
+      ~error_syntax_kind;
 
     Bsb_ninja_targets.output_build cur_dir buf
       ~implicit_deps:[ output_d_as_dep ] ~outputs:[ output_cmi ]

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -53,7 +53,6 @@ let output_ninja_and_namespace_map
     ~package_kind
     ({
       package_name;
-      external_includes;
       bsc_flags ;
       pp_file;
       ppx_config ;
@@ -73,7 +72,6 @@ let output_ninja_and_namespace_map
 
     } : Bsb_config_types.t) : unit
   =
-  let lib_artifacts_dir = Bsb_config.lib_bs in
   let warnings = Bsb_warning.to_bsb_string ~package_kind warning in
   let bsc_flags = (get_bsc_flags bsc_flags) in
   let bs_groups : Bsb_db.t = {lib = Map_string.empty; dev = Map_string.empty} in
@@ -100,7 +98,6 @@ let output_ninja_and_namespace_map
       ~g_dev_incls:source_dirs.dev
       ~g_sourcedirs_incls:source_dirs.lib
       ~g_lib_incls:(bsc_lib_includes bs_dependencies)
-      ~external_incls:external_includes
       ~gentypeconfig:(Ext_option.map gentype_config (fun x ->
           ("-bs-gentype " ^ x.path)))
       ~ppx_config
@@ -151,7 +148,7 @@ let output_ninja_and_namespace_map
   Buffer.add_char buf '\n';
   Ext_option.iter namespace (fun ns ->
       let namespace_dir =
-        Ext_path.rel_normalized_absolute_path ~from:root_dir (per_proj_dir // lib_artifacts_dir)
+        Ext_path.rel_normalized_absolute_path ~from:root_dir (per_proj_dir // Bsb_config.artifacts_dir)
       in
       Bsb_namespace_map_gen.output
         ~dir:namespace_dir ns

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -33,7 +33,6 @@ type t = {
   g_dpkg_incls : string list;
   g_dev_incls : string list;
   g_lib_incls : string list;
-  external_incls : string list;
   g_sourcedirs_incls : string list;
   gentypeconfig : string option;
   pp_flags : string option;
@@ -42,8 +41,8 @@ type t = {
 }
 
 let make ~db ~package_name ~per_proj_dir ~bsc ~bsdep ~warnings ~bsc_flags
-    ~g_dpkg_incls ~g_dev_incls ~g_lib_incls ~external_incls ~g_sourcedirs_incls
-    ~gentypeconfig ~pp_flags ~ppx_config ~namespace =
+    ~g_dpkg_incls ~g_dev_incls ~g_lib_incls ~g_sourcedirs_incls ~gentypeconfig
+    ~pp_flags ~ppx_config ~namespace =
   {
     db;
     package_name;
@@ -55,7 +54,6 @@ let make ~db ~package_name ~per_proj_dir ~bsc ~bsdep ~warnings ~bsc_flags
     g_dpkg_incls;
     g_dev_incls;
     g_lib_incls;
-    external_incls;
     g_sourcedirs_incls;
     gentypeconfig;
     pp_flags;

--- a/jscomp/bsb/bsb_ninja_regen.ml
+++ b/jscomp/bsb/bsb_ninja_regen.ml
@@ -30,7 +30,7 @@ let ( // ) = Ext_path.combine
 *)
 let regenerate_ninja ~config ~(package_kind : Bsb_package_kind.t) ~buf ~root_dir
     per_proj_dir : unit =
-  let artifacts_dir = per_proj_dir // Bsb_config.lib_bs in
+  let artifacts_dir = per_proj_dir // Bsb_config.artifacts_dir in
   (* create directory, lib/bs, lib/js, lib/es6 etc *)
   Bsb_build_util.mkp artifacts_dir;
   (* PR2184: we still need record empty dir

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -80,15 +80,6 @@ type builtin = {
   customs : t Map_string.t
 }
 
-let external_includes (global_config : Bsb_ninja_global_vars.t) =
-  (* for external includes, if it is absolute path, leave it as is
-     for relative path './xx', we need '../.././x' since we are in
-     [lib/bs], [build] is different from merlin though
-  *)
-  Ext_list.map
-    global_config.external_incls
-    (fun x -> if Filename.is_relative x then Bsb_config.rev_lib_bs_prefix x else x)
-
 let make_custom_rules
   ~(global_config : Bsb_ninja_global_vars.t)
   ~(has_postbuild : string option)
@@ -138,8 +129,6 @@ let make_custom_rules
     Buffer.add_string buf (rel_incls global_config.g_sourcedirs_incls);
     Buffer.add_string buf " ";
     Buffer.add_string buf (rel_incls ?namespace:global_config.namespace global_config.g_lib_incls);
-    Buffer.add_string buf " ";
-    Buffer.add_string buf (rel_incls (external_includes global_config));
     if is_dev then begin
       Buffer.add_string buf " ";
       Buffer.add_string buf (rel_incls global_config.g_dpkg_incls);

--- a/jscomp/bsb/bsb_package_specs.ml
+++ b/jscomp/bsb/bsb_package_specs.ml
@@ -159,7 +159,7 @@ let get_list_of_output_js (package_specs : t)
         Ext_namespace.change_ext_ns_suffix output_file_sans_extension
           (Ext_js_suffix.to_string spec.suffix)
       in
-      (Bsb_config.rev_lib_bs_prefix basename, spec.in_source) :: acc)
+      (basename, spec.in_source) :: acc)
     package_specs.modules []
 
 type json_map = Ext_json_types.t Map_string.t

--- a/jscomp/bsb/bsb_world.ml
+++ b/jscomp/bsb/bsb_world.ml
@@ -25,7 +25,7 @@
 let ( // ) = Ext_path.combine
 
 let install_targets cwd dep_configs =
-  let artifacts_dir = cwd // Bsb_config.lib_bs in
+  let artifacts_dir = cwd // Bsb_config.artifacts_dir in
   Bsb_log.info "@{<info>Installing started@}@.";
   let file_groups = ref [] in
   Ext_list.iter dep_configs (fun (dep_config : Bsb_config_types.t) ->

--- a/jscomp/bsb/dune
+++ b/jscomp/bsb/dune
@@ -3,6 +3,7 @@
  (preprocess
   (action
    (run %{bin:cppo} %{env:CPPO_FLAGS=} %{input-file})))
+ (modules_without_implementation bsb_config_types)
  (flags
   (:standard -w -9-50))
  (libraries bsb_helper bs_hash_stubs ext common str unix))

--- a/jscomp/build_tests/monorepo/bsconfig.json
+++ b/jscomp/build_tests/monorepo/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "warnerror",
+  "name": "monorepo-test",
   "version": "0.1.0",
   "sources": [],
   "bs-dependencies": [


### PR DESCRIPTION
- Remove the `bs-external-includes` option, but emit a warning saying it's not supported
  - because we use dune, there are better ways of supporting external includes
- Clean up the `Bsb_config` module, we need way less stuff here