### PR TITLE
Fix a few bugs in `Ext_path.concat`

### DIFF
--- a/jscomp/ext/ext_path.ml
+++ b/jscomp/ext/ext_path.ml
@@ -105,23 +105,13 @@ let strip_trailing_slashes p =
 
 let concat dirname filename =
   if Ext_string.is_empty filename then dirname
-  else
-    let filename =
-      if Filename.is_implicit filename then filename
-      else if
-        String.length filename > 2
-        && String.unsafe_get filename 0 == '.'
-        && String.unsafe_get filename 1 == '/'
-      then String.sub filename 2 (String.length filename - 2)
-      else filename
-    in
-
-    if strip_trailing_slashes filename = Filename.current_dir_name then dirname
-    else if strip_trailing_slashes dirname = Filename.current_dir_name then
-      filename
-    else if strip_trailing_slashes filename = Filename.current_dir_name then
-      filename
-    else Filename.concat dirname filename
+  else if strip_trailing_slashes filename = Filename.current_dir_name then
+    dirname
+  else if strip_trailing_slashes dirname = Filename.current_dir_name then
+    filename
+  else if strip_trailing_slashes filename = Filename.current_dir_name then
+    filename
+  else Filename.concat dirname filename
 
 (***
    {[

--- a/jscomp/ext/ext_path.mli
+++ b/jscomp/ext/ext_path.mli
@@ -43,6 +43,7 @@ val combine : string -> string -> string
 *)
 
 val ( // ) : string -> string -> string
+val strip_trailing_slashes : string -> string
 
 (**
    {[

--- a/jscomp/ext/ext_string.cppo.mli
+++ b/jscomp/ext/ext_string.cppo.mli
@@ -220,3 +220,4 @@ val first_marshal_char:
 val is_valid_hash_number: string -> bool
 
 val hash_number_as_i32_exn: string -> int32
+

--- a/jscomp/ounit_tests/ounit_path_tests.ml
+++ b/jscomp/ounit_tests/ounit_path_tests.ml
@@ -153,5 +153,18 @@ let suites =
         ~to_:"lib/js/src/a/"
         ~from:"lib/js/src/a/" "b"
       =~ "./b"
-    end
+   end;
+
+
+    __LOC__ >:: begin fun _ ->
+      Ext_path.strip_trailing_slashes "hello" =~ "hello" ;
+      Ext_path.strip_trailing_slashes "hello/" =~ "hello" ;
+      Ext_path.strip_trailing_slashes "hello///" =~ "hello" ;
+      Ext_path.strip_trailing_slashes "///" =~ "/" ;
+      Ext_path.strip_trailing_slashes "/" =~ "/" ;
+    end;
+
+    __LOC__ >:: begin fun _ ->
+      Ext_path.concat "foo" "./bar" =~ "foo/bar";
+    end;
   ]

--- a/jscomp/ounit_tests/ounit_path_tests.ml
+++ b/jscomp/ounit_tests/ounit_path_tests.ml
@@ -29,7 +29,8 @@ let suites =
             "/a/";
             "/a";
             "/a.txt/";
-            "/a.txt"
+            "/a.txt";
+            "/foo/bar/./baz"
           |] in
       OUnit.assert_equal norm
         [|
@@ -42,7 +43,8 @@ let suites =
           "/a";
           "/a";
           "/a.txt";
-          "/a.txt"
+          "/a.txt";
+          "/foo/bar/baz"
         |]
     end;
     __LOC__ >:: begin fun _ ->
@@ -165,6 +167,7 @@ let suites =
     end;
 
     __LOC__ >:: begin fun _ ->
-      Ext_path.concat "foo" "./bar" =~ "foo/bar";
+      Ext_path.concat "/foo" "./bar" |> Ext_path.normalize_absolute_path =~ "/foo/bar";
+      Ext_path.concat "foo" "./bar" |> Ext_path.normalize_absolute_path =~ "./foo/bar";
     end;
   ]

--- a/jscomp/ounit_tests/ounit_string_tests.ml
+++ b/jscomp/ounit_tests/ounit_string_tests.ml
@@ -529,6 +529,5 @@ let suites =
         f "bcdef" "abcdef";
         f "" "A";
         f "Abcdef" "abcdef";
-    end
+    end;
   ]
-

--- a/shell.nix
+++ b/shell.nix
@@ -3,12 +3,22 @@
 let
   melange = pkgs.callPackage ./nix { };
   inherit (pkgs) stdenv lib;
+
+  pnpm = pkgs.writeScriptBin "pnpm" ''
+    #!${pkgs.runtimeShell}
+    ${pkgs.nodejs_latest}/bin/node \
+      ${pkgs.nodePackages_latest.pnpm}/lib/node_modules/pnpm/bin/pnpm.cjs \
+      "$@"
+  '';
+
 in
+
 with pkgs;
 
 mkShell {
   inputsFrom = [ melange ];
   buildInputs = [
+    pnpm
     python3
     nodejs-16_x
     yarn
@@ -18,4 +28,8 @@ mkShell {
     ounit2
     ocamlformat
   ]);
+
+  shellHook = ''
+    PATH=$PWD/bin:$PATH
+  '';
 }


### PR DESCRIPTION
Notably, if the result of `Ext_path.concat "foo" "./bar"` is `"foo/./bar"`, that can't be passed to `mkdirp`