### PR TITLE
refactor: unify usage of resolve_package functions

### DIFF
--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -216,16 +216,7 @@ let rec walk_all_deps_aux (visited : string Hash_string.t) (paths : string list)
                    Ext_array.iter new_packages (fun js ->
                        match js with
                        | Str { str = new_package } ->
-                           let package_dir =
-                             match
-                               Bsb_path_resolver.resolve_import_map_package
-                                 new_package
-                             with
-                             | Some path -> path
-                             | None ->
-                                 Bsb_pkg.resolve_bs_package ~cwd:dir
-                                   (Bsb_pkg_types.string_as_package new_package)
-                           in
+                           let package_dir = Bsb_pkg.resolve_package ~cwd:dir new_package in
                            walk_all_deps_aux visited package_stacks
                              ~top:(Expect_name new_package) package_dir queue
                        | _ ->

--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -125,7 +125,7 @@ let resolve_bsb_magic_file ~cwd ~desc p : result =
       in
       (* let p = if Ext_sys.is_windows_or_cygwin then Ext_string.replace_slash_backward p else p in *)
       (* TODO: it's unclear whether we should be calling Bsb_pkg.resolve_package here instead. Let's discuss in PR #304 *)
-      let package_dir = Bsb_pkg.resolve_bs_package ~cwd package_name in
+      let package_dir = Bsb_pkg.resolve_package ~cwd (Bsb_pkg_types.to_string package_name) in
       let path = package_dir // relative_path in
       if Sys.file_exists path then { path; checked = true }
       else (

--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -124,6 +124,7 @@ let resolve_bsb_magic_file ~cwd ~desc p : result =
         else rest
       in
       (* let p = if Ext_sys.is_windows_or_cygwin then Ext_string.replace_slash_backward p else p in *)
+      (* TODO: it's unclear whether we should be calling Bsb_pkg.resolve_package here instead. Let's discuss in PR #304 *)
       let package_dir = Bsb_pkg.resolve_bs_package ~cwd package_name in
       let path = package_dir // relative_path in
       if Sys.file_exists path then { path; checked = true }

--- a/jscomp/bsb/bsb_config_parse.ml
+++ b/jscomp/bsb/bsb_config_parse.ml
@@ -27,12 +27,8 @@
 let (//) = Ext_path.combine
 
 let resolve_package cwd package_name =
+  let path = Bsb_pkg.resolve_package ~cwd package_name in
   let package = Bsb_pkg_types.string_as_package package_name in
-  let path =
-    match Bsb_path_resolver.resolve_import_map_package package_name with
-    | Some path -> path
-    | None -> Bsb_pkg.resolve_bs_package ~cwd package
-  in
   {
     Bsb_config_types.package_name = package;
     package_path = path;

--- a/jscomp/bsb/bsb_pkg.ml
+++ b/jscomp/bsb/bsb_pkg.ml
@@ -81,8 +81,6 @@ let cache : string Coll.t = Coll.create 0
 
 let to_list cb  =   
   Coll.to_list cache  cb 
-  
-
 
 (** TODO: collect all warnings and print later *)
 let resolve_bs_package ~cwd (package : t) =
@@ -102,6 +100,11 @@ let resolve_bs_package ~cwd (package : t) =
               Bsb_pkg_types.print package x result cwd;
         end;
       x
+
+let resolve_package ~cwd (package_name) =
+  match Bsb_path_resolver.resolve_import_map_package package_name with
+  | Some path -> path
+  | None -> resolve_bs_package ~cwd (Bsb_pkg_types.string_as_package package_name)
 
 
 (** The package does not need to be a bspackage

--- a/jscomp/bsb/bsb_pkg.mli
+++ b/jscomp/bsb/bsb_pkg.mli
@@ -31,6 +31,7 @@
     it relies on [npm_config_prefix] env variable for global npm modules
 *)
 
+val resolve_package : cwd:string -> string -> string
 val resolve_bs_package : cwd:string -> Bsb_pkg_types.t -> string
 (** @raise  when not found *)
 


### PR DESCRIPTION
In reference to issue #300

This unifies the resolution of packages under a single `resolve_package` function.

It'd probably be a good idea to simply remove the `bsb_path_resolver` module and put all its functionality under `bsb_pkg` instead.