### PR TITLE
Add meta.mainProgram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _opam
 node_modules
 lib/melange
 .vscode/settings.json
+bin

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -54,4 +54,6 @@ stdenv.mkDerivation rec {
     cmdliner
     luv
   ];
+
+  meta.mainProgram = "mel";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -31,5 +31,6 @@ mkShell {
 
   shellHook = ''
     PATH=$PWD/bin:$PATH
+    ln -sfn _build/install/default/bin ./bin
   '';
 }


### PR DESCRIPTION
This makes `nix run github:melange-re:melange` just work, e.g.:

```shell
$ nix run github:melange-re/melange -- build 
```