### PR TITLE
Enable fully out of source builds

### DIFF
--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -70,6 +70,10 @@ let include_dirs dirs = include_dirs_by dirs Fun.id
 
 let rel_include_dirs ~package_name ~root_dir ~per_proj_dir ~cur_dir ?namespace
     source_dirs =
+  let per_proj_dir =
+    Bsb_config.virtual_proj_dir ~root_dir ~package_dir:per_proj_dir
+      ~package_name
+  in
   let relativize_single dir =
     Ext_path.rel_normalized_absolute_path ~from:(per_proj_dir // cur_dir)
       (per_proj_dir // dir)
@@ -86,18 +90,6 @@ let rel_include_dirs ~package_name ~root_dir ~per_proj_dir ~cur_dir ?namespace
     (*working dir is [lib/bs] we include this path to have namespace mapping*)
   in
   include_dirs dirs
-
-let rel_include_dirs ~package_name ~root_dir ~per_proj_dir ~cur_dir ?namespace
-    source_dirs =
-  if Bsb_config.is_dep_inside_workspace ~root_dir ~package_dir:per_proj_dir then
-    rel_include_dirs ~package_name ~root_dir ~per_proj_dir ~cur_dir ?namespace
-      source_dirs
-  else
-    let virtual_proj_dir =
-      root_dir // Bsb_config.to_workspace_proj_dir ~package_name
-    in
-    rel_include_dirs ~package_name ~root_dir ~per_proj_dir:virtual_proj_dir
-      ~cur_dir ?namespace source_dirs
 
 (* we use lazy $src_root_dir *)
 

--- a/jscomp/bsb/bsb_build_util.mli
+++ b/jscomp/bsb/bsb_build_util.mli
@@ -55,6 +55,7 @@ include_dirs [dirs]
 val include_dirs_by : 'a list -> ('a -> string) -> string
 
 val rel_include_dirs :
+  package_name:string ->
   root_dir:string ->
   per_proj_dir:string ->
   cur_dir:string ->

--- a/jscomp/bsb/bsb_config.ml
+++ b/jscomp/bsb/bsb_config.ml
@@ -36,6 +36,10 @@ let is_dep_inside_workspace ~root_dir ~package_dir =
 
 let to_workspace_proj_dir ~package_name = Literals.node_modules // package_name
 
+let virtual_proj_dir ~root_dir ~package_dir ~package_name =
+  if is_dep_inside_workspace ~root_dir ~package_dir then package_dir
+  else root_dir // to_workspace_proj_dir ~package_name
+
 let absolute_artifacts_dir ?(include_dune_build_dir = false) ~package_name
     ~root_dir proj_dir =
   if not (is_dep_inside_workspace ~root_dir ~package_dir:proj_dir) then
@@ -59,13 +63,12 @@ let absolute_artifacts_dir ?(include_dune_build_dir = false) ~package_name
 
 let rel_artifacts_dir ?include_dune_build_dir ~package_name ~root_dir ~proj_dir
     from =
-  if not (is_dep_inside_workspace ~root_dir ~package_dir:proj_dir) then
-    Ext_path.rel_normalized_absolute_path ~from
-      (root_dir // to_workspace_proj_dir ~package_name)
-  else
-    let absolute =
-      absolute_artifacts_dir ?include_dune_build_dir ~package_name ~root_dir
-        proj_dir
-    in
-    let from = if Filename.is_relative from then proj_dir // from else from in
-    Ext_path.rel_normalized_absolute_path ~from absolute
+  let proj_dir =
+    virtual_proj_dir ~root_dir ~package_dir:proj_dir ~package_name
+  in
+  let absolute =
+    absolute_artifacts_dir ?include_dune_build_dir ~package_name ~root_dir
+      proj_dir
+  in
+  let from = if Filename.is_relative from then proj_dir // from else from in
+  Ext_path.rel_normalized_absolute_path ~from absolute

--- a/jscomp/bsb/bsb_config.mli
+++ b/jscomp/bsb/bsb_config.mli
@@ -25,6 +25,9 @@
 val is_dep_inside_workspace : root_dir:string -> package_dir:string -> bool
 val to_workspace_proj_dir : package_name:string -> string
 
+val virtual_proj_dir :
+  root_dir:string -> package_dir:string -> package_name:string -> string
+
 val absolute_artifacts_dir :
   ?include_dune_build_dir:bool ->
   package_name:string ->

--- a/jscomp/bsb/bsb_config.mli
+++ b/jscomp/bsb/bsb_config.mli
@@ -22,11 +22,19 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+val is_dep_inside_workspace : root_dir:string -> package_dir:string -> bool
+val to_workspace_proj_dir : package_name:string -> string
+
 val absolute_artifacts_dir :
-  ?include_dune_build_dir:bool -> root_dir:string -> string -> string
+  ?include_dune_build_dir:bool ->
+  package_name:string ->
+  root_dir:string ->
+  string ->
+  string
 
 val rel_artifacts_dir :
   ?include_dune_build_dir:bool ->
+  package_name:string ->
   root_dir:string ->
   proj_dir:string ->
   string ->

--- a/jscomp/bsb/bsb_config_parse.ml
+++ b/jscomp/bsb/bsb_config_parse.ml
@@ -407,8 +407,9 @@ and extract_dependencies ~package_kind (map : json_map) cwd (field : string )
      in
      let ns_incl =
        Ext_option.map namespace (fun _ ->
-         let artifacts_dir = Bsb_config.absolute_artifacts_dir ~root_dir:cwd dep.package_path  in
-         artifacts_dir)
+           { Bsb_config_types.package_path = Bsb_global_paths.cwd;
+             dir = Literals.melange_eobjs_dir // Bsb_config.to_workspace_proj_dir ~package_name:(Bsb_pkg_types.to_string dep.package_name);
+             package_name = Bsb_pkg_types.to_string dep.package_name })
      in
      let dirs = Ext_list.filter_map files (fun ({ Bsb_file_groups.dir; is_dev; _ } as group) ->
         if not is_dev && not (Bsb_file_groups.is_empty group) then
@@ -417,10 +418,17 @@ and extract_dependencies ~package_kind (map : json_map) cwd (field : string )
           None)
      in
      let install_dirs = Ext_list.filter_map files (fun { Bsb_file_groups.dir; is_dev; _ } ->
-        if not is_dev then Some (dep.package_path // dir) else None)
+       if not is_dev then
+         Some {
+           Bsb_config_types.package_path = dep.package_path;
+           dir;
+           package_name  = Bsb_pkg_types.to_string dep.package_name}
+        else None)
      in
      { dep with
-       package_install_dirs = (match ns_incl with Some ns_incl -> ns_incl :: install_dirs | None -> install_dirs);
+       package_install_dirs = (match ns_incl with
+       | None -> install_dirs
+       | Some ns -> ns :: install_dirs);
        package_dirs = dirs
      })
   | Some config ->

--- a/jscomp/bsb/bsb_config_types.mli
+++ b/jscomp/bsb/bsb_config_types.mli
@@ -32,7 +32,7 @@ type dependency = {
   package_name : Bsb_pkg_types.t;
   package_path : string;
   package_dirs : string list;
-  package_install_dirs : install_dir list; (* ns_install_dir : string option; *)
+  package_install_dirs : install_dir list;
 }
 
 type dependencies = dependency list

--- a/jscomp/bsb/bsb_config_types.mli
+++ b/jscomp/bsb/bsb_config_types.mli
@@ -22,11 +22,17 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+type install_dir = {
+  package_name : string;
+  package_path : string;
+  dir : string;
+}
+
 type dependency = {
   package_name : Bsb_pkg_types.t;
   package_path : string;
   package_dirs : string list;
-  package_install_dirs : string list;
+  package_install_dirs : install_dir list; (* ns_install_dir : string option; *)
 }
 
 type dependencies = dependency list

--- a/jscomp/bsb/bsb_exception.ml
+++ b/jscomp/bsb/bsb_exception.ml
@@ -71,7 +71,7 @@ let print (fmt : Format.formatter) (x : error) =
          https://rescript-lang.org/docs/manual/latest/build-configuration-schema"
         pos.pos_fname pos.pos_lnum s
   | Invalid_spec s ->
-      Format.fprintf fmt "@{<error>Error: Invalid bsconfig.json %s@}" s
+      Format.fprintf fmt "@{<error>Error: Invalid bsconfig.json. %s@}" s
   | Invalid_json s ->
       Format.fprintf fmt
         "File %S, line 1\n@{<error>Error: Invalid json format@}" s

--- a/jscomp/bsb/bsb_ninja_file_groups.ml
+++ b/jscomp/bsb/bsb_ninja_file_groups.ml
@@ -34,19 +34,13 @@ let rel_dependencies_alias ~root_dir ~proj_dir ~cur_dir deps =
             (* We don't emit the `mel` alias for the artifacts directory *)
             None
           else
+            let virtual_package_dir =
+              Bsb_config.virtual_proj_dir ~root_dir ~package_dir:package_path
+                ~package_name
+            in
             let rel_dir =
-              if
-                Bsb_config.is_dep_inside_workspace ~root_dir
-                  ~package_dir:package_path
-              then
-                Ext_path.rel_normalized_absolute_path
-                  ~from:(proj_dir // cur_dir) (package_path // dir)
-              else
-                let virtual_package_dir =
-                  root_dir // Bsb_config.to_workspace_proj_dir ~package_name
-                in
-                Ext_path.rel_normalized_absolute_path ~from:(proj_dir // cur_dir)
-                  (virtual_package_dir // dir)
+              Ext_path.rel_normalized_absolute_path ~from:(proj_dir // cur_dir)
+                (virtual_package_dir // dir)
             in
             Some (rel_dir // Literals.mel_dune_alias)))
 

--- a/jscomp/bsb/bsb_ninja_file_groups.mli
+++ b/jscomp/bsb/bsb_ninja_file_groups.mli
@@ -23,7 +23,11 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 val rel_dependencies_alias :
-  proj_dir:string -> cur_dir:string -> string list -> string list
+  root_dir:string ->
+  proj_dir:string ->
+  cur_dir:string ->
+  Bsb_config_types.dependency list ->
+  string list
 
 val handle_files_per_dir :
   Buffer.t ->
@@ -32,7 +36,7 @@ val handle_files_per_dir :
   package_specs:Bsb_package_specs.t ->
   js_post_build_cmd:string option ->
   files_to_install:Bsb_db.module_info Queue.t ->
-  bs_dependencies:string list ->
-  bs_dev_dependencies:string list ->
+  bs_dependencies:Bsb_config_types.dependency list ->
+  bs_dev_dependencies:Bsb_config_types.dependency list ->
   Bsb_file_groups.file_group ->
   unit

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -37,15 +37,10 @@ let bsc_lib_includes ~root_dir (bs_dependencies : Bsb_config_types.dependencies)
   Ext_list.flat_map bs_dependencies (fun { package_install_dirs; _ } ->
     Ext_list.map package_install_dirs
       (fun { Bsb_config_types.package_path; package_name; dir } ->
-          if
-            Bsb_config.is_dep_inside_workspace ~root_dir
-              ~package_dir:package_path
-          then (package_path // dir)
-          else
-            let virtual_proj_dir =
-              root_dir // Bsb_config.to_workspace_proj_dir ~package_name
-            in
-            (virtual_proj_dir // dir)))
+        let virtual_proj_dir =
+          Bsb_config.virtual_proj_dir ~root_dir ~package_dir:package_path ~package_name
+        in
+        (virtual_proj_dir // dir)))
 
 let output_ninja_and_namespace_map
     ~buf
@@ -150,18 +145,9 @@ let output_ninja_and_namespace_map
   Buffer.add_char buf '\n';
 
   let artifacts_dir =
-    if Bsb_config.is_dep_inside_workspace ~root_dir ~package_dir:per_proj_dir
-    then
     Bsb_config.rel_artifacts_dir
       ~package_name
       ~root_dir ~proj_dir:per_proj_dir root_dir
-    else
-      let virtual_proj_dir =
-        root_dir // Bsb_config.to_workspace_proj_dir ~package_name
-      in
-    Bsb_config.rel_artifacts_dir
-      ~package_name
-      ~root_dir ~proj_dir:virtual_proj_dir root_dir
   in
 
   Buffer.add_string buf "(subdir ";

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -26,17 +26,26 @@
    it is a bad idea to copy package.json which requires to copy js files
 *)
 
-let dependencies_directories deps =
-  Ext_list.flat_map deps (fun { Bsb_config_types.package_dirs; _ } -> package_dirs)
-
+let (//) = Ext_path.concat
 
 let get_bsc_flags
     (bsc_flags : string list)
   : string =
   String.concat Ext_string.single_space bsc_flags
 
-let bsc_lib_includes (bs_dependencies : Bsb_config_types.dependencies) =
-  (Ext_list.flat_map bs_dependencies (fun x -> x.package_install_dirs))
+let bsc_lib_includes ~root_dir (bs_dependencies : Bsb_config_types.dependencies) =
+  Ext_list.flat_map bs_dependencies (fun { package_install_dirs; _ } ->
+    Ext_list.map package_install_dirs
+      (fun { Bsb_config_types.package_path; package_name; dir } ->
+          if
+            Bsb_config.is_dep_inside_workspace ~root_dir
+              ~package_dir:package_path
+          then (package_path // dir)
+          else
+            let virtual_proj_dir =
+              root_dir // Bsb_config.to_workspace_proj_dir ~package_name
+            in
+            (virtual_proj_dir // dir)))
 
 let output_ninja_and_namespace_map
     ~buf
@@ -87,10 +96,10 @@ let output_ninja_and_namespace_map
       ~bsdep:(Ext_filename.maybe_quote Bsb_global_paths.vendor_bsdep)
       ~warnings
       ~bsc_flags
-      ~g_dpkg_incls:(bsc_lib_includes bs_dev_dependencies)
+      ~g_dpkg_incls:(bsc_lib_includes ~root_dir bs_dev_dependencies)
       ~g_dev_incls:source_dirs.dev
       ~g_sourcedirs_incls:source_dirs.lib
-      ~g_lib_incls:(bsc_lib_includes bs_dependencies)
+      ~g_lib_incls:(bsc_lib_includes ~root_dir bs_dependencies)
       ~gentypeconfig:(Ext_option.map gentype_config (fun x ->
           ("-bs-gentype " ^ x.path)))
       ~ppx_config
@@ -113,12 +122,6 @@ let output_ninja_and_namespace_map
       ~reason_react_jsx
       ~package_specs
       generators in
-  let bs_dependencies =
-    dependencies_directories bs_dependencies
-  in
-  let bs_dev_dependencies =
-    dependencies_directories bs_dev_dependencies
-  in
   Buffer.add_char buf '\n';
 
   (* output_static_resources static_resources rules.copy_resources oc ; *)
@@ -133,15 +136,34 @@ let output_ninja_and_namespace_map
          ~js_post_build_cmd
          ~bs_dev_dependencies
          ~bs_dependencies
-         files_per_dir)
-  ;
+         files_per_dir);
+
+  if not (Bsb_config.is_dep_inside_workspace ~root_dir ~package_dir:per_proj_dir) then (
+    Buffer.add_string buf "(subdir ";
+    Buffer.add_string buf (Bsb_config.to_workspace_proj_dir ~package_name);
+    Buffer.add_string buf
+      "\n (copy_files (alias mel_copy_out_of_source_dir)\n (files ";
+    Buffer.add_string buf (per_proj_dir);
+    Buffer.add_string buf Filename.dir_sep;
+    Buffer.add_string buf "*)))");
 
   Buffer.add_char buf '\n';
 
   let artifacts_dir =
+    if Bsb_config.is_dep_inside_workspace ~root_dir ~package_dir:per_proj_dir
+    then
     Bsb_config.rel_artifacts_dir
+      ~package_name
       ~root_dir ~proj_dir:per_proj_dir root_dir
+    else
+      let virtual_proj_dir =
+        root_dir // Bsb_config.to_workspace_proj_dir ~package_name
+      in
+    Bsb_config.rel_artifacts_dir
+      ~package_name
+      ~root_dir ~proj_dir:virtual_proj_dir root_dir
   in
+
   Buffer.add_string buf "(subdir ";
   Buffer.add_string buf artifacts_dir;
 
@@ -175,6 +197,7 @@ let output_ninja_and_namespace_map
     (* Build the dependencies in case `"sources"` == []. *)
     Ext_list.iter
       (Bsb_ninja_file_groups.rel_dependencies_alias
+        ~root_dir:root_dir
         ~proj_dir:root_dir
         ~cur_dir:root_dir
         bs_dependencies)

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -90,6 +90,7 @@ let make_custom_rules
   (** FIXME: We don't need set [-o ${out}] when building ast
       since the default is already good -- it does not*)
   (** NOTE(anmonteiro): The above comment is false, namespace needs `-o` *)
+let package_name = global_config.package_name in
   let ns_flag =
     match global_config.namespace with None -> ""
     | Some n -> " -bs-ns " ^ n in
@@ -102,12 +103,15 @@ let make_custom_rules
       ?(target="%{targets}")
       cur_dir =
     let rel_incls ?namespace dirs =
-      Bsb_build_util.rel_include_dirs
+      let ret = Bsb_build_util.rel_include_dirs
+        ~package_name
         ~root_dir:global_config.root_dir
         ~per_proj_dir:global_config.per_proj_dir
         ~cur_dir
         ?namespace
         dirs
+      in
+      ret
     in
     Buffer.add_string buf "(action\n ";
     Buffer.add_string buf " (run ";
@@ -160,6 +164,7 @@ let make_custom_rules
   let mk_ast buf ?error_syntax_kind:_ ?target:_ cur_dir : unit =
     let rel_artifacts_dir =
       Bsb_config.rel_artifacts_dir
+        ~package_name
         ~root_dir:global_config.root_dir
         ~proj_dir:global_config.per_proj_dir
       cur_dir
@@ -206,10 +211,11 @@ let make_custom_rules
     define
       ~command:(fun buf ?error_syntax_kind:_ ?target:_ cur_dir ->
         let s =
-          Format.asprintf "(action (run %s -root-dir %s -cwd %s -proj-dir %s %s %%{inputs}))"
+          Format.asprintf "(action (run %s -root-dir %s -cwd %s -p %s -proj-dir %s %s %%{inputs}))"
             global_config.bsdep
             global_config.root_dir
             cur_dir
+            package_name
             global_config.per_proj_dir
             ns_flag
         in
@@ -219,10 +225,11 @@ let make_custom_rules
     define
       ~command:(fun buf ?error_syntax_kind:_ ?target:_ cur_dir ->
         let s =
-          Format.asprintf "(action (run %s -root-dir %s -g -cwd %s -proj-dir %s %s %%{inputs}))"
+          Format.asprintf "(action (run %s -root-dir %s -g -cwd %s -p %s -proj-dir %s %s %%{inputs}))"
             global_config.bsdep
             global_config.root_dir
             cur_dir
+            package_name
             global_config.per_proj_dir
             ns_flag
         in

--- a/jscomp/bsb/bsb_ninja_targets.ml
+++ b/jscomp/bsb/bsb_ninja_targets.ml
@@ -22,9 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-let enabled_if =
-  Format.asprintf "(enabled_if %%{bin-available:melc})"
-
+let enabled_if = Format.asprintf "(enabled_if %%{bin-available:melc})"
 let dune_header = ";;;;{BSB GENERATED: NO EDIT"
 let dune_trailer = ";;;;BSB GENERATED: NO EDIT}"
 let dune_trailer_length = String.length dune_trailer

--- a/jscomp/bsb/bsb_package_specs.ml
+++ b/jscomp/bsb/bsb_package_specs.ml
@@ -41,6 +41,9 @@ type t = {
       *)
 }
 
+let has_in_source t =
+  Spec_set.exists (fun { in_source; _ } -> in_source) t.modules
+
 let ( .?() ) = Map_string.find_opt
 
 let bad_module_format_message_exn ~loc format =

--- a/jscomp/bsb/bsb_package_specs.mli
+++ b/jscomp/bsb/bsb_package_specs.mli
@@ -1,5 +1,5 @@
 (* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -31,3 +31,5 @@ val package_flag_of_package_specs : t -> dirname:string -> string
 (**
   Sample output: {[ -bs-package-output commonjs:lib/js/jscomp/test]}
 *)
+
+val has_in_source : t -> bool

--- a/jscomp/bsb/bsb_pkg.ml
+++ b/jscomp/bsb/bsb_pkg.ml
@@ -27,16 +27,16 @@ let (//) = Filename.concat
 
 type t = Bsb_pkg_types.t
 
-(* TODO: be more restrict 
-  [bsconfig.json] does not always make sense, 
+(* TODO: be more restrict
+  [bsconfig.json] does not always make sense,
   when resolving [ppx-flags]
 *)
-let make_sub_path (x : t) : string = 
+let make_sub_path (x : t) : string =
   Literals.node_modules // Bsb_pkg_types.to_string x
 
-let node_paths : string list Lazy.t =     
+let node_paths : string list Lazy.t =
   lazy (try Ext_string.split (Sys.getenv "NODE_PATH")
-              (if Sys.win32 then ';' else ':')   
+              (if Sys.win32 then ';' else ':')
         with _ -> [])
 (** It makes sense to have this function raise, when [bsb] could not resolve a package, it used to mean
     a failure
@@ -50,7 +50,8 @@ let  resolve_bs_package_aux  ~cwd (pkg : t) =
   (* First try to resolve recursively from the current working directory  *)
   let sub_path = make_sub_path pkg   in
   let rec aux  cwd  =
-    let abs_marker =  cwd // sub_path in
+    let abs_marker = Ext_path.normalize_absolute_path (cwd // sub_path) in
+
     if Sys.file_exists abs_marker then abs_marker
     else
       let another_cwd = Filename.dirname cwd in (* TODO: may non-terminating when see symlinks *)
@@ -59,28 +60,29 @@ let  resolve_bs_package_aux  ~cwd (pkg : t) =
       else (* To the end try other possiblilities [NODE_PATH]*)
         (match Ext_list.find_opt (Lazy.force node_paths)
                  (fun dir -> check_dir (dir // Bsb_pkg_types.to_string pkg))  with
-        | Some(resolved_dir) -> resolved_dir
-        | None -> Bsb_exception.package_not_found ~pkg ~json:None)    
+        | Some(resolved_dir) ->
+            resolved_dir
+        | None -> Bsb_exception.package_not_found ~pkg ~json:None)
   in
-   aux cwd 
-    
-    
-    
-    
-    
+   aux cwd
+
+
+
+
+
 
 module Coll = Hash.Make(struct
-  type nonrec t = t 
+  type nonrec t = t
   let equal = Bsb_pkg_types.equal
-  let hash (x : t) = Hashtbl.hash x     
+  let hash (x : t) = Hashtbl.hash x
 end)
 
 
 let cache : string Coll.t = Coll.create 0
 
 
-let to_list cb  =   
-  Coll.to_list cache  cb 
+let to_list cb  =
+  Coll.to_list cache  cb
 
 (** TODO: collect all warnings and print later *)
 let resolve_bs_package ~cwd (package : t) =
@@ -96,7 +98,7 @@ let resolve_bs_package ~cwd (package : t) =
       if not (Bsb_real_path.is_same_paths_via_io result x) then
         begin
           Bsb_log.warn
-            "@{<warning>Duplicated package:@} %a %s (chosen) vs %s in %s @." 
+            "@{<warning>Duplicated package:@} %a %s (chosen) vs %s in %s @."
               Bsb_pkg_types.print package x result cwd;
         end;
       x
@@ -116,7 +118,7 @@ let resolve_package ~cwd (package_name) =
     It also returns the path name
     Note the input [sub_path] is already converted to physical meaning path according to OS
 *)
-(* let resolve_npm_package_file ~cwd sub_path = *) 
+(* let resolve_npm_package_file ~cwd sub_path = *)
 (*   let rec aux  cwd  =  *)
 (*     let abs_marker =  cwd // Literals.node_modules // sub_path in  *)
 (*     if Sys.file_exists abs_marker then Some abs_marker *)

--- a/jscomp/bsb/bsb_world.ml
+++ b/jscomp/bsb/bsb_world.ml
@@ -26,7 +26,8 @@ let ( // ) = Ext_path.combine
 
 let install_targets cwd dep_configs =
   let artifacts_dir =
-    Bsb_config.rel_artifacts_dir ~root_dir:cwd ~proj_dir:cwd cwd
+    Bsb_config.rel_artifacts_dir ~package_name:"root"
+      ~include_dune_build_dir:true ~root_dir:cwd ~proj_dir:cwd cwd
   in
   Bsb_log.info "@{<info>Installing started@}@.";
   let file_groups = ref [] in

--- a/jscomp/bsb_helper/bsb_helper_depfile_gen.ml
+++ b/jscomp/bsb_helper/bsb_helper_depfile_gen.ml
@@ -102,10 +102,17 @@ let process_deps_for_dune ~proj_dir ~cur_dir deps =
   in
   String.concat " " rel_deps
 
-let emit_d ~root_dir ~cur_dir ~proj_dir ~(is_dev : bool)
+let emit_d ~package_name ~root_dir ~cur_dir ~proj_dir ~(is_dev : bool)
     (namespace : string option) (mlast : string) (mliast : string) =
   let rel_artifacts_dir =
-    Bsb_config.rel_artifacts_dir ~root_dir ~proj_dir cur_dir
+    if Bsb_config.is_dep_inside_workspace ~root_dir ~package_dir:proj_dir then
+      Bsb_config.rel_artifacts_dir ~package_name ~root_dir ~proj_dir cur_dir
+    else
+      let virtual_proj_dir =
+        root_dir // Bsb_config.to_workspace_proj_dir ~package_name
+      in
+      Bsb_config.rel_artifacts_dir ~root_dir ~package_name
+        ~proj_dir:virtual_proj_dir cur_dir
   in
   let data = Bsb_db_decode.read_build_cache ~dir:rel_artifacts_dir in
   let deps = ref Set_string.empty in

--- a/jscomp/bsb_helper/bsb_helper_depfile_gen.ml
+++ b/jscomp/bsb_helper/bsb_helper_depfile_gen.ml
@@ -105,14 +105,7 @@ let process_deps_for_dune ~proj_dir ~cur_dir deps =
 let emit_d ~package_name ~root_dir ~cur_dir ~proj_dir ~(is_dev : bool)
     (namespace : string option) (mlast : string) (mliast : string) =
   let rel_artifacts_dir =
-    if Bsb_config.is_dep_inside_workspace ~root_dir ~package_dir:proj_dir then
-      Bsb_config.rel_artifacts_dir ~package_name ~root_dir ~proj_dir cur_dir
-    else
-      let virtual_proj_dir =
-        root_dir // Bsb_config.to_workspace_proj_dir ~package_name
-      in
-      Bsb_config.rel_artifacts_dir ~root_dir ~package_name
-        ~proj_dir:virtual_proj_dir cur_dir
+    Bsb_config.rel_artifacts_dir ~package_name ~root_dir ~proj_dir cur_dir
   in
   let data = Bsb_db_decode.read_build_cache ~dir:rel_artifacts_dir in
   let deps = ref Set_string.empty in

--- a/jscomp/bsb_helper/bsb_helper_depfile_gen.mli
+++ b/jscomp/bsb_helper/bsb_helper_depfile_gen.mli
@@ -23,6 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 val emit_d :
+  package_name:string ->
   root_dir:string ->
   cur_dir:string ->
   proj_dir:string ->

--- a/jscomp/main/meldep.ml
+++ b/jscomp/main/meldep.ml
@@ -45,6 +45,12 @@ let namespace =
   let docv = "namespace" in
   Arg.(value & opt (some string) None & info [ "n"; "bs-ns" ] ~doc ~docv)
 
+let package_name =
+  let doc = "Melange namespace for the current dependency" in
+  let docv = "namespace" in
+  Arg.(
+    required & opt (some string) None & info [ "p"; "package-name" ] ~doc ~docv)
+
 let dev =
   let doc = "Whether we're building in dev mode" in
   Arg.(value & flag & info [ "g" ] ~doc)
@@ -53,19 +59,21 @@ let filenames =
   let docv = "filenames" in
   Arg.(value & pos_all string [] & info [] ~docv)
 
-let main root_dir proj_dir cwd namespace is_dev filenames =
+let main root_dir proj_dir cwd namespace package_name is_dev filenames =
   let impl, intf =
     match filenames with
     | [ impl; intf ] -> (impl, intf)
     | [ impl ] -> (impl, "")
     | _ -> assert false
   in
-  Bsb_helper_depfile_gen.emit_d ~root_dir ~proj_dir ~cur_dir:cwd ~is_dev
-    namespace impl intf
+  Bsb_helper_depfile_gen.emit_d ~package_name ~root_dir ~proj_dir ~cur_dir:cwd
+    ~is_dev namespace impl intf
 
 let cmd =
   let term =
-    Term.(const main $ root_dir $ proj_dir $ cwd $ namespace $ dev $ filenames)
+    Term.(
+      const main $ root_dir $ proj_dir $ cwd $ namespace $ package_name $ dev
+      $ filenames)
   in
   let info = Cmd.info "meldep" in
   Cmd.v info term


### PR DESCRIPTION
### Problem statement

Tools like [Yarn PnP](https://yarnpkg.com/features/pnp) and the [`NODE_PATH` environment variable](https://nodejs.org/api/modules.html#loading-from-the-global-folders) enable module resolution outside of the workspace (in contrast with the familar `node_modules` folder in the root directory).

Melange used to generate some build artifacts in-source before #296. That produces an error if those directories are read-only (in e.g. Nix, they are).

### Solution in this PR

After #296 and #302, we no longer write any artifacts to dependency directories, and only write the `dune.mel` file in the workspace directory.

- Not writing any artifacts to the dependency directories is the first step
- However, Dune will refuse to build anything outside the workspace
  - This PR creates a "virtual filesystem" within Dune rules (using `copy_files`, `subdir` and `data_only_dirs`) that builds the requested dependencies into `<DUNE_BUILD_DIR>/node_modules/package_name/`.

A quick example of the generated rules:

```lisp
(subdir node_modules/my-reason-package/src
 (copy_files
  (files
   /some/absolute/path/my-reason-package/src/*)))
```

After that, it's just a matter of tracking the relative paths to `<workspace-root>/node_modules/my-reason-package`, and voilà! All intermediate and final JS build outputs will end up in the Dune build folder.

This fixes #279.

### TODOs:
- [x] Lift the virtual project directory logic to `Bsb_config`
- [x] Detect whether `in-source` is true and there are dependencies outside the workspace
  - It might be possible to support this use case but it's a little grey area that I'll explore later. It makes sense to just error out for now.
