### PR TITLE
lam: convert first then match, helps when Levent

### DIFF
--- a/jscomp/core/lam_convert.ml
+++ b/jscomp/core/lam_convert.ml
@@ -37,7 +37,7 @@ let lazy_block_info : Lam_tag_info.t =
 let unbox_extension info (args : Lam.t list) mutable_flag loc =
   prim ~primitive:(Pmakeblock (0, info, mutable_flag)) ~args loc
 
-(** A conservative approach to avoid packing exceptions
+(* A conservative approach to avoid packing exceptions
     for lambda expression like {[
       try { ... }catch(id){body}
     ]}
@@ -116,7 +116,7 @@ let no_over_flow_int32 x = Int32.abs x < 0x1fff_ffffl
 let lam_is_var (x : Lam.t) (y : Ident.t) =
   match x with Lvar y2 | Lmutvar y2 -> Ident.same y2 y | _ -> false
 
-(** Make sure no int range overflow happens
+(* Make sure no int range overflow happens
     also we only check [int]
 *)
 let happens_to_be_diff (sw_consts : (int * Lam.t) list) : int32 option =
@@ -145,9 +145,9 @@ let happens_to_be_diff (sw_consts : (int * Lam.t) list) : int32 option =
 
 (* type required_modules = Lam_module_ident.Hash_set.t *)
 
-(** drop Lseq (List! ) etc
-  see #3852, we drop all these required global modules
-  but added it back based on our own module analysis
+(* drop Lseq (List! ) etc
+   see #3852, we drop all these required global modules
+   but added it back based on our own module analysis
 *)
 let rec drop_global_marker (lam : Lam.t) =
   match lam with
@@ -847,7 +847,7 @@ let convert (exports : Set_ident.t) (lam : Lambda.lambda) :
   in
   (convert_aux lam, may_depends)
 
-(** FIXME: more precise analysis of [id], if it is not
+(* FIXME: more precise analysis of [id], if it is not
     used, we can remove it
         only two places emit [Lifused],
         {[
@@ -863,7 +863,7 @@ let convert (exports : Set_ident.t) (lam : Lambda.lambda) :
 
         | Lifused(v, l) ->
           if count_var v > 0 then simplif l else lambda_unit
-      *)
+*)
 
 (*
         | Lfunction(kind,params,Lprim(prim,inner_args,inner_loc))

--- a/jscomp/core/lam_convert.ml
+++ b/jscomp/core/lam_convert.ml
@@ -22,22 +22,26 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-let caml_id_field_info : Lambda.field_dbg_info =
-  Fld_record { name = Literals.exception_id; mutable_flag = Immutable }
 
-let lam_caml_id : Lam_primitive.t = Pfield (0, caml_id_field_info)
+let caml_id_field_info : Lambda.field_dbg_info = Fld_record {name = Literals.exception_id; mutable_flag = Immutable;}
+let lam_caml_id : Lam_primitive.t = Pfield(0, caml_id_field_info)
+
 let prim = Lam.prim
 
+
 let lam_extension_id loc (head : Lam.t) =
-  prim ~primitive:lam_caml_id ~args:[ head ] loc
+  prim ~primitive:lam_caml_id ~args:[head] loc
 
 let lazy_block_info : Lam_tag_info.t =
-  Blk_record [| Literals.lazy_done; Literals.lazy_val |]
+  Blk_record
+    [|Literals.lazy_done;
+      Literals.lazy_val|]
 
 let unbox_extension info (args : Lam.t list) mutable_flag loc =
-  prim ~primitive:(Pmakeblock (0, info, mutable_flag)) ~args loc
+    prim ~primitive:(Pmakeblock (0,info,mutable_flag)) ~args loc
 
-(* A conservative approach to avoid packing exceptions
+
+(** A conservative approach to avoid packing exceptions
     for lambda expression like {[
       try { ... }catch(id){body}
     ]}
@@ -66,226 +70,283 @@ let unbox_extension info (args : Lam.t list) mutable_flag loc =
     It is hard to judge an exception is destructed or escaped, any potential
     alias(or if it is passed as an argument) would cause it to be leaked
 *)
-let exception_id_destructed (l : Lam.t) (fv : Ident.t) : bool =
-  let rec hit_opt (x : _ option) =
-    match x with None -> false | Some a -> hit a
-  and hit_list_snd : 'a. ('a * _) list -> bool =
-   fun x -> Ext_list.exists_snd x hit
+let exception_id_destructed (l : Lam.t) (fv : Ident.t): bool  =
+  let rec
+    hit_opt (x : _ option) =
+  match x with
+  | None -> false
+  | Some a -> hit a
+  and hit_list_snd : 'a. ('a * _ ) list -> bool = fun x ->
+    Ext_list.exists_snd  x  hit
   and hit_list xs = Ext_list.exists xs hit
   and hit (l : Lam.t) =
-    match l with
+    match l  with
     (* | Lprim {primitive = Pintcomp _ ;
-              args = ([x;y ])  } ->
-       begin match x,y with
-         | Lvar _, Lvar _ -> false
-         | Lvar _, _ -> hit y
-         | _, Lvar _ -> hit x
-         | _, _  -> hit x || hit y
-       end *)
-    (* FIXME: this can be uncovered after we do the unboxing *)
-    | Lprim { primitive = Praise; args = [ Lvar _ ] } -> false
-    | Lprim { primitive = _; args; _ } -> hit_list args
-    | Lvar id | Lmutvar id -> Ident.same id fv
-    | Lassign (id, e) -> Ident.same id fv || hit e
-    | Lstaticcatch (e1, (_, _vars), e2) -> hit e1 || hit e2
-    | Ltrywith (e1, _exn, e2) -> hit e1 || hit e2
-    | Lfunction { body; params = _ } -> hit body
-    | Llet (_, _id, arg, body) | Lmutlet (_id, arg, body) -> hit arg || hit body
-    | Lletrec (decl, body) -> hit body || hit_list_snd decl
-    | Lfor (_v, e1, e2, _dir, e3) -> hit e1 || hit e2 || hit e3
+             args = ([x;y ])  } ->
+      begin match x,y with
+        | Lvar _, Lvar _ -> false
+        | Lvar _, _ -> hit y
+        | _, Lvar _ -> hit x
+        | _, _  -> hit x || hit y
+      end *) (* FIXME: this can be uncovered after we do the unboxing *)
+    | Lprim {primitive = Praise ; args = [Lvar _]} -> false
+    | Lprim {primitive = _; args; _} ->
+      hit_list args
+    | Lvar id
+    | Lmutvar id ->
+      Ident.same id fv
+    | Lassign(id, e) ->
+      Ident.same id fv || hit e
+    | Lstaticcatch(e1, (_,_vars), e2) ->
+      hit e1 || hit e2
+    | Ltrywith(e1, _exn, e2) ->
+      hit e1 || hit e2
+    | Lfunction{body;params=_} ->
+      hit body;
+    | Llet(_, _id, arg, body)
+    | Lmutlet (_id, arg, body) ->
+      hit arg || hit body
+    | Lletrec(decl, body) ->
+      hit body ||
+      hit_list_snd decl
+    | Lfor(_v, e1, e2, _dir, e3) ->
+      hit e1 || hit e2 || hit e3
     | Lconst _ -> false
-    | Lapply { ap_func; ap_args; _ } -> hit ap_func || hit_list ap_args
-    | Lglobal_module _ (* global persistent module, play safe *) -> false
-    | Lswitch (arg, sw) ->
-        hit arg || hit_list_snd sw.sw_consts || hit_list_snd sw.sw_blocks
-        || hit_opt sw.sw_failaction
-    | Lstringswitch (arg, cases, default) ->
-        hit arg || hit_list_snd cases || hit_opt default
-    | Lstaticraise (_, args) -> hit_list args
-    | Lifthenelse (e1, e2, e3) -> hit e1 || hit e2 || hit e3
-    | Lsequence (e1, e2) -> hit e1 || hit e2
-    | Lwhile (e1, e2) -> hit e1 || hit e2
-    | Lsend (_k, met, obj, args, _) -> hit met || hit obj || hit_list args
-  in
-  hit l
+    | Lapply{ap_func; ap_args; _} ->
+      hit ap_func || hit_list ap_args
+    | Lglobal_module _  (* global persistent module, play safe *)
+      -> false
+    | Lswitch(arg, sw) ->
+      hit arg ||
+      hit_list_snd sw.sw_consts ||
+      hit_list_snd sw.sw_blocks ||
+      hit_opt sw.sw_failaction
+    | Lstringswitch (arg,cases,default) ->
+      hit arg ||
+      hit_list_snd cases ||
+      hit_opt default
+    | Lstaticraise (_,args) ->
+      hit_list args
+    | Lifthenelse(e1, e2, e3) ->
+      hit e1 || hit e2 || hit e3
+    | Lsequence(e1, e2) ->
+      hit e1 || hit e2
+    | Lwhile(e1, e2) ->
+      hit e1 || hit e2
+    | Lsend (_k, met, obj, args, _) ->
+      hit met || hit obj || hit_list args
+  in hit l
 
-let abs_int x = if x < 0 then -x else x
-let no_over_flow x = abs_int x < 0x1fff_ffff
+
+let abs_int x = if x < 0 then - x else x
+let no_over_flow x  = abs_int x < 0x1fff_ffff
+let no_over_flow_int32 x  = (Int32.abs x) < 0x1fff_ffffl
 
 let lam_is_var (x : Lam.t) (y : Ident.t) =
-  match x with Lvar y2 | Lmutvar y2 -> Ident.same y2 y | _ -> false
+  match x with
+  | Lvar y2 | Lmutvar y2 -> Ident.same y2 y
+  | _ -> false
 
-(* Make sure no int range overflow happens
+(** Make sure no int range overflow happens
     also we only check [int]
 *)
-let happens_to_be_diff (sw_consts : (int * Lambda.lambda) list) : int option =
+let happens_to_be_diff
+    (sw_consts :
+       (int * Lam.t) list) : int32 option =
   match sw_consts with
-  | ( a,
-      Lconst
-        ( Const_base (Const_int a0, Pt_constructor _)
-        | Const_base (Const_int a0, _) ) )
-    :: ( b,
-         Lconst
-           ( Const_base (Const_int b0, Pt_constructor _)
-           | Const_base (Const_int b0, _) ) )
-    :: rest
-    when no_over_flow a && no_over_flow a0 && no_over_flow b && no_over_flow b0
-    ->
-      let diff = a0 - a in
-      if b0 - b = diff then
-        if
-          Ext_list.for_all rest (fun (x, lam) ->
-              match lam with
-              | Lconst
-                  ( Const_base (Const_int x0, Pt_constructor _)
-                  | Const_base (Const_int x0, _) )
-                when no_over_flow x0 && no_over_flow x ->
-                  x0 - x = diff
-              | _ -> false)
-        then Some diff
-        else None
-      else None
+  | (a, Lconst (Const_int { i = a0; comment = _ }))::
+    (b, Lconst (Const_int { i = b0; comment = _ }))::
+    rest when
+     no_over_flow a  &&
+     no_over_flow_int32 a0 &&
+     no_over_flow b &&
+     no_over_flow_int32 b0 ->
+    let a = Int32.of_int a in
+    let b = Int32.of_int b in
+    let diff = Int32.sub a0 a in
+    if Int32.sub b0 b = diff then
+      if Ext_list.for_all rest (fun (x, lam) ->
+          match lam with
+          | Lconst (Const_int { i = x0; comment = _ })
+            when no_over_flow_int32 x0 && no_over_flow x ->
+            let x = Int32.of_int x in
+            Int32.sub x0 x = diff
+          | _ -> false
+        ) then
+        Some diff
+      else
+        None
+    else None
   | _ -> None
+
+
+
 
 (* type required_modules = Lam_module_ident.Hash_set.t *)
 
-(* drop Lseq (List! ) etc
-   see #3852, we drop all these required global modules
-   but added it back based on our own module analysis
+
+(** drop Lseq (List! ) etc
+  see #3852, we drop all these required global modules
+  but added it back based on our own module analysis
 *)
 let rec drop_global_marker (lam : Lam.t) =
   match lam with
-  | Lsequence (Lglobal_module _, rest) -> drop_global_marker rest
+  | Lsequence (Lglobal_module _, rest) ->
+    drop_global_marker rest
   | _ -> lam
 
 let seq = Lam.seq
 let unit = Lam.unit
 
-let convert_record_repr (x : Types.record_representation) :
-    Lam_primitive.record_representation =
+let convert_record_repr ( x : Types.record_representation)
+  : Lam_primitive.record_representation =
   match x with
-  | Record_regular | Record_float -> Record_regular
+  | Record_regular
+  | Record_float ->  Record_regular
   | Record_extension _ -> Record_extension
-  | Record_unboxed _ ->
-      assert false (* see patches in {!Typedecl.get_unboxed_from_attributes}*)
-  | Record_inlined { tag; name; num_nonconsts } ->
-      Record_inlined { tag; name; num_nonconsts }
+  | Record_unboxed _ -> assert false
+    (* see patches in {!Typedecl.get_unboxed_from_attributes}*)
+  | Record_inlined {tag; name; num_nonconsts} ->
+    Record_inlined {tag; name; num_nonconsts}
 
-let lam_prim ~primitive:(p : Lambda.primitive) ~args loc : Lam.t =
+
+let lam_prim ~primitive:( p : Lambda.primitive) ~args loc : Lam.t =
   match p with
   | Pint_as_pointer
   (* | Pidentity -> Ext_list.singleton_exn args *)
-  | Pccall _ ->
-      assert false
-  | Pbytes_to_string (* handled very early *) ->
-      prim ~primitive:Pbytes_to_string ~args loc
+  | Pccall _ -> assert false
+
+  | Pbytes_to_string (* handled very early *)
+    -> prim ~primitive:Pbytes_to_string ~args loc
   | Pbytes_of_string -> prim ~primitive:Pbytes_of_string ~args loc
-  | Pignore ->
-      (* Pignore means return unit, it is not an nop *)
-      seq (Ext_list.singleton_exn args) unit
+  | Pignore -> (* Pignore means return unit, it is not an nop *)
+    seq (Ext_list.singleton_exn args) unit
+
   | Pcompare_ints ->
-      prim ~primitive:(Pccall { prim_name = "caml_int_compare" }) ~args loc
+    prim ~primitive:(Pccall {prim_name = "caml_int_compare" }) ~args loc
   | Pcompare_floats ->
-      prim ~primitive:(Pccall { prim_name = "caml_float_compare" }) ~args loc
-  | Pcompare_bints Pnativeint -> assert false
+    prim ~primitive:(Pccall {prim_name = "caml_float_compare" }) ~args loc
+  | Pcompare_bints Pnativeint ->  assert false
   | Pcompare_bints Pint32 ->
-      prim ~primitive:(Pccall { prim_name = "caml_int32_compare" }) ~args loc
+    prim ~primitive:(Pccall {prim_name = "caml_int32_compare"}) ~args loc
   | Pcompare_bints Pint64 ->
-      prim ~primitive:(Pccall { prim_name = "caml_int64_compare" }) ~args loc
-  | Pgetglobal _ -> assert false
+    prim ~primitive:(Pccall {prim_name = "caml_int64_compare"}) ~args loc
+  | Pgetglobal _ ->
+    assert false
   | Psetglobal _ ->
-      (* we discard [Psetglobal] in the beginning*)
-      drop_global_marker (Ext_list.singleton_exn args)
+    (* we discard [Psetglobal] in the beginning*)
+    drop_global_marker (Ext_list.singleton_exn args)
   (* prim ~primitive:(Psetglobal id) ~args loc *)
-  | Pmakeblock (tag, info, mutable_flag, _block_shape) -> (
-      match info with
-      | Blk_some_not_nested -> prim ~primitive:Psome_not_nest ~args loc
-      | Blk_some -> prim ~primitive:Psome ~args loc
-      | Blk_constructor { name; num_nonconst } ->
-          let info : Lam_tag_info.t = Blk_constructor { name; num_nonconst } in
-          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
-      | Blk_tuple ->
-          let info : Lam_tag_info.t = Blk_tuple in
-          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
-      | Blk_extension ->
-          let info : Lam_tag_info.t = Blk_extension in
-          unbox_extension info args mutable_flag loc
-      | Blk_record_ext s ->
-          let info : Lam_tag_info.t = Blk_record_ext s in
-          unbox_extension info args mutable_flag loc
-      | Blk_extension_slot -> (
-          match args with
-          | [ Lconst (Const_string name) ] ->
-              prim ~primitive:(Pcreate_extension name) ~args:[] loc
-          | _ -> assert false)
-      | Blk_class ->
-          let info : Lam_tag_info.t = Blk_class in
-          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
-      | Blk_array ->
-          let info : Lam_tag_info.t = Blk_array in
-          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
-      | Blk_record s ->
-          let info : Lam_tag_info.t = Blk_record s in
-          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
-      | Blk_record_inlined { name; fields; num_nonconst } ->
-          let info : Lam_tag_info.t =
-            Blk_record_inlined { name; fields; num_nonconst }
-          in
-          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
-      | Blk_module s ->
-          let info : Lam_tag_info.t = Blk_module s in
-          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
-      | Blk_module_export _ ->
-          let info : Lam_tag_info.t = Blk_module_export in
-          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
-      | Blk_poly_var s -> (
-          match args with
-          | [ _; value ] ->
-              let info : Lam_tag_info.t = Blk_poly_var in
-              prim
-                ~primitive:(Pmakeblock (tag, info, mutable_flag))
-                ~args:[ Lam.const (Const_string s); value ]
-                loc
-          | _ -> assert false)
-      | Blk_lazy_general -> (
-          match args with
-          | [ ((Lvar _ | Lmutvar _ | Lconst _ | Lfunction _) as result) ] ->
-              let args = [ Lam.const Const_js_true; result ] in
-              prim
-                ~primitive:(Pmakeblock (tag, lazy_block_info, Mutable))
-                ~args loc
-          | [ computation ] ->
-              let args =
-                [
-                  Lam.const Const_js_false;
-                  (* FIXME: arity 0 does not get proper supported*)
-                  Lam.function_ ~arity:0 ~params:[] ~body:computation
-                    ~attr:Lambda.default_function_attribute;
-                ]
-              in
-              prim
-                ~primitive:(Pmakeblock (tag, lazy_block_info, Mutable))
-                ~args loc
-          | _ -> assert false)
-      | Blk_na s ->
-          let info : Lam_tag_info.t = Blk_na s in
-          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc)
-  | Pfield (id, info) -> prim ~primitive:(Pfield (id, info)) ~args loc
-  | Psetfield (id, _, _initialization_or_assignment, info) ->
-      prim ~primitive:(Psetfield (id, info)) ~args loc
-  | Psetfloatfield _ | Pfloatfield _ -> assert false
-  | Pduprecord (repr, _) ->
-      prim ~primitive:(Pduprecord (convert_record_repr repr)) ~args loc
-  | Praise _ -> prim ~primitive:Praise ~args loc
+  | Pmakeblock (tag,info, mutable_flag
+    , _block_shape
+  )
+    ->
+    begin match info with
+    | Blk_some_not_nested
+      ->
+      prim ~primitive:Psome_not_nest ~args loc
+    | Blk_some
+      ->
+      prim ~primitive:Psome ~args loc
+    | Blk_constructor{name ; num_nonconst } ->
+      let info : Lam_tag_info.t = Blk_constructor {name; num_nonconst} in
+      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
+    | Blk_tuple  ->
+      let info : Lam_tag_info.t = Blk_tuple in
+      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
+    | Blk_extension  ->
+      let info : Lam_tag_info.t = Blk_extension in
+      unbox_extension info args mutable_flag loc
+    | Blk_record_ext s ->
+      let info : Lam_tag_info.t = Blk_record_ext s in
+      unbox_extension info args mutable_flag loc
+    | Blk_extension_slot ->
+      (
+        match args with
+        | [ Lconst (Const_string name)] ->
+          prim ~primitive:(Pcreate_extension name) ~args:[] loc
+        | _ ->
+          assert false
+      )
+
+    | Blk_class  ->
+      let info : Lam_tag_info.t = Blk_class in
+      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
+    | Blk_array ->
+      let info : Lam_tag_info.t = Blk_array in
+      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
+    | Blk_record s ->
+      let info : Lam_tag_info.t = Blk_record s in
+      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
+    | Blk_record_inlined {name; fields; num_nonconst} ->
+      let info : Lam_tag_info.t = Blk_record_inlined {name; fields; num_nonconst} in
+      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
+    | Blk_module s ->
+      let info : Lam_tag_info.t = Blk_module s in
+      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
+    | Blk_module_export _ ->
+      let info : Lam_tag_info.t = Blk_module_export in
+      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
+    | Blk_poly_var s ->
+      begin match args with
+      | [_; value] ->
+        let info : Lam_tag_info.t = Blk_poly_var  in
+        prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args:[Lam.const (Const_string s); value] loc
+      | _ -> assert false
+      end
+    | Blk_lazy_general
+      ->
+      begin match args with
+      | [Lvar _ | Lmutvar _ | Lconst _ | Lfunction _ as result ] ->
+        let args =
+          [ Lam.const Const_js_true ;
+           result
+          ] in
+        prim ~primitive:(Pmakeblock (tag,lazy_block_info,Mutable)) ~args loc
+      | [computation] ->
+        let args =
+          [ Lam.const Const_js_false ;
+            (* FIXME: arity 0 does not get proper supported*)
+            Lam.function_
+              ~arity:0
+              ~params:[] ~body:computation
+              ~attr:Lambda.default_function_attribute
+          ] in
+        prim ~primitive:(Pmakeblock (tag,lazy_block_info,Mutable)) ~args loc
+
+      | _ -> assert false
+      end
+    | Blk_na s ->
+      let info : Lam_tag_info.t = Blk_na s in
+      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
+    end
+  | Pfield (id,info)
+    -> prim ~primitive:(Pfield (id,info)) ~args loc
+
+  | Psetfield (id, _,
+    _initialization_or_assignment,
+      info)
+    -> prim ~primitive:(Psetfield (id,info)) ~args loc
+  | Psetfloatfield _
+  | Pfloatfield _
+    -> assert false
+  | Pduprecord (repr,_)
+    -> prim ~primitive:(Pduprecord (convert_record_repr repr)) ~args loc
+  | Praise _ ->
+    prim ~primitive:Praise ~args loc
   | Psequand -> prim ~primitive:Psequand ~args loc
   | Psequor -> prim ~primitive:Psequor ~args loc
   | Pnot -> prim ~primitive:Pnot ~args loc
-  | Pnegint -> prim ~primitive:Pnegint ~args loc
+  | Pnegint -> prim ~primitive:Pnegint ~args  loc
   | Paddint -> prim ~primitive:Paddint ~args loc
   | Psubint -> prim ~primitive:Psubint ~args loc
   | Pmulint -> prim ~primitive:Pmulint ~args loc
-  | Pdivint _is_safe (*FIXME*) -> prim ~primitive:Pdivint ~args loc
-  | Pmodint _is_safe (*FIXME*) -> prim ~primitive:Pmodint ~args loc
+  | Pdivint
+    _is_safe (*FIXME*)
+    -> prim ~primitive:Pdivint ~args loc
+  | Pmodint
+    _is_safe (*FIXME*)
+    -> prim ~primitive:Pmodint ~args loc
   | Pandint -> prim ~primitive:Pandint ~args loc
   | Porint -> prim ~primitive:Porint ~args loc
   | Pxorint -> prim ~primitive:Pxorint ~args loc
@@ -298,455 +359,530 @@ let lam_prim ~primitive:(p : Lambda.primitive) ~args loc : Lam.t =
   | Pstringrefs -> prim ~primitive:Pstringrefs ~args loc
   | Pbyteslength -> prim ~primitive:Pbyteslength ~args loc
   | Pbytesrefu -> prim ~primitive:Pbytesrefu ~args loc
-  | Pbytessetu -> prim ~primitive:Pbytessetu ~args loc
+  | Pbytessetu -> prim ~primitive:Pbytessetu ~args  loc
   | Pbytesrefs -> prim ~primitive:Pbytesrefs ~args loc
   | Pbytessets -> prim ~primitive:Pbytessets ~args loc
   | Pisint -> prim ~primitive:Pisint ~args loc
-  | Pisout -> (
-      match args with
-      | [ range; Lprim { primitive = Poffsetint i; args = [ x ] } ] ->
-          prim ~primitive:(Pisout i) ~args:[ range; x ] loc
-      | _ -> prim ~primitive:(Pisout 0) ~args loc)
+  | Pisout ->
+    begin match args with
+    | [ range; Lprim {primitive = Poffsetint i; args = [x]}] ->
+
+      prim ~primitive:(Pisout i) ~args:[range;x] loc
+    | _ ->
+      prim ~primitive:(Pisout 0) ~args loc
+    end
   | Pintoffloat -> prim ~primitive:Pintoffloat ~args loc
   | Pfloatofint -> prim ~primitive:Pfloatofint ~args loc
   | Pnegfloat -> prim ~primitive:Pnegfloat ~args loc
+
   | Paddfloat -> prim ~primitive:Paddfloat ~args loc
   | Psubfloat -> prim ~primitive:Psubfloat ~args loc
   | Pmulfloat -> prim ~primitive:Pmulfloat ~args loc
   | Pdivfloat -> prim ~primitive:Pdivfloat ~args loc
-  | Pintcomp x -> prim ~primitive:(Pintcomp x) ~args loc
+  | Pintcomp x -> prim ~primitive:(Pintcomp x)  ~args loc
   | Poffsetint x -> prim ~primitive:(Poffsetint x) ~args loc
-  | Poffsetref x -> prim ~primitive:(Poffsetref x) ~args loc
+  | Poffsetref x -> prim ~primitive:(Poffsetref x) ~args  loc
   | Pfloatcomp x -> prim ~primitive:(Pfloatcomp x) ~args loc
-  | Pmakearray (_, _mutable_flag) (*FIXME*) ->
-      prim ~primitive:Pmakearray ~args loc
+  | Pmakearray
+    (_, _mutable_flag) (*FIXME*)
+    -> prim ~primitive:Pmakearray ~args  loc
   | Parraylength _ -> prim ~primitive:Parraylength ~args loc
-  | Parrayrefu _ -> prim ~primitive:Parrayrefu ~args loc
-  | Parraysetu _ -> prim ~primitive:Parraysetu ~args loc
-  | Parrayrefs _ -> prim ~primitive:Parrayrefs ~args loc
-  | Parraysets _ -> prim ~primitive:Parraysets ~args loc
-  | Pbintofint x -> (
-      match x with
+  | Parrayrefu _ -> prim ~primitive:(Parrayrefu ) ~args loc
+  | Parraysetu _ -> prim ~primitive:(Parraysetu ) ~args loc
+  | Parrayrefs _ -> prim ~primitive:(Parrayrefs ) ~args loc
+  | Parraysets _ -> prim ~primitive:(Parraysets ) ~args loc
+  | Pbintofint x ->
+    begin match x with
+    | Pint32 | Pnativeint -> Ext_list.singleton_exn args
+    | Pint64 -> prim ~primitive:(Pint64ofint ) ~args loc
+    end
+  | Pintofbint x ->
+    begin match x with
       | Pint32 | Pnativeint -> Ext_list.singleton_exn args
-      | Pint64 -> prim ~primitive:Pint64ofint ~args loc)
-  | Pintofbint x -> (
-      match x with
-      | Pint32 | Pnativeint -> Ext_list.singleton_exn args
-      | Pint64 -> prim ~primitive:Pintofint64 ~args loc)
-  | Pnegbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Pnegint ~args loc
-      | Pint64 -> prim ~primitive:Pnegint64 ~args loc)
-  | Paddbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Paddint ~args loc
-      | Pint64 -> prim ~primitive:Paddint64 ~args loc)
-  | Psubbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Psubint ~args loc
-      | Pint64 -> prim ~primitive:Psubint64 ~args loc)
-  | Pmulbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Pmulint ~args loc
-      | Pint64 -> prim ~primitive:Pmulint64 ~args loc)
-  | Pdivbint { size = x; is_safe = _ } (*FIXME*) -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Pdivint ~args loc
-      | Pint64 -> prim ~primitive:Pdivint64 ~args loc)
-  | Pmodbint { size = x; is_safe = _ } (*FIXME*) -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Pmodint ~args loc
-      | Pint64 -> prim ~primitive:Pmodint64 ~args loc)
-  | Pandbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Pandint ~args loc
-      | Pint64 -> prim ~primitive:Pandint64 ~args loc)
-  | Porbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Porint ~args loc
-      | Pint64 -> prim ~primitive:Porint64 ~args loc)
-  | Pxorbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Pxorint ~args loc
-      | Pint64 -> prim ~primitive:Pxorint64 ~args loc)
-  | Plslbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Plslint ~args loc
-      | Pint64 -> prim ~primitive:Plslint64 ~args loc)
-  | Plsrbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Plsrint ~args loc
-      | Pint64 -> prim ~primitive:Plsrint64 ~args loc)
-  | Pasrbint x -> (
-      match x with
-      | Pnativeint | Pint32 -> prim ~primitive:Pasrint ~args loc
-      | Pint64 -> prim ~primitive:Pasrint64 ~args loc)
-  | Pbigarraydim _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
-  | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
-  | Pbigstring_set_64 _ | Pbytes_load_16 _ | Pbytes_load_32 _ | Pbytes_load_64 _
-  | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_64 _ | Pstring_load_16 _
-  | Pstring_load_32 _ | Pstring_load_64 _ | Pbigarrayref _ | Pbigarrayset _ ->
-      Location.raise_errorf ~loc "unsupported primitive"
-  | Pctconst x -> (
-      match x with
-      | Word_size | Int_size ->
-          Lam.const (Const_int { i = 32l; comment = None })
-      | Max_wosize ->
-          Lam.const (Const_int { i = 2147483647l; comment = Some "Max_wosize" })
-      | Big_endian -> prim ~primitive:(Pctconst Big_endian) ~args loc
-      | Ostype_unix -> prim ~primitive:(Pctconst Ostype_unix) ~args loc
-      | Ostype_win32 -> prim ~primitive:(Pctconst Ostype_win32) ~args loc
-      | Ostype_cygwin -> Lam.false_
-      | Backend_type -> prim ~primitive:(Pctconst Backend_type) ~args loc)
-  | Pcvtbint (a, b) -> (
-      match (a, b) with
-      | (Pnativeint | Pint32), (Pnativeint | Pint32) | Pint64, Pint64 ->
-          Ext_list.singleton_exn args
-      | Pint64, (Pnativeint | Pint32) -> prim ~primitive:Pintofint64 ~args loc
-      | (Pnativeint | Pint32), Pint64 -> prim ~primitive:Pint64ofint ~args loc)
-  | Pbintcomp (a, b) -> (
-      match a with
-      | Pnativeint | Pint32 -> prim ~primitive:(Pintcomp b) ~args loc
-      | Pint64 -> prim ~primitive:(Pint64comp b) ~args loc)
-  | Pfield_computed -> prim ~primitive:Pfield_computed ~args loc
+      | Pint64 -> prim ~primitive:Pintofint64  ~args loc
+    end
+  | Pnegbint x ->
+    begin match x with
+    | Pnativeint
+    | Pint32 -> prim ~primitive:Pnegint ~args loc
+    | Pint64 -> prim ~primitive:Pnegint64 ~args loc
+    end
+  | Paddbint x ->
+    begin match x with
+    | Pnativeint
+    | Pint32  -> prim ~primitive:Paddint ~args loc
+    | Pint64 -> prim ~primitive:Paddint64 ~args loc
+    end
+  | Psubbint x ->
+    begin match x with
+    | Pnativeint
+    | Pint32 -> prim ~primitive:(Psubint) ~args loc
+    | Pint64 -> prim ~primitive:(Psubint64) ~args loc
+    end
+  | Pmulbint x ->
+    begin match x with
+    | Pnativeint
+    | Pint32 -> prim ~primitive:Pmulint ~args loc
+    | Pint64 -> prim ~primitive:Pmulint64 ~args loc
+    end
+  | Pdivbint
+    {size = x; is_safe = _} (*FIXME*)
+    ->
+    begin match x with
+    | Pnativeint
+    | Pint32 ->  prim ~primitive:(Pdivint) ~args loc
+    | Pint64->  prim ~primitive:(Pdivint64) ~args loc
+    end
+  | Pmodbint
+    {size = x; is_safe = _} (*FIXME*)
+    ->
+      begin match x with
+      | Pnativeint
+      | Pint32 -> prim ~primitive:(Pmodint ) ~args loc
+      | Pint64 -> prim ~primitive:(Pmodint64 ) ~args loc
+      end
+  | Pandbint x ->
+    begin match x with
+      | Pnativeint
+      | Pint32 ->
+        prim ~primitive:(Pandint ) ~args loc
+      | Pint64 -> prim ~primitive:(Pandint64 ) ~args loc
+    end
+  | Porbint x ->
+    begin match x with
+      | Pnativeint
+      | Pint32 ->
+        prim ~primitive:(Porint ) ~args loc
+      | Pint64 ->
+        prim ~primitive:(Porint64 ) ~args loc
+    end
+  | Pxorbint x ->
+    begin match x with
+      | Pnativeint
+      | Pint32 ->
+        prim ~primitive:(Pxorint ) ~args loc
+      | Pint64 ->
+        prim ~primitive:(Pxorint64 ) ~args loc
+    end
+  | Plslbint x ->
+    begin match x with
+    | Pnativeint
+    | Pint32 -> prim ~primitive:(Plslint) ~args loc
+    | Pint64 -> prim ~primitive:(Plslint64) ~args loc
+    end
+  | Plsrbint x ->
+    begin match x with
+    | Pnativeint
+    | Pint32 -> prim ~primitive:(Plsrint) ~args loc
+    | Pint64 -> prim ~primitive:(Plsrint64) ~args loc
+    end
+  | Pasrbint x ->
+    begin match x with
+    | Pnativeint
+    | Pint32 -> prim ~primitive:(Pasrint) ~args loc
+    | Pint64 -> prim ~primitive:(Pasrint64) ~args loc
+    end
+  | Pbigarraydim _
+  | Pbigstring_load_16 _
+  | Pbigstring_load_32 _
+  | Pbigstring_load_64 _
+  | Pbigstring_set_16 _
+  | Pbigstring_set_32 _
+  | Pbigstring_set_64 _
+  | Pbytes_load_16 _
+  | Pbytes_load_32 _
+  | Pbytes_load_64 _
+  | Pbytes_set_16 _
+  | Pbytes_set_32 _
+  | Pbytes_set_64 _
+  | Pstring_load_16 _
+  | Pstring_load_32 _
+  | Pstring_load_64 _
+  | Pbigarrayref _
+  | Pbigarrayset _ ->
+    Location.raise_errorf ~loc "unsupported primitive"
+  | Pctconst x ->
+    begin match x with
+      | Word_size
+      | Int_size -> Lam.const(Const_int {i = 32l; comment = None})
+      | Max_wosize -> Lam.const (Const_int {i = 2147483647l; comment = Some "Max_wosize"})
+      | Big_endian
+        -> prim ~primitive:(Pctconst Big_endian) ~args loc
+      | Ostype_unix
+        -> prim ~primitive:(Pctconst Ostype_unix) ~args loc
+      | Ostype_win32
+        -> prim ~primitive:(Pctconst Ostype_win32) ~args loc
+      | Ostype_cygwin
+        -> Lam.false_
+      | Backend_type
+        -> prim ~primitive:(Pctconst Backend_type) ~args loc
+    end
+
+
+  | Pcvtbint (a,b) ->
+    begin match a, b with
+    | (Pnativeint | Pint32), (Pnativeint | Pint32)
+    | Pint64, Pint64 ->   Ext_list.singleton_exn args
+    | Pint64, (Pnativeint | Pint32)
+      ->
+      prim ~primitive:(Pintofint64) ~args loc
+    | (Pnativeint | Pint32) , Pint64
+      ->
+      prim ~primitive:(Pint64ofint) ~args loc
+    end
+  | Pbintcomp (a,b) ->
+    begin match a with
+    | Pnativeint
+    | Pint32 -> prim ~primitive:(Pintcomp b) ~args loc
+    | Pint64 -> prim ~primitive:(Pint64comp b) ~args loc
+    end
+  | Pfield_computed ->
+    prim ~primitive:Pfield_computed ~args loc
   | Popaque -> Ext_list.singleton_exn args
-  | Psetfield_computed _ -> prim ~primitive:Psetfield_computed ~args loc
-  | Pbbswap _ | Pbswap16 | Pduparray _ -> assert false
-(* Does not exist since we compile array in js backend unlike native backend *)
+  | Psetfield_computed _ ->
+    prim ~primitive:Psetfield_computed ~args loc
+  | Pbbswap _
+  | Pbswap16
+  | Pduparray _ ->  assert false
+    (* Does not exist since we compile array in js backend unlike native backend *)
+
 
 let may_depend = Lam_module_ident.Hash_set.add
 
-let rec rename_optional_parameters map params (body : Lambda.lambda) =
-  match body with
-  | Llet
-      ( k,
-        value_kind,
-        id,
-        Lifthenelse
-          (Lprim (p, [ Lvar opt ], p_loc), Lprim (p1, [ Lvar opt2 ], x_loc), f),
-        rest )
-    when Ident.name opt = "*opt*"
-         && Ident.name opt2 = "*opt*"
-         && Ident.same opt opt2 && List.mem opt params ->
-      let map, rest = rename_optional_parameters map params rest in
-      let new_id = Ident.create_local (Ident.name id ^ "Opt") in
-      ( Map_ident.add map opt new_id,
-        Lambda.Llet
-          ( k,
-            value_kind,
-            id,
-            Lifthenelse
-              ( Lprim (p, [ Lvar new_id ], p_loc),
-                Lprim (p1, [ Lvar new_id ], x_loc),
-                f ),
-            rest ) )
-  | Lmutlet
-      ( value_kind,
-        id,
-        Lifthenelse
-          (Lprim (p, [ Lvar opt ], p_loc), Lprim (p1, [ Lvar opt2 ], x_loc), f),
-        rest )
-    when Ident.name opt = "*opt*"
-         && Ident.name opt2 = "*opt*"
-         && Ident.same opt opt2 && List.mem opt params ->
-      let map, rest = rename_optional_parameters map params rest in
-      let new_id = Ident.create_local (Ident.name id ^ "Opt") in
-      ( Map_ident.add map opt new_id,
-        Lambda.Lmutlet
-          ( value_kind,
-            id,
-            Lifthenelse
-              ( Lprim (p, [ Lvar new_id ], p_loc),
-                Lprim (p1, [ Lvar new_id ], x_loc),
-                f ),
-            rest ) )
-  | _ -> (map, body)
 
-let convert (exports : Set_ident.t) (lam : Lambda.lambda) :
-    Lam.t * Lam_module_ident.Hash_set.t =
+let rec rename_optional_parameters map params (body : Lam.t) =
+  match body with
+  | Llet(k,id, (Lifthenelse(
+      Lprim({ primitive = p; args = [Lvar opt]; loc = p_loc}),
+        Lprim({ primitive = p1; args = [Lvar opt2]; loc = x_loc}), f)),rest)
+    when Ident.name opt = "*opt*" &&
+         Ident.name opt2 = "*opt*" &&
+         Ident.same opt opt2 && List.mem opt params
+    ->
+    let map, rest = rename_optional_parameters map params rest in
+    let new_id = Ident.create_local (Ident.name id ^ "Opt") in
+    Map_ident.add map opt new_id,
+    Lam.let_ k id
+      (Lam.if_
+        (Lam.prim ~primitive:p ~args:[Lam.var new_id] p_loc)
+        (Lam.prim ~primitive:p1 ~args:[Lam.var new_id] x_loc)
+        f) rest
+  | Lmutlet(id, (Lifthenelse(
+      Lprim({ primitive = p; args = [Lvar opt]; loc = p_loc }),
+        Lprim({ primitive = p1; args = [Lvar opt2]; loc = x_loc }), f)),rest)
+    when Ident.name opt = "*opt*" &&
+         Ident.name opt2 = "*opt*" &&
+         Ident.same opt opt2 && List.mem opt params
+    ->
+    let map, rest = rename_optional_parameters map params rest in
+    let new_id = Ident.create_local (Ident.name id ^ "Opt") in
+    Map_ident.add map opt new_id,
+
+    Lam.mutlet id
+      (Lam.if_
+        (Lam.prim ~primitive:p ~args:[Lam.var new_id] p_loc)
+        (Lam.prim ~primitive:p1 ~args:[Lam.var new_id] x_loc)
+        f) rest
+  | _ ->
+    map, body
+    [@@warning "-27"]
+
+let convert (exports : Set_ident.t) (lam : Lambda.lambda) : Lam.t * Lam_module_ident.Hash_set.t  =
   let alias_tbl = Hash_ident.create 64 in
   let exit_map = Hash_int.create 0 in
   let may_depends = Lam_module_ident.Hash_set.create 0 in
 
-  let rec convert_ccall (a_prim : Primitive.description)
-      (args : Lambda.lambda list) loc : Lam.t =
+  let rec
+    convert_ccall (a_prim : Primitive.description)  (args : Lambda.lambda list) loc : Lam.t =
     let prim_name = a_prim.prim_name in
-    let prim_name_len = String.length prim_name in
+    let prim_name_len  = String.length prim_name in
     match External_ffi_types.from_string a_prim.prim_native_name with
     | Ffi_normal ->
-        if prim_name_len > 0 && String.unsafe_get prim_name 0 = '#' then
-          convert_js_primitive a_prim args loc
-        else
-          let args = Ext_list.map args convert_aux in
-          prim ~primitive:(Pccall { prim_name }) ~args loc
+      if prim_name_len > 0 && String.unsafe_get prim_name 0 = '#' then
+        convert_js_primitive a_prim args loc
+      else
+        let args = Ext_list.map args convert_aux in
+        prim ~primitive:(Pccall {prim_name }) ~args loc
     | Ffi_obj_create labels ->
-        let args = Ext_list.map args convert_aux in
-        prim ~primitive:(Pjs_object_create labels) ~args loc
-    | Ffi_bs (arg_types, result_type, ffi) ->
-        let arg_types =
-          match arg_types with
-          | Params ls -> ls
-          | Param_number i -> Ext_list.init i (fun _ -> External_arg_spec.dummy)
-        in
-        let args = Ext_list.map args convert_aux in
-        Lam.handle_bs_non_obj_ffi arg_types result_type ffi args loc prim_name
+      let args = Ext_list.map args  convert_aux in
+      prim ~primitive:(Pjs_object_create labels) ~args loc
+    | Ffi_bs(arg_types, result_type, ffi) ->
+      let arg_types =
+        match arg_types with
+        | Params ls -> ls
+        | Param_number i -> Ext_list.init i (fun _ -> External_arg_spec.dummy )   in
+      let args = Ext_list.map args convert_aux in
+      Lam.handle_bs_non_obj_ffi arg_types result_type ffi args loc prim_name
     | Ffi_inline_const i -> Lam.const i
-  and convert_js_primitive (p : Primitive.description)
-      (args : Lambda.lambda list) loc =
+
+  and convert_js_primitive (p: Primitive.description) (args : Lambda.lambda list) loc =
     let s = p.prim_name in
+    let args = Ext_list.map args convert_aux in
     match () with
     | _ when s = "#is_not_none" ->
-        prim ~primitive:Pis_not_none ~args:(Ext_list.map args convert_aux) loc
-    | _ when s = "#val_from_unnest_option" ->
-        let v = convert_aux (Ext_list.singleton_exn args) in
-        prim ~primitive:Pval_from_option_not_nest ~args:[ v ] loc
-    | _ when s = "#val_from_option" ->
-        prim ~primitive:Pval_from_option
-          ~args:(Ext_list.map args convert_aux)
-          loc
-    | _ when s = "#is_poly_var_const" ->
-        prim ~primitive:Pis_poly_var_const
-          ~args:(Ext_list.map args convert_aux)
-          loc
-    | _ when s = "#raw_expr" -> (
-        match args with
-        | [ Lconst (Const_base (Const_string (code, _, _), _)) ] ->
-            (* js parsing here *)
-            let kind = Classify_function.classify code in
-            prim
-              ~primitive:(Praw_js_code { code; code_info = Exp kind })
-              ~args:[] loc
-        | _ -> assert false)
-    | _ when s = "#raw_stmt" -> (
-        match args with
-        | [ Lconst (Const_base (Const_string (code, _, _), _)) ] ->
-            let kind = Classify_function.classify_stmt code in
-            prim
-              ~primitive:(Praw_js_code { code; code_info = Stmt kind })
-              ~args:[] loc
-        | _ -> assert false)
-    | _ when s = "#debugger" ->
-        (* ATT: Currently, the arity is one due to PPX *)
-        prim ~primitive:Pdebugger ~args:[] loc
-    | _ when s = "#null" -> Lam.const Const_js_null
+      prim ~primitive:Pis_not_none ~args loc
+    | _ when s = "#val_from_unnest_option"
+      ->
+      let v = (Ext_list.singleton_exn args) in
+      prim ~primitive:Pval_from_option_not_nest
+        ~args:[v] loc
+    | _ when s = "#val_from_option"
+      ->
+      prim ~primitive:Pval_from_option ~args loc
+    | _ when s = "#is_poly_var_const"
+      ->
+      prim ~primitive:Pis_poly_var_const ~args loc
+    | _ when s = "#raw_expr" ->
+      (match args with
+       | [Lconst(Const_string(code))] ->
+        (* js parsing here *)
+        let kind =
+            Classify_function.classify code in
+         prim ~primitive:(Praw_js_code {code; code_info = Exp kind})
+           ~args:[] loc
+       | _ -> assert false)
+
+    | _ when s = "#raw_stmt" ->
+      begin match args with
+        | [Lconst(Const_string(code))] ->
+          let kind = Classify_function.classify_stmt code in
+          prim ~primitive:(Praw_js_code {code; code_info = Stmt kind})
+            ~args:[] loc
+        | _ -> assert false
+      end
+    | _ when s =  "#debugger"  ->
+      (* ATT: Currently, the arity is one due to PPX *)
+      prim ~primitive:Pdebugger ~args:[] loc
+    | _ when s = "#null" ->
+      Lam.const (Const_js_null)
     | _ when s = "#os_type" ->
-        prim ~primitive:(Pctconst Ostype) ~args:[ unit ] loc
-    | _ when s = "#undefined" -> Lam.const Const_js_undefined
-    | _ when s = "#init_mod" -> (
-        let args = Ext_list.map args convert_aux in
-        match args with
-        | [ _loc; Lconst (Const_block (0, _, [ Const_block (0, _, []) ])) ] ->
-            Lam.unit
-        | _ -> prim ~primitive:Pinit_mod ~args loc)
-    | _ when s = "#update_mod" -> (
-        let args = Ext_list.map args convert_aux in
-        match args with
-        | [ Lconst (Const_block (0, _, [ Const_block (0, _, []) ])); _; _ ] ->
-            Lam.unit
-        | _ -> prim ~primitive:Pupdate_mod ~args loc)
-    | _ when s = "#extension_slot_eq" -> (
-        match Ext_list.map args convert_aux with
-        | [ lhs; rhs ] ->
-            prim
-              ~primitive:(Pccall { prim_name = "caml_string_equal" })
-              ~args:[ lam_extension_id loc lhs; rhs ]
-              loc
-        | _ -> assert false)
+      prim ~primitive:(Pctconst Ostype) ~args:[unit] loc
+    | _ when s = "#undefined" ->
+      Lam.const (Const_js_undefined)
+    | _ when s = "#init_mod" ->
+      begin match args with
+      | [_loc; Lconst(Const_block(0,_,[Const_block(0,_,[])]))]
+        ->
+        Lam.unit
+      | _ -> prim ~primitive:Pinit_mod ~args loc
+      end
+    | _ when s = "#update_mod" ->
+      begin match args with
+      | [Lconst(Const_block(0,_,[Const_block(0,_,[])]));_;_]
+        -> Lam.unit
+      | _ -> prim ~primitive:Pupdate_mod ~args loc
+      end
+    | _ when s = "#extension_slot_eq" ->
+      begin match args with
+      | [lhs; rhs] ->
+        prim
+          ~primitive:(Pccall {prim_name = "caml_string_equal"})
+          ~args:[lam_extension_id loc lhs ;
+                 rhs;
+                ] loc
+      | _ -> assert false end
     | _ ->
-        let primitive : Lam_primitive.t =
-          match s with
-          | "#apply" -> Pjs_runtime_apply
-          | "#apply1" | "#apply2" | "#apply3" | "#apply4" | "#apply5"
-          | "#apply6" | "#apply7" | "#apply8" ->
-              Pjs_apply
-          | "#makemutablelist" ->
-              Pmakeblock
-                (0, Blk_constructor { name = "::"; num_nonconst = 1 }, Mutable)
-          | "#undefined_to_opt" -> Pundefined_to_opt
-          | "#nullable_to_opt" -> Pnull_undefined_to_opt
-          | "#null_to_opt" -> Pnull_to_opt
-          | "#is_nullable" -> Pis_null_undefined
-          | "#string_append" -> Pstringadd
-          | "#obj_length" -> Pcaml_obj_length
-          | "#function_length" -> Pjs_function_length
-          | "#unsafe_lt" -> Pjscomp Clt
-          | "#unsafe_gt" -> Pjscomp Cgt
-          | "#unsafe_le" -> Pjscomp Cle
-          | "#unsafe_ge" -> Pjscomp Cge
-          | "#unsafe_eq" -> Pjscomp Ceq
-          | "#unsafe_neq" -> Pjscomp Cne
-          | "#typeof" -> Pjs_typeof
-          | "#run" -> Pvoid_run
-          | "#full_apply" -> Pfull_apply
-          | "#fn_mk" ->
-              Pjs_fn_make (Ext_pervasives.nat_of_string_exn p.prim_native_name)
-          | "#fn_method" -> Pjs_fn_method
-          | "#unsafe_downgrade" ->
-              Pjs_unsafe_downgrade
-                { name = Ext_string.empty; loc; setter = false }
-          | _ ->
-              Location.raise_errorf ~loc
-                "@{<error>Error:@} internal error, using unrecognized \
-                 primitive %s"
-                s
-        in
-        if primitive = Pfull_apply then
-          match args with
-          | [ Lapply { ap_func = Lprim (Popaque, [ ap_func ], _); ap_args } ] ->
-              let ap_func = convert_aux ap_func in
-              let ap_args = Ext_list.map ap_args convert_aux in
-              prim ~primitive ~args:(ap_func :: ap_args) loc
-              (* There may be some optimization opportunities here
-                 for cases like `(fun [@bs] a b -> a + b ) 1 2 [@bs]` *)
-          | _ -> assert false
-        else
-          let args = Ext_list.map args convert_aux in
-          prim ~primitive ~args loc
+      let primitive : Lam_primitive.t =
+        match s with
+        | "#apply" -> Pjs_runtime_apply
+        | "#apply1"
+        | "#apply2"
+        | "#apply3"
+        | "#apply4"
+        | "#apply5"
+        | "#apply6"
+        | "#apply7"
+        | "#apply8" -> Pjs_apply
+        | "#makemutablelist" ->
+          Pmakeblock(0, Blk_constructor{name = "::"; num_nonconst = 1},Mutable)
+        | "#undefined_to_opt" -> Pundefined_to_opt
+        | "#nullable_to_opt" -> Pnull_undefined_to_opt
+        | "#null_to_opt" -> Pnull_to_opt
+        | "#is_nullable" -> Pis_null_undefined
+        | "#string_append" -> Pstringadd
+        | "#obj_length" -> Pcaml_obj_length
+        | "#function_length" -> Pjs_function_length
+
+        | "#unsafe_lt" -> Pjscomp Clt
+        | "#unsafe_gt" -> Pjscomp Cgt
+        | "#unsafe_le" -> Pjscomp Cle
+        | "#unsafe_ge" -> Pjscomp Cge
+        | "#unsafe_eq" -> Pjscomp Ceq
+        | "#unsafe_neq" -> Pjscomp Cne
+
+        | "#typeof" -> Pjs_typeof
+        | "#run"  ->
+          Pvoid_run
+        | "#full_apply" ->
+          Pfull_apply
+
+        | "#fn_mk" -> Pjs_fn_make (Ext_pervasives.nat_of_string_exn p.prim_native_name)
+        | "#fn_method" -> Pjs_fn_method
+        | "#unsafe_downgrade" -> Pjs_unsafe_downgrade {name = Ext_string.empty; loc ; setter = false}
+        | _ -> Location.raise_errorf ~loc
+                 "@{<error>Error:@} internal error, using unrecognized primitive %s" s
+      in
+      if primitive = Pfull_apply then
+        match args with
+        | [Lapply {ap_func; ap_args}] ->
+          prim ~primitive ~args:(ap_func::ap_args) loc
+          (* There may be some optimization opportunities here
+            for cases like `(fun [@bs] a b -> a + b ) 1 2 [@bs]` *)
+        | _ -> assert false
+      else
+        prim ~primitive ~args loc
   and convert_aux (lam : Lambda.lambda) : Lam.t =
     match lam with
-    | Lvar x -> Lam.var (Hash_ident.find_default alias_tbl x x)
-    | Lmutvar x -> Lam.mutvar (Hash_ident.find_default alias_tbl x x)
-    | Lconst x -> Lam.const (Lam_constant_convert.convert_constant x)
-    | Lapply { ap_func = fn; ap_args = args; ap_loc = loc; ap_inlined } ->
-        (* we need do this eargly in case [aux fn] add some wrapper *)
-        Lam.apply (convert_aux fn)
-          (Ext_list.map args convert_aux)
-          {
-            ap_loc = Debuginfo.Scoped_location.to_location loc;
-            ap_inlined;
-            ap_status = App_na;
-          }
-    | Lfunction { params; body; attr } ->
-        let just_params = List.map fst params in
-        let new_map, body =
-          rename_optional_parameters Map_ident.empty just_params body
-        in
-        if Map_ident.is_empty new_map then
-          Lam.function_ ~attr ~arity:(List.length params) ~params:just_params
-            ~body:(convert_aux body)
-        else
-          let params =
-            Ext_list.map just_params (fun x ->
-                Map_ident.find_default new_map x x)
-          in
-          Lam.function_ ~attr ~arity:(List.length params) ~params
-            ~body:(convert_aux body)
-    | Llet (kind, _value_kind, id, e, body) (*FIXME*) ->
-        convert_let kind id e body
-    | Lmutlet (_value_kind, id, e, body) (*FIXME*) -> convert_mutlet id e body
-    | Lletrec (bindings, body) ->
-        let bindings = Ext_list.map_snd bindings convert_aux in
-        let body = convert_aux body in
-        let lam = Lam.letrec bindings body in
-        Lam_scc.scc bindings lam body
+    | Lvar x ->
+      Lam.var (Hash_ident.find_default alias_tbl x x)
+    | Lmutvar x ->
+      Lam.mutvar (Hash_ident.find_default alias_tbl x x)
+    | Lconst x ->
+      Lam.const (Lam_constant_convert.convert_constant x )
+    | Lapply
+        {ap_func = fn; ap_args = args; ap_loc = loc; ap_inlined}
+      ->
+          (** we need do this eargly in case [aux fn] add some wrapper *)
+          Lam.apply (convert_aux fn) (Ext_list.map args convert_aux ) {ap_loc = Debuginfo.Scoped_location.to_location loc; ap_inlined; ap_status =  App_na}
+    | Lfunction
+    { params; body ; attr }
+      ->
+      let just_params = Ext_list.map params fst in
+      let body = convert_aux body in
+      let new_map,body = rename_optional_parameters Map_ident.empty just_params body in
+      let params =
+        if Map_ident.is_empty new_map then just_params
+        else Ext_list.map just_params (fun x ->
+          Map_ident.find_default new_map x x) in
+      Lam.function_ ~attr
+        ~arity:(List.length params)  ~params
+        ~body
+    | Llet
+      (kind,_value_kind, id,e,body) (*FIXME*)
+      -> convert_let kind id e body
+    | Lmutlet
+      (_value_kind, id,e,body) (*FIXME*)
+      -> convert_mutlet id e body
+
+    | Lletrec (bindings,body)
+      ->
+      let bindings = Ext_list.map_snd  bindings convert_aux in
+      let body = convert_aux body in
+      let lam = Lam.letrec bindings body in
+      Lam_scc.scc bindings lam body
     (* inlining will affect how mututal recursive behave *)
     (* | Lprim(Prevapply, [x ; f ],  outer_loc) *)
     (* | Lprim(Pdirapply, [f ; x],  outer_loc) -> *)
-    (* convert_pipe f x outer_loc *)
+      (* convert_pipe f x outer_loc *)
     (* | Lprim (Prevapply, _, _ ) -> assert false *)
     (* | Lprim(Pdirapply, _, _) -> assert false *)
-    | Lprim (Pccall a, args, loc) ->
-        convert_ccall a args (Debuginfo.Scoped_location.to_location loc)
+    | Lprim(Pccall a, args, loc)  ->
+      convert_ccall a  args (Debuginfo.Scoped_location.to_location loc)
     | Lprim (Pgetglobal id, args, _) ->
-        let args = Ext_list.map args convert_aux in
-        if Ident.is_predef id then Lam.const (Const_string (Ident.name id))
-        else (
+      let args = Ext_list.map args convert_aux in
+      if Ident.is_predef id then
+        Lam.const (Const_string (Ident.name id))
+      else
+        begin
           may_depend may_depends (Lam_module_ident.of_ml id);
           assert (args = []);
-          Lam.global_module id)
-    | Lprim (primitive, args, loc) ->
-        let args = Ext_list.map args convert_aux in
-        lam_prim ~primitive ~args (Debuginfo.Scoped_location.to_location loc)
-    | Lswitch (e, s, _loc) -> convert_switch e s
-    | Lstringswitch (e, cases, default, _) ->
-        Lam.stringswitch (convert_aux e)
-          (Ext_list.map_snd cases convert_aux)
-          (Ext_option.map default convert_aux)
-    | Lstaticraise (id, []) ->
+          Lam.global_module id
+        end
+    | Lprim (primitive,args, loc)
+      ->
+      let args = Ext_list.map args convert_aux in
+      lam_prim ~primitive ~args (Debuginfo.Scoped_location.to_location loc)
+    | Lswitch
+      (e,s, _loc)
+      -> convert_switch e s
+    | Lstringswitch (e, cases, default, _ ) ->
+      Lam.stringswitch
+      (convert_aux e)
+      (Ext_list.map_snd cases convert_aux)
+      (Ext_option.map default convert_aux)
+    | Lstaticraise (id,[]) ->
         Lam.staticraise (Hash_int.find_default exit_map id id) []
     | Lstaticraise (id, args) ->
-        Lam.staticraise id (Ext_list.map args convert_aux)
-    | Lstaticcatch (b, (i, []), Lstaticraise (j, [])) ->
-        (* peep-hole [i] aliased to [j] *)
-        Hash_int.add exit_map i (Hash_int.find_default exit_map j j);
-        convert_aux b
+      Lam.staticraise id (Ext_list.map args convert_aux )
+    | Lstaticcatch (b, (i,[]), Lstaticraise (j,[]) )
+      -> (* peep-hole [i] aliased to [j] *)
+      Hash_int.add exit_map i (Hash_int.find_default exit_map j j);
+      convert_aux b
     | Lstaticcatch (b, (i, ids), handler) ->
-        Lam.staticcatch (convert_aux b)
-          (i, List.map fst ids)
-          (convert_aux handler)
+      Lam.staticcatch (convert_aux b) (i,(Ext_list.map ids fst)) (convert_aux handler)
     | Ltrywith (b, id, handler) ->
-        let body = convert_aux b in
-        let handler = convert_aux handler in
-        if exception_id_destructed handler id then
-          let newId = Ident.create_local ("raw_" ^ Ident.name id) in
-          Lam.try_ body newId
-            (Lam.let_ StrictOpt id
-               (prim ~primitive:Pwrap_exn ~args:[ Lam.var newId ] Location.none)
-               handler)
-        else Lam.try_ body id handler
-    | Lifthenelse (b, then_, else_) ->
-        Lam.if_ (convert_aux b) (convert_aux then_) (convert_aux else_)
-    | Lsequence (a, b) -> Lam.seq (convert_aux a) (convert_aux b)
-    | Lwhile (b, body) -> Lam.while_ (convert_aux b) (convert_aux body)
+      let body = convert_aux b in
+      let handler = convert_aux handler in
+      if exception_id_destructed handler id then
+        let newId = Ident.create_local ("raw_" ^ (Ident.name id)) in
+        Lam.try_ body newId
+                  (Lam.let_ StrictOpt id
+                    (prim ~primitive:Pwrap_exn ~args:[Lam.var newId] Location.none)
+                    handler
+                 )
+      else
+        Lam.try_  body id handler
+    | Lifthenelse (b,then_,else_) ->
+      Lam.if_ (convert_aux b) (convert_aux then_) (convert_aux else_)
+    | Lsequence (a,b)
+      -> Lam.seq (convert_aux a) (convert_aux b)
+    | Lwhile (b,body) ->
+      Lam.while_ (convert_aux b) (convert_aux body)
     | Lfor (id, from_, to_, dir, loop) ->
-        Lam.for_ id (convert_aux from_) (convert_aux to_) dir (convert_aux loop)
-    | Lassign (id, body) -> Lam.assign id (convert_aux body)
-    | Lsend (kind, a, b, ls, loc) -> (
-        (* Format.fprintf Format.err_formatter "%a@." Printlambda.lambda b ; *)
-        match convert_aux b with
-        | Lprim { primitive = Pjs_unsafe_downgrade { loc }; args } -> (
-            match kind with
-            | Public (Some name) -> (
-                let setter = Ext_string.ends_with name Literals.setter_suffix in
-                let property =
-                  if setter then
-                    Lam_methname.translate
-                      (String.sub name 0
-                         (String.length name - Literals.setter_suffix_len))
-                  else Lam_methname.translate name
-                in
-                let lam =
-                  prim
-                    ~primitive:
-                      (Pjs_unsafe_downgrade { name = property; loc; setter })
-                    ~args loc
-                in
-                match ls with
-                | [] -> lam
-                | [ arg ] ->
-                    (* Since https://github.com/ocaml/ocaml/pull/10081, `b |> a` gets
-                       turned into `a b` by the typechecker. So this actually means
-                       `(x ## y) z` rather than `x#y z` *)
-                    Lam.apply lam
-                      [ convert_aux arg ]
-                      {
-                        ap_loc = loc;
-                        ap_inlined = Default_inline;
-                        ap_status = App_na;
-                      }
-                | _ -> assert false)
-            | _ -> assert false)
+      Lam.for_ id (convert_aux from_) (convert_aux to_) dir (convert_aux loop)
+    | Lassign (id, body) ->
+      Lam.assign id (convert_aux body)
+    | Lsend (kind, a,b,ls, loc) ->
+      let a = convert_aux a in
+      let b = convert_aux b in
+      let ls = Ext_list.map ls convert_aux in
+      (* Format.fprintf Format.err_formatter "%a@." Printlambda.lambda b ; *)
+        (match b with
+        | Lprim {primitive =  Pjs_unsafe_downgrade {loc};  args}
+          ->
+            begin match kind with
+            | Public (Some name) ->
+              let setter = Ext_string.ends_with name Literals.setter_suffix in
+              let property =
+                if setter then
+                  Lam_methname.translate
+                    (String.sub name 0
+                       (String.length name - Literals.setter_suffix_len))
+                else Lam_methname.translate  name in
+              let lam = prim ~primitive:(Pjs_unsafe_downgrade {name = property;loc; setter})
+                ~args loc
+              in
+              begin match ls with
+              | [] -> lam
+              | [ arg ] ->
+                (* Since https://github.com/ocaml/ocaml/pull/10081, `b |> a` gets
+                   turned into `a b` by the typechecker. So this actually means
+                   `(x ## y) z` rather than `x#y z` *)
+                Lam.apply lam [arg]
+              {ap_loc = loc; ap_inlined= Default_inline; ap_status =  App_na}
+
+              | _ -> assert false
+              end
+            | _ -> assert false
+          end
         | b ->
-            Lam.send kind (convert_aux a) b
-              (Ext_list.map ls convert_aux)
-              (Debuginfo.Scoped_location.to_location loc))
-    | Levent _ ->
-        (* disabled by upstream*)
-        assert false
+          Lam.send kind a b ls (Debuginfo.Scoped_location.to_location loc))
+
+    | Levent (e, _ev) -> convert_aux e
     | Lifused (_, e) -> convert_aux e (* TODO: remove it ASAP *)
-  and convert_let (kind : Lam_compat.let_kind) id (e : Lambda.lambda) body :
-      Lam.t =
-    match (kind, e) with
-    | Alias, Lvar u ->
-        let new_u = Hash_ident.find_default alias_tbl u u in
-        Hash_ident.add alias_tbl id new_u;
-        if Set_ident.mem exports id then
-          Lam.let_ kind id (Lam.var new_u) (convert_aux body)
-        else convert_aux body
-    | _, _ -> (
-        let new_e = convert_aux e in
-        let new_body = convert_aux body in
-        (*
+
+  and convert_let (kind : Lam_compat.let_kind) id (e : Lambda.lambda) body : Lam.t =
+    let e = convert_aux e in
+    match kind, e with
+    | Alias , Lvar u  ->
+      let new_u = Hash_ident.find_default alias_tbl u u in
+      Hash_ident.add alias_tbl id new_u ;
+      if Set_ident.mem exports id then
+        Lam.let_ kind id (Lam.var new_u) (convert_aux body)
+      else convert_aux body
+    | _, _ ->
+      let new_body = convert_aux body in
+          (*
             reverse engineering cases as {[
            (let (switcher/1013 =a (-1+ match/1012))
                (if (isout 2 switcher/1013) (exit 1)
@@ -760,116 +896,94 @@ let convert (exports : Set_ident.t) (lam : Lambda.lambda) :
 
          To advance this case, when [sw_failaction] is None
       *)
-        match (kind, new_e, new_body) with
-        | ( Alias,
-            Lprim
-              { primitive = Poffsetint offset; args = [ (Lvar _ as matcher) ] },
-            Lswitch
-              ( Lvar switcher3,
-                ({
-                   sw_consts_full = false;
-                   sw_consts;
-                   sw_blocks = [];
-                   sw_blocks_full = true;
-                   sw_failaction = Some ifso;
-                 } as px) ) )
-          when Ident.same switcher3 id
-               && (not (Lam_hit.hit_variable id ifso))
-               && not (Ext_list.exists_snd sw_consts (Lam_hit.hit_variable id))
-          ->
-            Lam.switch matcher
-              {
-                px with
-                sw_consts =
-                  Ext_list.map sw_consts (fun (i, act) -> (i - offset, act));
-              }
-        | _ -> Lam.let_ kind id new_e new_body)
+      match kind, e, new_body with
+      | Alias, Lprim {primitive = Poffsetint offset; args =  [Lvar _ as matcher ]},
+        Lswitch (Lvar switcher3 ,
+                 ({
+                   sw_consts_full = false ;
+                   sw_consts ;
+                   sw_blocks = []; sw_blocks_full = true;
+                   sw_failaction = Some ifso
+                 } as px)
+                )
+        when Ident.same switcher3 id    &&
+             not (Lam_hit.hit_variable id ifso ) &&
+             not (Ext_list.exists_snd sw_consts (Lam_hit.hit_variable id))
+        ->
+        Lam.switch matcher
+          {px with
+           sw_consts =
+             Ext_list.map sw_consts
+               (fun (i,act) -> i - offset, act)
+          }
+      | _ ->
+        Lam.let_ kind id e new_body
+
   and convert_mutlet id (e : Lambda.lambda) body : Lam.t =
     let new_e = convert_aux e in
     let new_body = convert_aux body in
     Lam.mutlet id new_e new_body
-  and _convert_pipe (f : Lambda.lambda) (x : Lambda.lambda) outer_loc =
-    let x = convert_aux x in
-    let f = convert_aux f in
-    match f with
-    | Lfunction
-        {
-          params = [ param ];
-          body = Lprim { primitive; args = [ Lvar inner_arg ] };
-        }
-      when Ident.same param inner_arg ->
-        Lam.prim ~primitive ~args:[ x ]
-          (Debuginfo.Scoped_location.to_location outer_loc)
-    | Lapply
-        {
-          ap_func =
-            Lfunction { params; body = Lprim { primitive; args = inner_args } };
-          ap_args = args;
-        }
-      when Ext_list.for_all2_no_exn inner_args params lam_is_var
-           && Ext_list.length_larger_than_n inner_args args 1 ->
-        Lam.prim ~primitive
-          ~args:(Ext_list.append_one args x)
-          (Debuginfo.Scoped_location.to_location outer_loc)
-    | Lapply { ap_func; ap_args; ap_info } ->
-        Lam.apply ap_func
-          (Ext_list.append_one ap_args x)
-          {
-            ap_loc = Debuginfo.Scoped_location.to_location outer_loc;
-            ap_inlined = ap_info.ap_inlined;
-            ap_status = App_na;
-          }
-    | _ ->
-        Lam.apply f [ x ]
-          {
-            ap_loc = Debuginfo.Scoped_location.to_location outer_loc;
-            ap_inlined = Default_inline;
-            ap_status = App_na;
-          }
-  and convert_switch (e : Lambda.lambda) (s : Lambda.lambda_switch) =
-    let e = convert_aux e in
-    match s with
-    | {
-     sw_failaction = None;
-     sw_blocks = [];
-     sw_numblocks = 0;
-     sw_consts;
-     sw_numconsts;
-    } -> (
-        match happens_to_be_diff sw_consts with
-        | Some 0 -> e
-        | Some i ->
-            prim ~primitive:Paddint
-              ~args:
-                [
-                  e;
-                  Lam.const (Const_int { i = Int32.of_int i; comment = None });
-                ]
-              Location.none
-        | None ->
-            Lam.switch e
-              {
-                sw_failaction = None;
-                sw_blocks = [];
-                sw_blocks_full = true;
-                sw_consts = Ext_list.map_snd sw_consts convert_aux;
-                sw_consts_full = Ext_list.length_ge sw_consts sw_numconsts;
-                sw_names = s.sw_names;
-              })
-    | _ ->
-        Lam.switch e
-          {
-            sw_consts_full = Ext_list.length_ge s.sw_consts s.sw_numconsts;
-            sw_consts = Ext_list.map_snd s.sw_consts convert_aux;
-            sw_blocks_full = Ext_list.length_ge s.sw_blocks s.sw_numblocks;
-            sw_blocks = Ext_list.map_snd s.sw_blocks convert_aux;
-            sw_failaction = Ext_option.map s.sw_failaction convert_aux;
-            sw_names = s.sw_names;
-          }
-  in
-  (convert_aux lam, may_depends)
 
-(* FIXME: more precise analysis of [id], if it is not
+  and _convert_pipe (f : Lambda.lambda) (x : Lambda.lambda) outer_loc =
+      let x  = convert_aux x in
+      let f =  convert_aux f in
+      match  f with
+      | Lfunction {params = [param]; body = Lprim{primitive; args = [Lvar inner_arg];  }}
+        when Ident.same param inner_arg ->
+        Lam.prim ~primitive ~args:[x] (Debuginfo.Scoped_location.to_location outer_loc)
+      | Lapply {ap_func = Lfunction{params; body = Lprim{primitive; args = inner_args}}; ap_args=args}
+        when Ext_list.for_all2_no_exn inner_args params lam_is_var &&
+             Ext_list.length_larger_than_n inner_args args 1
+        ->
+        Lam.prim ~primitive ~args:(Ext_list.append_one args x) (Debuginfo.Scoped_location.to_location outer_loc)
+      | Lapply{ap_func;ap_args; ap_info} ->
+        Lam.apply ap_func (Ext_list.append_one ap_args x) {ap_loc = Debuginfo.Scoped_location.to_location outer_loc; ap_inlined = ap_info.ap_inlined; ap_status =  App_na }
+      | _ ->
+        Lam.apply f [x] {ap_loc = Debuginfo.Scoped_location.to_location outer_loc; ap_inlined = Default_inline; ap_status = App_na}
+    and convert_switch (e : Lambda.lambda) (s : Lambda.lambda_switch) =
+        let e = convert_aux e in
+        match s with
+        | {
+          sw_failaction = None ;
+          sw_blocks = [];
+          sw_numblocks = 0;
+          sw_consts ;
+          sw_numconsts ;
+        } ->
+          let sw_consts =
+              Ext_list.map
+                sw_consts
+                (fun (i, lam) -> i, convert_aux lam) in
+          begin match happens_to_be_diff sw_consts with
+            | Some 0l -> e
+            | Some i ->
+              prim
+                ~primitive:Paddint
+                ~args:[e; Lam.const(Const_int {i; comment = None})]
+                Location.none
+            | None ->
+              Lam.switch e
+                {sw_failaction = None;
+                 sw_blocks = [];
+                 sw_blocks_full = true;
+                 sw_consts = sw_consts;
+                 sw_consts_full =
+                   Ext_list.length_ge sw_consts sw_numconsts;
+                 sw_names = s.sw_names;
+                }
+          end
+        | _ ->
+          Lam.switch  e
+            { sw_consts_full =  Ext_list.length_ge s.sw_consts s.sw_numconsts ;
+              sw_consts = Ext_list.map_snd  s.sw_consts convert_aux;
+              sw_blocks_full = Ext_list.length_ge s.sw_blocks s.sw_numblocks;
+              sw_blocks = Ext_list.map_snd s.sw_blocks convert_aux;
+              sw_failaction =Ext_option.map s.sw_failaction convert_aux;
+              sw_names = s.sw_names } in
+  convert_aux lam , may_depends
+
+
+(** FIXME: more precise analysis of [id], if it is not
     used, we can remove it
         only two places emit [Lifused],
         {[
@@ -885,9 +999,10 @@ let convert (exports : Set_ident.t) (lam : Lambda.lambda) :
 
         | Lifused(v, l) ->
           if count_var v > 0 then simplif l else lambda_unit
-*)
+      *)
 
-(*
+
+      (*
         | Lfunction(kind,params,Lprim(prim,inner_args,inner_loc))
           when List.for_all2_no_exn (fun x y ->
           match y with

--- a/jscomp/core/lam_convert.ml
+++ b/jscomp/core/lam_convert.ml
@@ -22,24 +22,20 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+let caml_id_field_info : Lambda.field_dbg_info =
+  Fld_record { name = Literals.exception_id; mutable_flag = Immutable }
 
-let caml_id_field_info : Lambda.field_dbg_info = Fld_record {name = Literals.exception_id; mutable_flag = Immutable;}
-let lam_caml_id : Lam_primitive.t = Pfield(0, caml_id_field_info)
-
+let lam_caml_id : Lam_primitive.t = Pfield (0, caml_id_field_info)
 let prim = Lam.prim
 
-
 let lam_extension_id loc (head : Lam.t) =
-  prim ~primitive:lam_caml_id ~args:[head] loc
+  prim ~primitive:lam_caml_id ~args:[ head ] loc
 
 let lazy_block_info : Lam_tag_info.t =
-  Blk_record
-    [|Literals.lazy_done;
-      Literals.lazy_val|]
+  Blk_record [| Literals.lazy_done; Literals.lazy_val |]
 
 let unbox_extension info (args : Lam.t list) mutable_flag loc =
-    prim ~primitive:(Pmakeblock (0,info,mutable_flag)) ~args loc
-
+  prim ~primitive:(Pmakeblock (0, info, mutable_flag)) ~args loc
 
 (** A conservative approach to avoid packing exceptions
     for lambda expression like {[
@@ -70,120 +66,84 @@ let unbox_extension info (args : Lam.t list) mutable_flag loc =
     It is hard to judge an exception is destructed or escaped, any potential
     alias(or if it is passed as an argument) would cause it to be leaked
 *)
-let exception_id_destructed (l : Lam.t) (fv : Ident.t): bool  =
-  let rec
-    hit_opt (x : _ option) =
-  match x with
-  | None -> false
-  | Some a -> hit a
-  and hit_list_snd : 'a. ('a * _ ) list -> bool = fun x ->
-    Ext_list.exists_snd  x  hit
+let exception_id_destructed (l : Lam.t) (fv : Ident.t) : bool =
+  let rec hit_opt (x : _ option) =
+    match x with None -> false | Some a -> hit a
+  and hit_list_snd : 'a. ('a * _) list -> bool =
+   fun x -> Ext_list.exists_snd x hit
   and hit_list xs = Ext_list.exists xs hit
   and hit (l : Lam.t) =
-    match l  with
+    match l with
     (* | Lprim {primitive = Pintcomp _ ;
-             args = ([x;y ])  } ->
-      begin match x,y with
-        | Lvar _, Lvar _ -> false
-        | Lvar _, _ -> hit y
-        | _, Lvar _ -> hit x
-        | _, _  -> hit x || hit y
-      end *) (* FIXME: this can be uncovered after we do the unboxing *)
-    | Lprim {primitive = Praise ; args = [Lvar _]} -> false
-    | Lprim {primitive = _; args; _} ->
-      hit_list args
-    | Lvar id
-    | Lmutvar id ->
-      Ident.same id fv
-    | Lassign(id, e) ->
-      Ident.same id fv || hit e
-    | Lstaticcatch(e1, (_,_vars), e2) ->
-      hit e1 || hit e2
-    | Ltrywith(e1, _exn, e2) ->
-      hit e1 || hit e2
-    | Lfunction{body;params=_} ->
-      hit body;
-    | Llet(_, _id, arg, body)
-    | Lmutlet (_id, arg, body) ->
-      hit arg || hit body
-    | Lletrec(decl, body) ->
-      hit body ||
-      hit_list_snd decl
-    | Lfor(_v, e1, e2, _dir, e3) ->
-      hit e1 || hit e2 || hit e3
+              args = ([x;y ])  } ->
+       begin match x,y with
+         | Lvar _, Lvar _ -> false
+         | Lvar _, _ -> hit y
+         | _, Lvar _ -> hit x
+         | _, _  -> hit x || hit y
+       end *)
+    (* FIXME: this can be uncovered after we do the unboxing *)
+    | Lprim { primitive = Praise; args = [ Lvar _ ] } -> false
+    | Lprim { primitive = _; args; _ } -> hit_list args
+    | Lvar id | Lmutvar id -> Ident.same id fv
+    | Lassign (id, e) -> Ident.same id fv || hit e
+    | Lstaticcatch (e1, (_, _vars), e2) -> hit e1 || hit e2
+    | Ltrywith (e1, _exn, e2) -> hit e1 || hit e2
+    | Lfunction { body; params = _ } -> hit body
+    | Llet (_, _id, arg, body) | Lmutlet (_id, arg, body) -> hit arg || hit body
+    | Lletrec (decl, body) -> hit body || hit_list_snd decl
+    | Lfor (_v, e1, e2, _dir, e3) -> hit e1 || hit e2 || hit e3
     | Lconst _ -> false
-    | Lapply{ap_func; ap_args; _} ->
-      hit ap_func || hit_list ap_args
-    | Lglobal_module _  (* global persistent module, play safe *)
-      -> false
-    | Lswitch(arg, sw) ->
-      hit arg ||
-      hit_list_snd sw.sw_consts ||
-      hit_list_snd sw.sw_blocks ||
-      hit_opt sw.sw_failaction
-    | Lstringswitch (arg,cases,default) ->
-      hit arg ||
-      hit_list_snd cases ||
-      hit_opt default
-    | Lstaticraise (_,args) ->
-      hit_list args
-    | Lifthenelse(e1, e2, e3) ->
-      hit e1 || hit e2 || hit e3
-    | Lsequence(e1, e2) ->
-      hit e1 || hit e2
-    | Lwhile(e1, e2) ->
-      hit e1 || hit e2
-    | Lsend (_k, met, obj, args, _) ->
-      hit met || hit obj || hit_list args
-  in hit l
+    | Lapply { ap_func; ap_args; _ } -> hit ap_func || hit_list ap_args
+    | Lglobal_module _ (* global persistent module, play safe *) -> false
+    | Lswitch (arg, sw) ->
+        hit arg || hit_list_snd sw.sw_consts || hit_list_snd sw.sw_blocks
+        || hit_opt sw.sw_failaction
+    | Lstringswitch (arg, cases, default) ->
+        hit arg || hit_list_snd cases || hit_opt default
+    | Lstaticraise (_, args) -> hit_list args
+    | Lifthenelse (e1, e2, e3) -> hit e1 || hit e2 || hit e3
+    | Lsequence (e1, e2) -> hit e1 || hit e2
+    | Lwhile (e1, e2) -> hit e1 || hit e2
+    | Lsend (_k, met, obj, args, _) -> hit met || hit obj || hit_list args
+  in
+  hit l
 
-
-let abs_int x = if x < 0 then - x else x
-let no_over_flow x  = abs_int x < 0x1fff_ffff
-let no_over_flow_int32 x  = (Int32.abs x) < 0x1fff_ffffl
+let abs_int x = if x < 0 then -x else x
+let no_over_flow x = abs_int x < 0x1fff_ffff
+let no_over_flow_int32 x = Int32.abs x < 0x1fff_ffffl
 
 let lam_is_var (x : Lam.t) (y : Ident.t) =
-  match x with
-  | Lvar y2 | Lmutvar y2 -> Ident.same y2 y
-  | _ -> false
+  match x with Lvar y2 | Lmutvar y2 -> Ident.same y2 y | _ -> false
 
 (** Make sure no int range overflow happens
     also we only check [int]
 *)
-let happens_to_be_diff
-    (sw_consts :
-       (int * Lam.t) list) : int32 option =
+let happens_to_be_diff (sw_consts : (int * Lam.t) list) : int32 option =
   match sw_consts with
-  | (a, Lconst (Const_int { i = a0; comment = _ }))::
-    (b, Lconst (Const_int { i = b0; comment = _ }))::
-    rest when
-     no_over_flow a  &&
-     no_over_flow_int32 a0 &&
-     no_over_flow b &&
-     no_over_flow_int32 b0 ->
-    let a = Int32.of_int a in
-    let b = Int32.of_int b in
-    let diff = Int32.sub a0 a in
-    if Int32.sub b0 b = diff then
-      if Ext_list.for_all rest (fun (x, lam) ->
-          match lam with
-          | Lconst (Const_int { i = x0; comment = _ })
-            when no_over_flow_int32 x0 && no_over_flow x ->
-            let x = Int32.of_int x in
-            Int32.sub x0 x = diff
-          | _ -> false
-        ) then
-        Some diff
-      else
-        None
-    else None
+  | (a, Lconst (Const_int { i = a0; comment = _ }))
+    :: (b, Lconst (Const_int { i = b0; comment = _ }))
+    :: rest
+    when no_over_flow a && no_over_flow_int32 a0 && no_over_flow b
+         && no_over_flow_int32 b0 ->
+      let a = Int32.of_int a in
+      let b = Int32.of_int b in
+      let diff = Int32.sub a0 a in
+      if Int32.sub b0 b = diff then
+        if
+          Ext_list.for_all rest (fun (x, lam) ->
+              match lam with
+              | Lconst (Const_int { i = x0; comment = _ })
+                when no_over_flow_int32 x0 && no_over_flow x ->
+                  let x = Int32.of_int x in
+                  Int32.sub x0 x = diff
+              | _ -> false)
+        then Some diff
+        else None
+      else None
   | _ -> None
 
-
-
-
 (* type required_modules = Lam_module_ident.Hash_set.t *)
-
 
 (** drop Lseq (List! ) etc
   see #3852, we drop all these required global modules
@@ -191,162 +151,137 @@ let happens_to_be_diff
 *)
 let rec drop_global_marker (lam : Lam.t) =
   match lam with
-  | Lsequence (Lglobal_module _, rest) ->
-    drop_global_marker rest
+  | Lsequence (Lglobal_module _, rest) -> drop_global_marker rest
   | _ -> lam
 
 let seq = Lam.seq
 let unit = Lam.unit
 
-let convert_record_repr ( x : Types.record_representation)
-  : Lam_primitive.record_representation =
+let convert_record_repr (x : Types.record_representation) :
+    Lam_primitive.record_representation =
   match x with
-  | Record_regular
-  | Record_float ->  Record_regular
+  | Record_regular | Record_float -> Record_regular
   | Record_extension _ -> Record_extension
-  | Record_unboxed _ -> assert false
-    (* see patches in {!Typedecl.get_unboxed_from_attributes}*)
-  | Record_inlined {tag; name; num_nonconsts} ->
-    Record_inlined {tag; name; num_nonconsts}
+  | Record_unboxed _ ->
+      assert false (* see patches in {!Typedecl.get_unboxed_from_attributes}*)
+  | Record_inlined { tag; name; num_nonconsts } ->
+      Record_inlined { tag; name; num_nonconsts }
 
-
-let lam_prim ~primitive:( p : Lambda.primitive) ~args loc : Lam.t =
+let lam_prim ~primitive:(p : Lambda.primitive) ~args loc : Lam.t =
   match p with
   | Pint_as_pointer
   (* | Pidentity -> Ext_list.singleton_exn args *)
-  | Pccall _ -> assert false
-
-  | Pbytes_to_string (* handled very early *)
-    -> prim ~primitive:Pbytes_to_string ~args loc
+  | Pccall _ ->
+      assert false
+  | Pbytes_to_string (* handled very early *) ->
+      prim ~primitive:Pbytes_to_string ~args loc
   | Pbytes_of_string -> prim ~primitive:Pbytes_of_string ~args loc
-  | Pignore -> (* Pignore means return unit, it is not an nop *)
-    seq (Ext_list.singleton_exn args) unit
-
+  | Pignore ->
+      (* Pignore means return unit, it is not an nop *)
+      seq (Ext_list.singleton_exn args) unit
   | Pcompare_ints ->
-    prim ~primitive:(Pccall {prim_name = "caml_int_compare" }) ~args loc
+      prim ~primitive:(Pccall { prim_name = "caml_int_compare" }) ~args loc
   | Pcompare_floats ->
-    prim ~primitive:(Pccall {prim_name = "caml_float_compare" }) ~args loc
-  | Pcompare_bints Pnativeint ->  assert false
+      prim ~primitive:(Pccall { prim_name = "caml_float_compare" }) ~args loc
+  | Pcompare_bints Pnativeint -> assert false
   | Pcompare_bints Pint32 ->
-    prim ~primitive:(Pccall {prim_name = "caml_int32_compare"}) ~args loc
+      prim ~primitive:(Pccall { prim_name = "caml_int32_compare" }) ~args loc
   | Pcompare_bints Pint64 ->
-    prim ~primitive:(Pccall {prim_name = "caml_int64_compare"}) ~args loc
-  | Pgetglobal _ ->
-    assert false
+      prim ~primitive:(Pccall { prim_name = "caml_int64_compare" }) ~args loc
+  | Pgetglobal _ -> assert false
   | Psetglobal _ ->
-    (* we discard [Psetglobal] in the beginning*)
-    drop_global_marker (Ext_list.singleton_exn args)
+      (* we discard [Psetglobal] in the beginning*)
+      drop_global_marker (Ext_list.singleton_exn args)
   (* prim ~primitive:(Psetglobal id) ~args loc *)
-  | Pmakeblock (tag,info, mutable_flag
-    , _block_shape
-  )
-    ->
-    begin match info with
-    | Blk_some_not_nested
-      ->
-      prim ~primitive:Psome_not_nest ~args loc
-    | Blk_some
-      ->
-      prim ~primitive:Psome ~args loc
-    | Blk_constructor{name ; num_nonconst } ->
-      let info : Lam_tag_info.t = Blk_constructor {name; num_nonconst} in
-      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
-    | Blk_tuple  ->
-      let info : Lam_tag_info.t = Blk_tuple in
-      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
-    | Blk_extension  ->
-      let info : Lam_tag_info.t = Blk_extension in
-      unbox_extension info args mutable_flag loc
-    | Blk_record_ext s ->
-      let info : Lam_tag_info.t = Blk_record_ext s in
-      unbox_extension info args mutable_flag loc
-    | Blk_extension_slot ->
-      (
-        match args with
-        | [ Lconst (Const_string name)] ->
-          prim ~primitive:(Pcreate_extension name) ~args:[] loc
-        | _ ->
-          assert false
-      )
-
-    | Blk_class  ->
-      let info : Lam_tag_info.t = Blk_class in
-      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
-    | Blk_array ->
-      let info : Lam_tag_info.t = Blk_array in
-      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
-    | Blk_record s ->
-      let info : Lam_tag_info.t = Blk_record s in
-      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
-    | Blk_record_inlined {name; fields; num_nonconst} ->
-      let info : Lam_tag_info.t = Blk_record_inlined {name; fields; num_nonconst} in
-      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
-    | Blk_module s ->
-      let info : Lam_tag_info.t = Blk_module s in
-      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
-    | Blk_module_export _ ->
-      let info : Lam_tag_info.t = Blk_module_export in
-      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
-    | Blk_poly_var s ->
-      begin match args with
-      | [_; value] ->
-        let info : Lam_tag_info.t = Blk_poly_var  in
-        prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args:[Lam.const (Const_string s); value] loc
-      | _ -> assert false
-      end
-    | Blk_lazy_general
-      ->
-      begin match args with
-      | [Lvar _ | Lmutvar _ | Lconst _ | Lfunction _ as result ] ->
-        let args =
-          [ Lam.const Const_js_true ;
-           result
-          ] in
-        prim ~primitive:(Pmakeblock (tag,lazy_block_info,Mutable)) ~args loc
-      | [computation] ->
-        let args =
-          [ Lam.const Const_js_false ;
-            (* FIXME: arity 0 does not get proper supported*)
-            Lam.function_
-              ~arity:0
-              ~params:[] ~body:computation
-              ~attr:Lambda.default_function_attribute
-          ] in
-        prim ~primitive:(Pmakeblock (tag,lazy_block_info,Mutable)) ~args loc
-
-      | _ -> assert false
-      end
-    | Blk_na s ->
-      let info : Lam_tag_info.t = Blk_na s in
-      prim ~primitive:(Pmakeblock (tag,info,mutable_flag)) ~args loc
-    end
-  | Pfield (id,info)
-    -> prim ~primitive:(Pfield (id,info)) ~args loc
-
-  | Psetfield (id, _,
-    _initialization_or_assignment,
-      info)
-    -> prim ~primitive:(Psetfield (id,info)) ~args loc
-  | Psetfloatfield _
-  | Pfloatfield _
-    -> assert false
-  | Pduprecord (repr,_)
-    -> prim ~primitive:(Pduprecord (convert_record_repr repr)) ~args loc
-  | Praise _ ->
-    prim ~primitive:Praise ~args loc
+  | Pmakeblock (tag, info, mutable_flag, _block_shape) -> (
+      match info with
+      | Blk_some_not_nested -> prim ~primitive:Psome_not_nest ~args loc
+      | Blk_some -> prim ~primitive:Psome ~args loc
+      | Blk_constructor { name; num_nonconst } ->
+          let info : Lam_tag_info.t = Blk_constructor { name; num_nonconst } in
+          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
+      | Blk_tuple ->
+          let info : Lam_tag_info.t = Blk_tuple in
+          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
+      | Blk_extension ->
+          let info : Lam_tag_info.t = Blk_extension in
+          unbox_extension info args mutable_flag loc
+      | Blk_record_ext s ->
+          let info : Lam_tag_info.t = Blk_record_ext s in
+          unbox_extension info args mutable_flag loc
+      | Blk_extension_slot -> (
+          match args with
+          | [ Lconst (Const_string name) ] ->
+              prim ~primitive:(Pcreate_extension name) ~args:[] loc
+          | _ -> assert false)
+      | Blk_class ->
+          let info : Lam_tag_info.t = Blk_class in
+          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
+      | Blk_array ->
+          let info : Lam_tag_info.t = Blk_array in
+          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
+      | Blk_record s ->
+          let info : Lam_tag_info.t = Blk_record s in
+          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
+      | Blk_record_inlined { name; fields; num_nonconst } ->
+          let info : Lam_tag_info.t =
+            Blk_record_inlined { name; fields; num_nonconst }
+          in
+          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
+      | Blk_module s ->
+          let info : Lam_tag_info.t = Blk_module s in
+          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
+      | Blk_module_export _ ->
+          let info : Lam_tag_info.t = Blk_module_export in
+          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc
+      | Blk_poly_var s -> (
+          match args with
+          | [ _; value ] ->
+              let info : Lam_tag_info.t = Blk_poly_var in
+              prim
+                ~primitive:(Pmakeblock (tag, info, mutable_flag))
+                ~args:[ Lam.const (Const_string s); value ]
+                loc
+          | _ -> assert false)
+      | Blk_lazy_general -> (
+          match args with
+          | [ ((Lvar _ | Lmutvar _ | Lconst _ | Lfunction _) as result) ] ->
+              let args = [ Lam.const Const_js_true; result ] in
+              prim
+                ~primitive:(Pmakeblock (tag, lazy_block_info, Mutable))
+                ~args loc
+          | [ computation ] ->
+              let args =
+                [
+                  Lam.const Const_js_false;
+                  (* FIXME: arity 0 does not get proper supported*)
+                  Lam.function_ ~arity:0 ~params:[] ~body:computation
+                    ~attr:Lambda.default_function_attribute;
+                ]
+              in
+              prim
+                ~primitive:(Pmakeblock (tag, lazy_block_info, Mutable))
+                ~args loc
+          | _ -> assert false)
+      | Blk_na s ->
+          let info : Lam_tag_info.t = Blk_na s in
+          prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc)
+  | Pfield (id, info) -> prim ~primitive:(Pfield (id, info)) ~args loc
+  | Psetfield (id, _, _initialization_or_assignment, info) ->
+      prim ~primitive:(Psetfield (id, info)) ~args loc
+  | Psetfloatfield _ | Pfloatfield _ -> assert false
+  | Pduprecord (repr, _) ->
+      prim ~primitive:(Pduprecord (convert_record_repr repr)) ~args loc
+  | Praise _ -> prim ~primitive:Praise ~args loc
   | Psequand -> prim ~primitive:Psequand ~args loc
   | Psequor -> prim ~primitive:Psequor ~args loc
   | Pnot -> prim ~primitive:Pnot ~args loc
-  | Pnegint -> prim ~primitive:Pnegint ~args  loc
+  | Pnegint -> prim ~primitive:Pnegint ~args loc
   | Paddint -> prim ~primitive:Paddint ~args loc
   | Psubint -> prim ~primitive:Psubint ~args loc
   | Pmulint -> prim ~primitive:Pmulint ~args loc
-  | Pdivint
-    _is_safe (*FIXME*)
-    -> prim ~primitive:Pdivint ~args loc
-  | Pmodint
-    _is_safe (*FIXME*)
-    -> prim ~primitive:Pmodint ~args loc
+  | Pdivint _is_safe (*FIXME*) -> prim ~primitive:Pdivint ~args loc
+  | Pmodint _is_safe (*FIXME*) -> prim ~primitive:Pmodint ~args loc
   | Pandint -> prim ~primitive:Pandint ~args loc
   | Porint -> prim ~primitive:Porint ~args loc
   | Pxorint -> prim ~primitive:Pxorint ~args loc
@@ -359,530 +294,438 @@ let lam_prim ~primitive:( p : Lambda.primitive) ~args loc : Lam.t =
   | Pstringrefs -> prim ~primitive:Pstringrefs ~args loc
   | Pbyteslength -> prim ~primitive:Pbyteslength ~args loc
   | Pbytesrefu -> prim ~primitive:Pbytesrefu ~args loc
-  | Pbytessetu -> prim ~primitive:Pbytessetu ~args  loc
+  | Pbytessetu -> prim ~primitive:Pbytessetu ~args loc
   | Pbytesrefs -> prim ~primitive:Pbytesrefs ~args loc
   | Pbytessets -> prim ~primitive:Pbytessets ~args loc
   | Pisint -> prim ~primitive:Pisint ~args loc
-  | Pisout ->
-    begin match args with
-    | [ range; Lprim {primitive = Poffsetint i; args = [x]}] ->
-
-      prim ~primitive:(Pisout i) ~args:[range;x] loc
-    | _ ->
-      prim ~primitive:(Pisout 0) ~args loc
-    end
+  | Pisout -> (
+      match args with
+      | [ range; Lprim { primitive = Poffsetint i; args = [ x ] } ] ->
+          prim ~primitive:(Pisout i) ~args:[ range; x ] loc
+      | _ -> prim ~primitive:(Pisout 0) ~args loc)
   | Pintoffloat -> prim ~primitive:Pintoffloat ~args loc
   | Pfloatofint -> prim ~primitive:Pfloatofint ~args loc
   | Pnegfloat -> prim ~primitive:Pnegfloat ~args loc
-
   | Paddfloat -> prim ~primitive:Paddfloat ~args loc
   | Psubfloat -> prim ~primitive:Psubfloat ~args loc
   | Pmulfloat -> prim ~primitive:Pmulfloat ~args loc
   | Pdivfloat -> prim ~primitive:Pdivfloat ~args loc
-  | Pintcomp x -> prim ~primitive:(Pintcomp x)  ~args loc
+  | Pintcomp x -> prim ~primitive:(Pintcomp x) ~args loc
   | Poffsetint x -> prim ~primitive:(Poffsetint x) ~args loc
-  | Poffsetref x -> prim ~primitive:(Poffsetref x) ~args  loc
+  | Poffsetref x -> prim ~primitive:(Poffsetref x) ~args loc
   | Pfloatcomp x -> prim ~primitive:(Pfloatcomp x) ~args loc
-  | Pmakearray
-    (_, _mutable_flag) (*FIXME*)
-    -> prim ~primitive:Pmakearray ~args  loc
+  | Pmakearray (_, _mutable_flag) (*FIXME*) ->
+      prim ~primitive:Pmakearray ~args loc
   | Parraylength _ -> prim ~primitive:Parraylength ~args loc
-  | Parrayrefu _ -> prim ~primitive:(Parrayrefu ) ~args loc
-  | Parraysetu _ -> prim ~primitive:(Parraysetu ) ~args loc
-  | Parrayrefs _ -> prim ~primitive:(Parrayrefs ) ~args loc
-  | Parraysets _ -> prim ~primitive:(Parraysets ) ~args loc
-  | Pbintofint x ->
-    begin match x with
-    | Pint32 | Pnativeint -> Ext_list.singleton_exn args
-    | Pint64 -> prim ~primitive:(Pint64ofint ) ~args loc
-    end
-  | Pintofbint x ->
-    begin match x with
+  | Parrayrefu _ -> prim ~primitive:Parrayrefu ~args loc
+  | Parraysetu _ -> prim ~primitive:Parraysetu ~args loc
+  | Parrayrefs _ -> prim ~primitive:Parrayrefs ~args loc
+  | Parraysets _ -> prim ~primitive:Parraysets ~args loc
+  | Pbintofint x -> (
+      match x with
       | Pint32 | Pnativeint -> Ext_list.singleton_exn args
-      | Pint64 -> prim ~primitive:Pintofint64  ~args loc
-    end
-  | Pnegbint x ->
-    begin match x with
-    | Pnativeint
-    | Pint32 -> prim ~primitive:Pnegint ~args loc
-    | Pint64 -> prim ~primitive:Pnegint64 ~args loc
-    end
-  | Paddbint x ->
-    begin match x with
-    | Pnativeint
-    | Pint32  -> prim ~primitive:Paddint ~args loc
-    | Pint64 -> prim ~primitive:Paddint64 ~args loc
-    end
-  | Psubbint x ->
-    begin match x with
-    | Pnativeint
-    | Pint32 -> prim ~primitive:(Psubint) ~args loc
-    | Pint64 -> prim ~primitive:(Psubint64) ~args loc
-    end
-  | Pmulbint x ->
-    begin match x with
-    | Pnativeint
-    | Pint32 -> prim ~primitive:Pmulint ~args loc
-    | Pint64 -> prim ~primitive:Pmulint64 ~args loc
-    end
-  | Pdivbint
-    {size = x; is_safe = _} (*FIXME*)
-    ->
-    begin match x with
-    | Pnativeint
-    | Pint32 ->  prim ~primitive:(Pdivint) ~args loc
-    | Pint64->  prim ~primitive:(Pdivint64) ~args loc
-    end
-  | Pmodbint
-    {size = x; is_safe = _} (*FIXME*)
-    ->
-      begin match x with
-      | Pnativeint
-      | Pint32 -> prim ~primitive:(Pmodint ) ~args loc
-      | Pint64 -> prim ~primitive:(Pmodint64 ) ~args loc
-      end
-  | Pandbint x ->
-    begin match x with
-      | Pnativeint
-      | Pint32 ->
-        prim ~primitive:(Pandint ) ~args loc
-      | Pint64 -> prim ~primitive:(Pandint64 ) ~args loc
-    end
-  | Porbint x ->
-    begin match x with
-      | Pnativeint
-      | Pint32 ->
-        prim ~primitive:(Porint ) ~args loc
-      | Pint64 ->
-        prim ~primitive:(Porint64 ) ~args loc
-    end
-  | Pxorbint x ->
-    begin match x with
-      | Pnativeint
-      | Pint32 ->
-        prim ~primitive:(Pxorint ) ~args loc
-      | Pint64 ->
-        prim ~primitive:(Pxorint64 ) ~args loc
-    end
-  | Plslbint x ->
-    begin match x with
-    | Pnativeint
-    | Pint32 -> prim ~primitive:(Plslint) ~args loc
-    | Pint64 -> prim ~primitive:(Plslint64) ~args loc
-    end
-  | Plsrbint x ->
-    begin match x with
-    | Pnativeint
-    | Pint32 -> prim ~primitive:(Plsrint) ~args loc
-    | Pint64 -> prim ~primitive:(Plsrint64) ~args loc
-    end
-  | Pasrbint x ->
-    begin match x with
-    | Pnativeint
-    | Pint32 -> prim ~primitive:(Pasrint) ~args loc
-    | Pint64 -> prim ~primitive:(Pasrint64) ~args loc
-    end
-  | Pbigarraydim _
-  | Pbigstring_load_16 _
-  | Pbigstring_load_32 _
-  | Pbigstring_load_64 _
-  | Pbigstring_set_16 _
-  | Pbigstring_set_32 _
-  | Pbigstring_set_64 _
-  | Pbytes_load_16 _
-  | Pbytes_load_32 _
-  | Pbytes_load_64 _
-  | Pbytes_set_16 _
-  | Pbytes_set_32 _
-  | Pbytes_set_64 _
-  | Pstring_load_16 _
-  | Pstring_load_32 _
-  | Pstring_load_64 _
-  | Pbigarrayref _
-  | Pbigarrayset _ ->
-    Location.raise_errorf ~loc "unsupported primitive"
-  | Pctconst x ->
-    begin match x with
-      | Word_size
-      | Int_size -> Lam.const(Const_int {i = 32l; comment = None})
-      | Max_wosize -> Lam.const (Const_int {i = 2147483647l; comment = Some "Max_wosize"})
-      | Big_endian
-        -> prim ~primitive:(Pctconst Big_endian) ~args loc
-      | Ostype_unix
-        -> prim ~primitive:(Pctconst Ostype_unix) ~args loc
-      | Ostype_win32
-        -> prim ~primitive:(Pctconst Ostype_win32) ~args loc
-      | Ostype_cygwin
-        -> Lam.false_
-      | Backend_type
-        -> prim ~primitive:(Pctconst Backend_type) ~args loc
-    end
-
-
-  | Pcvtbint (a,b) ->
-    begin match a, b with
-    | (Pnativeint | Pint32), (Pnativeint | Pint32)
-    | Pint64, Pint64 ->   Ext_list.singleton_exn args
-    | Pint64, (Pnativeint | Pint32)
-      ->
-      prim ~primitive:(Pintofint64) ~args loc
-    | (Pnativeint | Pint32) , Pint64
-      ->
-      prim ~primitive:(Pint64ofint) ~args loc
-    end
-  | Pbintcomp (a,b) ->
-    begin match a with
-    | Pnativeint
-    | Pint32 -> prim ~primitive:(Pintcomp b) ~args loc
-    | Pint64 -> prim ~primitive:(Pint64comp b) ~args loc
-    end
-  | Pfield_computed ->
-    prim ~primitive:Pfield_computed ~args loc
+      | Pint64 -> prim ~primitive:Pint64ofint ~args loc)
+  | Pintofbint x -> (
+      match x with
+      | Pint32 | Pnativeint -> Ext_list.singleton_exn args
+      | Pint64 -> prim ~primitive:Pintofint64 ~args loc)
+  | Pnegbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Pnegint ~args loc
+      | Pint64 -> prim ~primitive:Pnegint64 ~args loc)
+  | Paddbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Paddint ~args loc
+      | Pint64 -> prim ~primitive:Paddint64 ~args loc)
+  | Psubbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Psubint ~args loc
+      | Pint64 -> prim ~primitive:Psubint64 ~args loc)
+  | Pmulbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Pmulint ~args loc
+      | Pint64 -> prim ~primitive:Pmulint64 ~args loc)
+  | Pdivbint { size = x; is_safe = _ } (*FIXME*) -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Pdivint ~args loc
+      | Pint64 -> prim ~primitive:Pdivint64 ~args loc)
+  | Pmodbint { size = x; is_safe = _ } (*FIXME*) -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Pmodint ~args loc
+      | Pint64 -> prim ~primitive:Pmodint64 ~args loc)
+  | Pandbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Pandint ~args loc
+      | Pint64 -> prim ~primitive:Pandint64 ~args loc)
+  | Porbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Porint ~args loc
+      | Pint64 -> prim ~primitive:Porint64 ~args loc)
+  | Pxorbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Pxorint ~args loc
+      | Pint64 -> prim ~primitive:Pxorint64 ~args loc)
+  | Plslbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Plslint ~args loc
+      | Pint64 -> prim ~primitive:Plslint64 ~args loc)
+  | Plsrbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Plsrint ~args loc
+      | Pint64 -> prim ~primitive:Plsrint64 ~args loc)
+  | Pasrbint x -> (
+      match x with
+      | Pnativeint | Pint32 -> prim ~primitive:Pasrint ~args loc
+      | Pint64 -> prim ~primitive:Pasrint64 ~args loc)
+  | Pbigarraydim _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
+  | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
+  | Pbigstring_set_64 _ | Pbytes_load_16 _ | Pbytes_load_32 _ | Pbytes_load_64 _
+  | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_64 _ | Pstring_load_16 _
+  | Pstring_load_32 _ | Pstring_load_64 _ | Pbigarrayref _ | Pbigarrayset _ ->
+      Location.raise_errorf ~loc "unsupported primitive"
+  | Pctconst x -> (
+      match x with
+      | Word_size | Int_size ->
+          Lam.const (Const_int { i = 32l; comment = None })
+      | Max_wosize ->
+          Lam.const (Const_int { i = 2147483647l; comment = Some "Max_wosize" })
+      | Big_endian -> prim ~primitive:(Pctconst Big_endian) ~args loc
+      | Ostype_unix -> prim ~primitive:(Pctconst Ostype_unix) ~args loc
+      | Ostype_win32 -> prim ~primitive:(Pctconst Ostype_win32) ~args loc
+      | Ostype_cygwin -> Lam.false_
+      | Backend_type -> prim ~primitive:(Pctconst Backend_type) ~args loc)
+  | Pcvtbint (a, b) -> (
+      match (a, b) with
+      | (Pnativeint | Pint32), (Pnativeint | Pint32) | Pint64, Pint64 ->
+          Ext_list.singleton_exn args
+      | Pint64, (Pnativeint | Pint32) -> prim ~primitive:Pintofint64 ~args loc
+      | (Pnativeint | Pint32), Pint64 -> prim ~primitive:Pint64ofint ~args loc)
+  | Pbintcomp (a, b) -> (
+      match a with
+      | Pnativeint | Pint32 -> prim ~primitive:(Pintcomp b) ~args loc
+      | Pint64 -> prim ~primitive:(Pint64comp b) ~args loc)
+  | Pfield_computed -> prim ~primitive:Pfield_computed ~args loc
   | Popaque -> Ext_list.singleton_exn args
-  | Psetfield_computed _ ->
-    prim ~primitive:Psetfield_computed ~args loc
-  | Pbbswap _
-  | Pbswap16
-  | Pduparray _ ->  assert false
-    (* Does not exist since we compile array in js backend unlike native backend *)
-
+  | Psetfield_computed _ -> prim ~primitive:Psetfield_computed ~args loc
+  | Pbbswap _ | Pbswap16 | Pduparray _ -> assert false
+(* Does not exist since we compile array in js backend unlike native backend *)
 
 let may_depend = Lam_module_ident.Hash_set.add
 
-
 let rec rename_optional_parameters map params (body : Lam.t) =
   match body with
-  | Llet(k,id, (Lifthenelse(
-      Lprim({ primitive = p; args = [Lvar opt]; loc = p_loc}),
-        Lprim({ primitive = p1; args = [Lvar opt2]; loc = x_loc}), f)),rest)
-    when Ident.name opt = "*opt*" &&
-         Ident.name opt2 = "*opt*" &&
-         Ident.same opt opt2 && List.mem opt params
-    ->
-    let map, rest = rename_optional_parameters map params rest in
-    let new_id = Ident.create_local (Ident.name id ^ "Opt") in
-    Map_ident.add map opt new_id,
-    Lam.let_ k id
-      (Lam.if_
-        (Lam.prim ~primitive:p ~args:[Lam.var new_id] p_loc)
-        (Lam.prim ~primitive:p1 ~args:[Lam.var new_id] x_loc)
-        f) rest
-  | Lmutlet(id, (Lifthenelse(
-      Lprim({ primitive = p; args = [Lvar opt]; loc = p_loc }),
-        Lprim({ primitive = p1; args = [Lvar opt2]; loc = x_loc }), f)),rest)
-    when Ident.name opt = "*opt*" &&
-         Ident.name opt2 = "*opt*" &&
-         Ident.same opt opt2 && List.mem opt params
-    ->
-    let map, rest = rename_optional_parameters map params rest in
-    let new_id = Ident.create_local (Ident.name id ^ "Opt") in
-    Map_ident.add map opt new_id,
+  | Llet
+      ( k,
+        id,
+        Lifthenelse
+          ( Lprim { primitive = p; args = [ Lvar opt ]; loc = p_loc },
+            Lprim { primitive = p1; args = [ Lvar opt2 ]; loc = x_loc },
+            f ),
+        rest )
+    when Ident.name opt = "*opt*"
+         && Ident.name opt2 = "*opt*"
+         && Ident.same opt opt2 && List.mem opt params ->
+      let map, rest = rename_optional_parameters map params rest in
+      let new_id = Ident.create_local (Ident.name id ^ "Opt") in
+      ( Map_ident.add map opt new_id,
+        Lam.let_ k id
+          (Lam.if_
+             (Lam.prim ~primitive:p ~args:[ Lam.var new_id ] p_loc)
+             (Lam.prim ~primitive:p1 ~args:[ Lam.var new_id ] x_loc)
+             f)
+          rest )
+  | Lmutlet
+      ( id,
+        Lifthenelse
+          ( Lprim { primitive = p; args = [ Lvar opt ]; loc = p_loc },
+            Lprim { primitive = p1; args = [ Lvar opt2 ]; loc = x_loc },
+            f ),
+        rest )
+    when Ident.name opt = "*opt*"
+         && Ident.name opt2 = "*opt*"
+         && Ident.same opt opt2 && List.mem opt params ->
+      let map, rest = rename_optional_parameters map params rest in
+      let new_id = Ident.create_local (Ident.name id ^ "Opt") in
+      ( Map_ident.add map opt new_id,
+        Lam.mutlet id
+          (Lam.if_
+             (Lam.prim ~primitive:p ~args:[ Lam.var new_id ] p_loc)
+             (Lam.prim ~primitive:p1 ~args:[ Lam.var new_id ] x_loc)
+             f)
+          rest )
+  | _ -> (map, body)
+  [@@warning "-27"]
 
-    Lam.mutlet id
-      (Lam.if_
-        (Lam.prim ~primitive:p ~args:[Lam.var new_id] p_loc)
-        (Lam.prim ~primitive:p1 ~args:[Lam.var new_id] x_loc)
-        f) rest
-  | _ ->
-    map, body
-    [@@warning "-27"]
-
-let convert (exports : Set_ident.t) (lam : Lambda.lambda) : Lam.t * Lam_module_ident.Hash_set.t  =
+let convert (exports : Set_ident.t) (lam : Lambda.lambda) :
+    Lam.t * Lam_module_ident.Hash_set.t =
   let alias_tbl = Hash_ident.create 64 in
   let exit_map = Hash_int.create 0 in
   let may_depends = Lam_module_ident.Hash_set.create 0 in
 
-  let rec
-    convert_ccall (a_prim : Primitive.description)  (args : Lambda.lambda list) loc : Lam.t =
+  let rec convert_ccall (a_prim : Primitive.description)
+      (args : Lambda.lambda list) loc : Lam.t =
     let prim_name = a_prim.prim_name in
-    let prim_name_len  = String.length prim_name in
+    let prim_name_len = String.length prim_name in
     match External_ffi_types.from_string a_prim.prim_native_name with
     | Ffi_normal ->
-      if prim_name_len > 0 && String.unsafe_get prim_name 0 = '#' then
-        convert_js_primitive a_prim args loc
-      else
-        let args = Ext_list.map args convert_aux in
-        prim ~primitive:(Pccall {prim_name }) ~args loc
+        if prim_name_len > 0 && String.unsafe_get prim_name 0 = '#' then
+          convert_js_primitive a_prim args loc
+        else
+          let args = Ext_list.map args convert_aux in
+          prim ~primitive:(Pccall { prim_name }) ~args loc
     | Ffi_obj_create labels ->
-      let args = Ext_list.map args  convert_aux in
-      prim ~primitive:(Pjs_object_create labels) ~args loc
-    | Ffi_bs(arg_types, result_type, ffi) ->
-      let arg_types =
-        match arg_types with
-        | Params ls -> ls
-        | Param_number i -> Ext_list.init i (fun _ -> External_arg_spec.dummy )   in
-      let args = Ext_list.map args convert_aux in
-      Lam.handle_bs_non_obj_ffi arg_types result_type ffi args loc prim_name
+        let args = Ext_list.map args convert_aux in
+        prim ~primitive:(Pjs_object_create labels) ~args loc
+    | Ffi_bs (arg_types, result_type, ffi) ->
+        let arg_types =
+          match arg_types with
+          | Params ls -> ls
+          | Param_number i -> Ext_list.init i (fun _ -> External_arg_spec.dummy)
+        in
+        let args = Ext_list.map args convert_aux in
+        Lam.handle_bs_non_obj_ffi arg_types result_type ffi args loc prim_name
     | Ffi_inline_const i -> Lam.const i
-
-  and convert_js_primitive (p: Primitive.description) (args : Lambda.lambda list) loc =
+  and convert_js_primitive (p : Primitive.description)
+      (args : Lambda.lambda list) loc =
     let s = p.prim_name in
     let args = Ext_list.map args convert_aux in
     match () with
-    | _ when s = "#is_not_none" ->
-      prim ~primitive:Pis_not_none ~args loc
-    | _ when s = "#val_from_unnest_option"
-      ->
-      let v = (Ext_list.singleton_exn args) in
-      prim ~primitive:Pval_from_option_not_nest
-        ~args:[v] loc
-    | _ when s = "#val_from_option"
-      ->
-      prim ~primitive:Pval_from_option ~args loc
-    | _ when s = "#is_poly_var_const"
-      ->
-      prim ~primitive:Pis_poly_var_const ~args loc
-    | _ when s = "#raw_expr" ->
-      (match args with
-       | [Lconst(Const_string(code))] ->
-        (* js parsing here *)
-        let kind =
-            Classify_function.classify code in
-         prim ~primitive:(Praw_js_code {code; code_info = Exp kind})
-           ~args:[] loc
-       | _ -> assert false)
-
-    | _ when s = "#raw_stmt" ->
-      begin match args with
-        | [Lconst(Const_string(code))] ->
-          let kind = Classify_function.classify_stmt code in
-          prim ~primitive:(Praw_js_code {code; code_info = Stmt kind})
-            ~args:[] loc
-        | _ -> assert false
-      end
-    | _ when s =  "#debugger"  ->
-      (* ATT: Currently, the arity is one due to PPX *)
-      prim ~primitive:Pdebugger ~args:[] loc
-    | _ when s = "#null" ->
-      Lam.const (Const_js_null)
-    | _ when s = "#os_type" ->
-      prim ~primitive:(Pctconst Ostype) ~args:[unit] loc
-    | _ when s = "#undefined" ->
-      Lam.const (Const_js_undefined)
-    | _ when s = "#init_mod" ->
-      begin match args with
-      | [_loc; Lconst(Const_block(0,_,[Const_block(0,_,[])]))]
-        ->
-        Lam.unit
-      | _ -> prim ~primitive:Pinit_mod ~args loc
-      end
-    | _ when s = "#update_mod" ->
-      begin match args with
-      | [Lconst(Const_block(0,_,[Const_block(0,_,[])]));_;_]
-        -> Lam.unit
-      | _ -> prim ~primitive:Pupdate_mod ~args loc
-      end
-    | _ when s = "#extension_slot_eq" ->
-      begin match args with
-      | [lhs; rhs] ->
-        prim
-          ~primitive:(Pccall {prim_name = "caml_string_equal"})
-          ~args:[lam_extension_id loc lhs ;
-                 rhs;
-                ] loc
-      | _ -> assert false end
-    | _ ->
-      let primitive : Lam_primitive.t =
-        match s with
-        | "#apply" -> Pjs_runtime_apply
-        | "#apply1"
-        | "#apply2"
-        | "#apply3"
-        | "#apply4"
-        | "#apply5"
-        | "#apply6"
-        | "#apply7"
-        | "#apply8" -> Pjs_apply
-        | "#makemutablelist" ->
-          Pmakeblock(0, Blk_constructor{name = "::"; num_nonconst = 1},Mutable)
-        | "#undefined_to_opt" -> Pundefined_to_opt
-        | "#nullable_to_opt" -> Pnull_undefined_to_opt
-        | "#null_to_opt" -> Pnull_to_opt
-        | "#is_nullable" -> Pis_null_undefined
-        | "#string_append" -> Pstringadd
-        | "#obj_length" -> Pcaml_obj_length
-        | "#function_length" -> Pjs_function_length
-
-        | "#unsafe_lt" -> Pjscomp Clt
-        | "#unsafe_gt" -> Pjscomp Cgt
-        | "#unsafe_le" -> Pjscomp Cle
-        | "#unsafe_ge" -> Pjscomp Cge
-        | "#unsafe_eq" -> Pjscomp Ceq
-        | "#unsafe_neq" -> Pjscomp Cne
-
-        | "#typeof" -> Pjs_typeof
-        | "#run"  ->
-          Pvoid_run
-        | "#full_apply" ->
-          Pfull_apply
-
-        | "#fn_mk" -> Pjs_fn_make (Ext_pervasives.nat_of_string_exn p.prim_native_name)
-        | "#fn_method" -> Pjs_fn_method
-        | "#unsafe_downgrade" -> Pjs_unsafe_downgrade {name = Ext_string.empty; loc ; setter = false}
-        | _ -> Location.raise_errorf ~loc
-                 "@{<error>Error:@} internal error, using unrecognized primitive %s" s
-      in
-      if primitive = Pfull_apply then
+    | _ when s = "#is_not_none" -> prim ~primitive:Pis_not_none ~args loc
+    | _ when s = "#val_from_unnest_option" ->
+        let v = Ext_list.singleton_exn args in
+        prim ~primitive:Pval_from_option_not_nest ~args:[ v ] loc
+    | _ when s = "#val_from_option" ->
+        prim ~primitive:Pval_from_option ~args loc
+    | _ when s = "#is_poly_var_const" ->
+        prim ~primitive:Pis_poly_var_const ~args loc
+    | _ when s = "#raw_expr" -> (
         match args with
-        | [Lapply {ap_func; ap_args}] ->
-          prim ~primitive ~args:(ap_func::ap_args) loc
-          (* There may be some optimization opportunities here
-            for cases like `(fun [@bs] a b -> a + b ) 1 2 [@bs]` *)
-        | _ -> assert false
-      else
-        prim ~primitive ~args loc
+        | [ Lconst (Const_string code) ] ->
+            (* js parsing here *)
+            let kind = Classify_function.classify code in
+            prim
+              ~primitive:(Praw_js_code { code; code_info = Exp kind })
+              ~args:[] loc
+        | _ -> assert false)
+    | _ when s = "#raw_stmt" -> (
+        match args with
+        | [ Lconst (Const_string code) ] ->
+            let kind = Classify_function.classify_stmt code in
+            prim
+              ~primitive:(Praw_js_code { code; code_info = Stmt kind })
+              ~args:[] loc
+        | _ -> assert false)
+    | _ when s = "#debugger" ->
+        (* ATT: Currently, the arity is one due to PPX *)
+        prim ~primitive:Pdebugger ~args:[] loc
+    | _ when s = "#null" -> Lam.const Const_js_null
+    | _ when s = "#os_type" ->
+        prim ~primitive:(Pctconst Ostype) ~args:[ unit ] loc
+    | _ when s = "#undefined" -> Lam.const Const_js_undefined
+    | _ when s = "#init_mod" -> (
+        match args with
+        | [ _loc; Lconst (Const_block (0, _, [ Const_block (0, _, []) ])) ] ->
+            Lam.unit
+        | _ -> prim ~primitive:Pinit_mod ~args loc)
+    | _ when s = "#update_mod" -> (
+        match args with
+        | [ Lconst (Const_block (0, _, [ Const_block (0, _, []) ])); _; _ ] ->
+            Lam.unit
+        | _ -> prim ~primitive:Pupdate_mod ~args loc)
+    | _ when s = "#extension_slot_eq" -> (
+        match args with
+        | [ lhs; rhs ] ->
+            prim
+              ~primitive:(Pccall { prim_name = "caml_string_equal" })
+              ~args:[ lam_extension_id loc lhs; rhs ]
+              loc
+        | _ -> assert false)
+    | _ ->
+        let primitive : Lam_primitive.t =
+          match s with
+          | "#apply" -> Pjs_runtime_apply
+          | "#apply1" | "#apply2" | "#apply3" | "#apply4" | "#apply5"
+          | "#apply6" | "#apply7" | "#apply8" ->
+              Pjs_apply
+          | "#makemutablelist" ->
+              Pmakeblock
+                (0, Blk_constructor { name = "::"; num_nonconst = 1 }, Mutable)
+          | "#undefined_to_opt" -> Pundefined_to_opt
+          | "#nullable_to_opt" -> Pnull_undefined_to_opt
+          | "#null_to_opt" -> Pnull_to_opt
+          | "#is_nullable" -> Pis_null_undefined
+          | "#string_append" -> Pstringadd
+          | "#obj_length" -> Pcaml_obj_length
+          | "#function_length" -> Pjs_function_length
+          | "#unsafe_lt" -> Pjscomp Clt
+          | "#unsafe_gt" -> Pjscomp Cgt
+          | "#unsafe_le" -> Pjscomp Cle
+          | "#unsafe_ge" -> Pjscomp Cge
+          | "#unsafe_eq" -> Pjscomp Ceq
+          | "#unsafe_neq" -> Pjscomp Cne
+          | "#typeof" -> Pjs_typeof
+          | "#run" -> Pvoid_run
+          | "#full_apply" -> Pfull_apply
+          | "#fn_mk" ->
+              Pjs_fn_make (Ext_pervasives.nat_of_string_exn p.prim_native_name)
+          | "#fn_method" -> Pjs_fn_method
+          | "#unsafe_downgrade" ->
+              Pjs_unsafe_downgrade
+                { name = Ext_string.empty; loc; setter = false }
+          | _ ->
+              Location.raise_errorf ~loc
+                "@{<error>Error:@} internal error, using unrecognized \
+                 primitive %s"
+                s
+        in
+        if primitive = Pfull_apply then
+          match args with
+          | [ Lapply { ap_func; ap_args } ] ->
+              prim ~primitive ~args:(ap_func :: ap_args) loc
+              (* There may be some optimization opportunities here
+                 for cases like `(fun [@bs] a b -> a + b ) 1 2 [@bs]` *)
+          | _ -> assert false
+        else prim ~primitive ~args loc
   and convert_aux (lam : Lambda.lambda) : Lam.t =
     match lam with
-    | Lvar x ->
-      Lam.var (Hash_ident.find_default alias_tbl x x)
-    | Lmutvar x ->
-      Lam.mutvar (Hash_ident.find_default alias_tbl x x)
-    | Lconst x ->
-      Lam.const (Lam_constant_convert.convert_constant x )
-    | Lapply
-        {ap_func = fn; ap_args = args; ap_loc = loc; ap_inlined}
-      ->
-          (** we need do this eargly in case [aux fn] add some wrapper *)
-          Lam.apply (convert_aux fn) (Ext_list.map args convert_aux ) {ap_loc = Debuginfo.Scoped_location.to_location loc; ap_inlined; ap_status =  App_na}
-    | Lfunction
-    { params; body ; attr }
-      ->
-      let just_params = Ext_list.map params fst in
-      let body = convert_aux body in
-      let new_map,body = rename_optional_parameters Map_ident.empty just_params body in
-      let params =
-        if Map_ident.is_empty new_map then just_params
-        else Ext_list.map just_params (fun x ->
-          Map_ident.find_default new_map x x) in
-      Lam.function_ ~attr
-        ~arity:(List.length params)  ~params
-        ~body
-    | Llet
-      (kind,_value_kind, id,e,body) (*FIXME*)
-      -> convert_let kind id e body
-    | Lmutlet
-      (_value_kind, id,e,body) (*FIXME*)
-      -> convert_mutlet id e body
-
-    | Lletrec (bindings,body)
-      ->
-      let bindings = Ext_list.map_snd  bindings convert_aux in
-      let body = convert_aux body in
-      let lam = Lam.letrec bindings body in
-      Lam_scc.scc bindings lam body
+    | Lvar x -> Lam.var (Hash_ident.find_default alias_tbl x x)
+    | Lmutvar x -> Lam.mutvar (Hash_ident.find_default alias_tbl x x)
+    | Lconst x -> Lam.const (Lam_constant_convert.convert_constant x)
+    | Lapply { ap_func = fn; ap_args = args; ap_loc = loc; ap_inlined } ->
+        (* we need do this eargly in case [aux fn] add some wrapper *)
+        Lam.apply (convert_aux fn)
+          (Ext_list.map args convert_aux)
+          {
+            ap_loc = Debuginfo.Scoped_location.to_location loc;
+            ap_inlined;
+            ap_status = App_na;
+          }
+    | Lfunction { params; body; attr } ->
+        let just_params = Ext_list.map params fst in
+        let body = convert_aux body in
+        let new_map, body =
+          rename_optional_parameters Map_ident.empty just_params body
+        in
+        let params =
+          if Map_ident.is_empty new_map then just_params
+          else
+            Ext_list.map just_params (fun x ->
+                Map_ident.find_default new_map x x)
+        in
+        Lam.function_ ~attr ~arity:(List.length params) ~params ~body
+    | Llet (kind, _value_kind, id, e, body) (*FIXME*) ->
+        convert_let kind id e body
+    | Lmutlet (_value_kind, id, e, body) (*FIXME*) -> convert_mutlet id e body
+    | Lletrec (bindings, body) ->
+        let bindings = Ext_list.map_snd bindings convert_aux in
+        let body = convert_aux body in
+        let lam = Lam.letrec bindings body in
+        Lam_scc.scc bindings lam body
     (* inlining will affect how mututal recursive behave *)
     (* | Lprim(Prevapply, [x ; f ],  outer_loc) *)
     (* | Lprim(Pdirapply, [f ; x],  outer_loc) -> *)
-      (* convert_pipe f x outer_loc *)
+    (* convert_pipe f x outer_loc *)
     (* | Lprim (Prevapply, _, _ ) -> assert false *)
     (* | Lprim(Pdirapply, _, _) -> assert false *)
-    | Lprim(Pccall a, args, loc)  ->
-      convert_ccall a  args (Debuginfo.Scoped_location.to_location loc)
+    | Lprim (Pccall a, args, loc) ->
+        convert_ccall a args (Debuginfo.Scoped_location.to_location loc)
     | Lprim (Pgetglobal id, args, _) ->
-      let args = Ext_list.map args convert_aux in
-      if Ident.is_predef id then
-        Lam.const (Const_string (Ident.name id))
-      else
-        begin
+        let args = Ext_list.map args convert_aux in
+        if Ident.is_predef id then Lam.const (Const_string (Ident.name id))
+        else (
           may_depend may_depends (Lam_module_ident.of_ml id);
           assert (args = []);
-          Lam.global_module id
-        end
-    | Lprim (primitive,args, loc)
-      ->
-      let args = Ext_list.map args convert_aux in
-      lam_prim ~primitive ~args (Debuginfo.Scoped_location.to_location loc)
-    | Lswitch
-      (e,s, _loc)
-      -> convert_switch e s
-    | Lstringswitch (e, cases, default, _ ) ->
-      Lam.stringswitch
-      (convert_aux e)
-      (Ext_list.map_snd cases convert_aux)
-      (Ext_option.map default convert_aux)
-    | Lstaticraise (id,[]) ->
+          Lam.global_module id)
+    | Lprim (primitive, args, loc) ->
+        let args = Ext_list.map args convert_aux in
+        lam_prim ~primitive ~args (Debuginfo.Scoped_location.to_location loc)
+    | Lswitch (e, s, _loc) -> convert_switch e s
+    | Lstringswitch (e, cases, default, _) ->
+        Lam.stringswitch (convert_aux e)
+          (Ext_list.map_snd cases convert_aux)
+          (Ext_option.map default convert_aux)
+    | Lstaticraise (id, []) ->
         Lam.staticraise (Hash_int.find_default exit_map id id) []
     | Lstaticraise (id, args) ->
-      Lam.staticraise id (Ext_list.map args convert_aux )
-    | Lstaticcatch (b, (i,[]), Lstaticraise (j,[]) )
-      -> (* peep-hole [i] aliased to [j] *)
-      Hash_int.add exit_map i (Hash_int.find_default exit_map j j);
-      convert_aux b
+        Lam.staticraise id (Ext_list.map args convert_aux)
+    | Lstaticcatch (b, (i, []), Lstaticraise (j, [])) ->
+        (* peep-hole [i] aliased to [j] *)
+        Hash_int.add exit_map i (Hash_int.find_default exit_map j j);
+        convert_aux b
     | Lstaticcatch (b, (i, ids), handler) ->
-      Lam.staticcatch (convert_aux b) (i,(Ext_list.map ids fst)) (convert_aux handler)
+        Lam.staticcatch (convert_aux b)
+          (i, Ext_list.map ids fst)
+          (convert_aux handler)
     | Ltrywith (b, id, handler) ->
-      let body = convert_aux b in
-      let handler = convert_aux handler in
-      if exception_id_destructed handler id then
-        let newId = Ident.create_local ("raw_" ^ (Ident.name id)) in
-        Lam.try_ body newId
-                  (Lam.let_ StrictOpt id
-                    (prim ~primitive:Pwrap_exn ~args:[Lam.var newId] Location.none)
-                    handler
-                 )
-      else
-        Lam.try_  body id handler
-    | Lifthenelse (b,then_,else_) ->
-      Lam.if_ (convert_aux b) (convert_aux then_) (convert_aux else_)
-    | Lsequence (a,b)
-      -> Lam.seq (convert_aux a) (convert_aux b)
-    | Lwhile (b,body) ->
-      Lam.while_ (convert_aux b) (convert_aux body)
+        let body = convert_aux b in
+        let handler = convert_aux handler in
+        if exception_id_destructed handler id then
+          let newId = Ident.create_local ("raw_" ^ Ident.name id) in
+          Lam.try_ body newId
+            (Lam.let_ StrictOpt id
+               (prim ~primitive:Pwrap_exn ~args:[ Lam.var newId ] Location.none)
+               handler)
+        else Lam.try_ body id handler
+    | Lifthenelse (b, then_, else_) ->
+        Lam.if_ (convert_aux b) (convert_aux then_) (convert_aux else_)
+    | Lsequence (a, b) -> Lam.seq (convert_aux a) (convert_aux b)
+    | Lwhile (b, body) -> Lam.while_ (convert_aux b) (convert_aux body)
     | Lfor (id, from_, to_, dir, loop) ->
-      Lam.for_ id (convert_aux from_) (convert_aux to_) dir (convert_aux loop)
-    | Lassign (id, body) ->
-      Lam.assign id (convert_aux body)
-    | Lsend (kind, a,b,ls, loc) ->
-      let a = convert_aux a in
-      let b = convert_aux b in
-      let ls = Ext_list.map ls convert_aux in
-      (* Format.fprintf Format.err_formatter "%a@." Printlambda.lambda b ; *)
-        (match b with
-        | Lprim {primitive =  Pjs_unsafe_downgrade {loc};  args}
-          ->
-            begin match kind with
-            | Public (Some name) ->
-              let setter = Ext_string.ends_with name Literals.setter_suffix in
-              let property =
-                if setter then
-                  Lam_methname.translate
-                    (String.sub name 0
-                       (String.length name - Literals.setter_suffix_len))
-                else Lam_methname.translate  name in
-              let lam = prim ~primitive:(Pjs_unsafe_downgrade {name = property;loc; setter})
-                ~args loc
-              in
-              begin match ls with
-              | [] -> lam
-              | [ arg ] ->
-                (* Since https://github.com/ocaml/ocaml/pull/10081, `b |> a` gets
-                   turned into `a b` by the typechecker. So this actually means
-                   `(x ## y) z` rather than `x#y z` *)
-                Lam.apply lam [arg]
-              {ap_loc = loc; ap_inlined= Default_inline; ap_status =  App_na}
-
-              | _ -> assert false
-              end
-            | _ -> assert false
-          end
-        | b ->
-          Lam.send kind a b ls (Debuginfo.Scoped_location.to_location loc))
-
+        Lam.for_ id (convert_aux from_) (convert_aux to_) dir (convert_aux loop)
+    | Lassign (id, body) -> Lam.assign id (convert_aux body)
+    | Lsend (kind, a, b, ls, loc) -> (
+        let a = convert_aux a in
+        let b = convert_aux b in
+        let ls = Ext_list.map ls convert_aux in
+        (* Format.fprintf Format.err_formatter "%a@." Printlambda.lambda b ; *)
+        match b with
+        | Lprim { primitive = Pjs_unsafe_downgrade { loc }; args } -> (
+            match kind with
+            | Public (Some name) -> (
+                let setter = Ext_string.ends_with name Literals.setter_suffix in
+                let property =
+                  if setter then
+                    Lam_methname.translate
+                      (String.sub name 0
+                         (String.length name - Literals.setter_suffix_len))
+                  else Lam_methname.translate name
+                in
+                let lam =
+                  prim
+                    ~primitive:
+                      (Pjs_unsafe_downgrade { name = property; loc; setter })
+                    ~args loc
+                in
+                match ls with
+                | [] -> lam
+                | [ arg ] ->
+                    (* Since https://github.com/ocaml/ocaml/pull/10081, `b |> a` gets
+                       turned into `a b` by the typechecker. So this actually means
+                       `(x ## y) z` rather than `x#y z` *)
+                    Lam.apply lam [ arg ]
+                      {
+                        ap_loc = loc;
+                        ap_inlined = Default_inline;
+                        ap_status = App_na;
+                      }
+                | _ -> assert false)
+            | _ -> assert false)
+        | b -> Lam.send kind a b ls (Debuginfo.Scoped_location.to_location loc))
     | Levent (e, _ev) -> convert_aux e
     | Lifused (_, e) -> convert_aux e (* TODO: remove it ASAP *)
-
-  and convert_let (kind : Lam_compat.let_kind) id (e : Lambda.lambda) body : Lam.t =
+  and convert_let (kind : Lam_compat.let_kind) id (e : Lambda.lambda) body :
+      Lam.t =
     let e = convert_aux e in
-    match kind, e with
-    | Alias , Lvar u  ->
-      let new_u = Hash_ident.find_default alias_tbl u u in
-      Hash_ident.add alias_tbl id new_u ;
-      if Set_ident.mem exports id then
-        Lam.let_ kind id (Lam.var new_u) (convert_aux body)
-      else convert_aux body
-    | _, _ ->
-      let new_body = convert_aux body in
-          (*
+    match (kind, e) with
+    | Alias, Lvar u ->
+        let new_u = Hash_ident.find_default alias_tbl u u in
+        Hash_ident.add alias_tbl id new_u;
+        if Set_ident.mem exports id then
+          Lam.let_ kind id (Lam.var new_u) (convert_aux body)
+        else convert_aux body
+    | _, _ -> (
+        let new_body = convert_aux body in
+        (*
             reverse engineering cases as {[
            (let (switcher/1013 =a (-1+ match/1012))
                (if (isout 2 switcher/1013) (exit 1)
@@ -896,92 +739,113 @@ let convert (exports : Set_ident.t) (lam : Lambda.lambda) : Lam.t * Lam_module_i
 
          To advance this case, when [sw_failaction] is None
       *)
-      match kind, e, new_body with
-      | Alias, Lprim {primitive = Poffsetint offset; args =  [Lvar _ as matcher ]},
-        Lswitch (Lvar switcher3 ,
-                 ({
-                   sw_consts_full = false ;
-                   sw_consts ;
-                   sw_blocks = []; sw_blocks_full = true;
-                   sw_failaction = Some ifso
-                 } as px)
-                )
-        when Ident.same switcher3 id    &&
-             not (Lam_hit.hit_variable id ifso ) &&
-             not (Ext_list.exists_snd sw_consts (Lam_hit.hit_variable id))
-        ->
-        Lam.switch matcher
-          {px with
-           sw_consts =
-             Ext_list.map sw_consts
-               (fun (i,act) -> i - offset, act)
-          }
-      | _ ->
-        Lam.let_ kind id e new_body
-
+        match (kind, e, new_body) with
+        | ( Alias,
+            Lprim
+              { primitive = Poffsetint offset; args = [ (Lvar _ as matcher) ] },
+            Lswitch
+              ( Lvar switcher3,
+                ({
+                   sw_consts_full = false;
+                   sw_consts;
+                   sw_blocks = [];
+                   sw_blocks_full = true;
+                   sw_failaction = Some ifso;
+                 } as px) ) )
+          when Ident.same switcher3 id
+               && (not (Lam_hit.hit_variable id ifso))
+               && not (Ext_list.exists_snd sw_consts (Lam_hit.hit_variable id))
+          ->
+            Lam.switch matcher
+              {
+                px with
+                sw_consts =
+                  Ext_list.map sw_consts (fun (i, act) -> (i - offset, act));
+              }
+        | _ -> Lam.let_ kind id e new_body)
   and convert_mutlet id (e : Lambda.lambda) body : Lam.t =
     let new_e = convert_aux e in
     let new_body = convert_aux body in
     Lam.mutlet id new_e new_body
-
   and _convert_pipe (f : Lambda.lambda) (x : Lambda.lambda) outer_loc =
-      let x  = convert_aux x in
-      let f =  convert_aux f in
-      match  f with
-      | Lfunction {params = [param]; body = Lprim{primitive; args = [Lvar inner_arg];  }}
-        when Ident.same param inner_arg ->
-        Lam.prim ~primitive ~args:[x] (Debuginfo.Scoped_location.to_location outer_loc)
-      | Lapply {ap_func = Lfunction{params; body = Lprim{primitive; args = inner_args}}; ap_args=args}
-        when Ext_list.for_all2_no_exn inner_args params lam_is_var &&
-             Ext_list.length_larger_than_n inner_args args 1
-        ->
-        Lam.prim ~primitive ~args:(Ext_list.append_one args x) (Debuginfo.Scoped_location.to_location outer_loc)
-      | Lapply{ap_func;ap_args; ap_info} ->
-        Lam.apply ap_func (Ext_list.append_one ap_args x) {ap_loc = Debuginfo.Scoped_location.to_location outer_loc; ap_inlined = ap_info.ap_inlined; ap_status =  App_na }
-      | _ ->
-        Lam.apply f [x] {ap_loc = Debuginfo.Scoped_location.to_location outer_loc; ap_inlined = Default_inline; ap_status = App_na}
-    and convert_switch (e : Lambda.lambda) (s : Lambda.lambda_switch) =
-        let e = convert_aux e in
-        match s with
-        | {
-          sw_failaction = None ;
-          sw_blocks = [];
-          sw_numblocks = 0;
-          sw_consts ;
-          sw_numconsts ;
-        } ->
-          let sw_consts =
-              Ext_list.map
-                sw_consts
-                (fun (i, lam) -> i, convert_aux lam) in
-          begin match happens_to_be_diff sw_consts with
-            | Some 0l -> e
-            | Some i ->
-              prim
-                ~primitive:Paddint
-                ~args:[e; Lam.const(Const_int {i; comment = None})]
-                Location.none
-            | None ->
-              Lam.switch e
-                {sw_failaction = None;
-                 sw_blocks = [];
-                 sw_blocks_full = true;
-                 sw_consts = sw_consts;
-                 sw_consts_full =
-                   Ext_list.length_ge sw_consts sw_numconsts;
-                 sw_names = s.sw_names;
-                }
-          end
-        | _ ->
-          Lam.switch  e
-            { sw_consts_full =  Ext_list.length_ge s.sw_consts s.sw_numconsts ;
-              sw_consts = Ext_list.map_snd  s.sw_consts convert_aux;
-              sw_blocks_full = Ext_list.length_ge s.sw_blocks s.sw_numblocks;
-              sw_blocks = Ext_list.map_snd s.sw_blocks convert_aux;
-              sw_failaction =Ext_option.map s.sw_failaction convert_aux;
-              sw_names = s.sw_names } in
-  convert_aux lam , may_depends
-
+    let x = convert_aux x in
+    let f = convert_aux f in
+    match f with
+    | Lfunction
+        {
+          params = [ param ];
+          body = Lprim { primitive; args = [ Lvar inner_arg ] };
+        }
+      when Ident.same param inner_arg ->
+        Lam.prim ~primitive ~args:[ x ]
+          (Debuginfo.Scoped_location.to_location outer_loc)
+    | Lapply
+        {
+          ap_func =
+            Lfunction { params; body = Lprim { primitive; args = inner_args } };
+          ap_args = args;
+        }
+      when Ext_list.for_all2_no_exn inner_args params lam_is_var
+           && Ext_list.length_larger_than_n inner_args args 1 ->
+        Lam.prim ~primitive
+          ~args:(Ext_list.append_one args x)
+          (Debuginfo.Scoped_location.to_location outer_loc)
+    | Lapply { ap_func; ap_args; ap_info } ->
+        Lam.apply ap_func
+          (Ext_list.append_one ap_args x)
+          {
+            ap_loc = Debuginfo.Scoped_location.to_location outer_loc;
+            ap_inlined = ap_info.ap_inlined;
+            ap_status = App_na;
+          }
+    | _ ->
+        Lam.apply f [ x ]
+          {
+            ap_loc = Debuginfo.Scoped_location.to_location outer_loc;
+            ap_inlined = Default_inline;
+            ap_status = App_na;
+          }
+  and convert_switch (e : Lambda.lambda) (s : Lambda.lambda_switch) =
+    let e = convert_aux e in
+    match s with
+    | {
+     sw_failaction = None;
+     sw_blocks = [];
+     sw_numblocks = 0;
+     sw_consts;
+     sw_numconsts;
+    } -> (
+        let sw_consts =
+          Ext_list.map sw_consts (fun (i, lam) -> (i, convert_aux lam))
+        in
+        match happens_to_be_diff sw_consts with
+        | Some 0l -> e
+        | Some i ->
+            prim ~primitive:Paddint
+              ~args:[ e; Lam.const (Const_int { i; comment = None }) ]
+              Location.none
+        | None ->
+            Lam.switch e
+              {
+                sw_failaction = None;
+                sw_blocks = [];
+                sw_blocks_full = true;
+                sw_consts;
+                sw_consts_full = Ext_list.length_ge sw_consts sw_numconsts;
+                sw_names = s.sw_names;
+              })
+    | _ ->
+        Lam.switch e
+          {
+            sw_consts_full = Ext_list.length_ge s.sw_consts s.sw_numconsts;
+            sw_consts = Ext_list.map_snd s.sw_consts convert_aux;
+            sw_blocks_full = Ext_list.length_ge s.sw_blocks s.sw_numblocks;
+            sw_blocks = Ext_list.map_snd s.sw_blocks convert_aux;
+            sw_failaction = Ext_option.map s.sw_failaction convert_aux;
+            sw_names = s.sw_names;
+          }
+  in
+  (convert_aux lam, may_depends)
 
 (** FIXME: more precise analysis of [id], if it is not
     used, we can remove it
@@ -1001,8 +865,7 @@ let convert (exports : Set_ident.t) (lam : Lambda.lambda) : Lam.t * Lam_module_i
           if count_var v > 0 then simplif l else lambda_unit
       *)
 
-
-      (*
+(*
         | Lfunction(kind,params,Lprim(prim,inner_args,inner_loc))
           when List.for_all2_no_exn (fun x y ->
           match y with

--- a/jscomp/test/ocaml_typedtree_test.js
+++ b/jscomp/test/ocaml_typedtree_test.js
@@ -2708,8 +2708,8 @@ function kfalse(x) {
   return false;
 }
 
-function name($staropt$star, id) {
-  var paren = $staropt$star !== undefined ? $staropt$star : kfalse;
+function name(parenOpt, id) {
+  var paren = parenOpt !== undefined ? parenOpt : kfalse;
   switch (id.TAG | 0) {
     case /* Pident */0 :
         return id._0.name;
@@ -26038,6 +26038,16 @@ function TypedtreeMap_MakeMap(funarg) {
                 str_final_env: str$1.str_final_env
               });
   };
+  var map_class_signature = function (cs) {
+    var cs$1 = Curry._1(funarg.enter_class_signature, cs);
+    var csig_self = map_core_type(cs$1.csig_self);
+    var csig_fields = List.map(map_class_type_field, cs$1.csig_fields);
+    return Curry._1(funarg.leave_class_signature, {
+                csig_self: csig_self,
+                csig_fields: csig_fields,
+                csig_type: cs$1.csig_type
+              });
+  };
   var map_class_type = function (ct) {
     var ct$1 = Curry._1(funarg.enter_class_type, ct);
     var csg = ct$1.cltyp_desc;
@@ -26487,21 +26497,114 @@ function TypedtreeMap_MakeMap(funarg) {
                 exp_attributes: exp$1.exp_attributes
               });
   };
-  var map_row_field = function (rf) {
-    if (rf.TAG === /* Ttag */0) {
-      return {
-              TAG: /* Ttag */0,
-              _0: rf._0,
-              _1: rf._1,
-              _2: rf._2,
-              _3: List.map(map_core_type, rf._3)
-            };
-    } else {
-      return {
-              TAG: /* Tinherit */1,
-              _0: map_core_type(rf._0)
-            };
+  var map_class_type_field = function (ctf) {
+    var ctf$1 = Curry._1(funarg.enter_class_type_field, ctf);
+    var ct = ctf$1.ctf_desc;
+    var ctf_desc;
+    switch (ct.TAG | 0) {
+      case /* Tctf_inherit */0 :
+          ctf_desc = {
+            TAG: /* Tctf_inherit */0,
+            _0: map_class_type(ct._0)
+          };
+          break;
+      case /* Tctf_val */1 :
+          var match = ct._0;
+          ctf_desc = {
+            TAG: /* Tctf_val */1,
+            _0: [
+              match[0],
+              match[1],
+              match[2],
+              map_core_type(match[3])
+            ]
+          };
+          break;
+      case /* Tctf_method */2 :
+          var match$1 = ct._0;
+          ctf_desc = {
+            TAG: /* Tctf_method */2,
+            _0: [
+              match$1[0],
+              match$1[1],
+              match$1[2],
+              map_core_type(match$1[3])
+            ]
+          };
+          break;
+      case /* Tctf_constraint */3 :
+          var match$2 = ct._0;
+          ctf_desc = {
+            TAG: /* Tctf_constraint */3,
+            _0: [
+              map_core_type(match$2[0]),
+              map_core_type(match$2[1])
+            ]
+          };
+          break;
+      case /* Tctf_attribute */4 :
+          ctf_desc = ct;
+          break;
+      
     }
+    return Curry._1(funarg.leave_class_type_field, {
+                ctf_desc: ctf_desc,
+                ctf_loc: ctf$1.ctf_loc,
+                ctf_attributes: ctf$1.ctf_attributes
+              });
+  };
+  var map_module_type = function (mty) {
+    var mty$1 = Curry._1(funarg.enter_module_type, mty);
+    var sg = mty$1.mty_desc;
+    var mty_desc;
+    switch (sg.TAG | 0) {
+      case /* Tmty_signature */1 :
+          mty_desc = {
+            TAG: /* Tmty_signature */1,
+            _0: map_signature(sg._0)
+          };
+          break;
+      case /* Tmty_functor */2 :
+          mty_desc = {
+            TAG: /* Tmty_functor */2,
+            _0: sg._0,
+            _1: sg._1,
+            _2: may_map(map_module_type, sg._2),
+            _3: map_module_type(sg._3)
+          };
+          break;
+      case /* Tmty_with */3 :
+          mty_desc = {
+            TAG: /* Tmty_with */3,
+            _0: map_module_type(sg._0),
+            _1: List.map((function (param) {
+                    return [
+                            param[0],
+                            param[1],
+                            map_with_constraint(param[2])
+                          ];
+                  }), sg._1)
+          };
+          break;
+      case /* Tmty_typeof */4 :
+          mty_desc = {
+            TAG: /* Tmty_typeof */4,
+            _0: map_module_expr(sg._0)
+          };
+          break;
+      case /* Tmty_ident */0 :
+      case /* Tmty_alias */5 :
+          mty_desc = mty$1.mty_desc;
+          break;
+      
+    }
+    return Curry._1(funarg.leave_module_type, {
+                mty_desc: mty_desc,
+                mty_type: mty$1.mty_type,
+                mty_env: mty$1.mty_env,
+                mty_loc: mty$1.mty_loc,
+                mty_attributes: mty$1.mty_attributes
+              });
   };
   var map_package_type = function (pack) {
     var pack$1 = Curry._1(funarg.enter_package_type, pack);
@@ -26518,61 +26621,148 @@ function TypedtreeMap_MakeMap(funarg) {
                 pack_txt: pack$1.pack_txt
               });
   };
+  var map_row_field = function (rf) {
+    if (rf.TAG === /* Ttag */0) {
+      return {
+              TAG: /* Ttag */0,
+              _0: rf._0,
+              _1: rf._1,
+              _2: rf._2,
+              _3: List.map(map_core_type, rf._3)
+            };
+    } else {
+      return {
+              TAG: /* Tinherit */1,
+              _0: map_core_type(rf._0)
+            };
+    }
+  };
   var map_type_parameter = function (param) {
     return [
             map_core_type(param[0]),
             param[1]
           ];
   };
-  var map_type_declaration = function (decl) {
-    var decl$1 = Curry._1(funarg.enter_type_declaration, decl);
-    var typ_params = List.map(map_type_parameter, decl$1.typ_params);
-    var typ_cstrs = List.map((function (param) {
-            return [
-                    map_core_type(param[0]),
-                    map_core_type(param[1]),
-                    param[2]
-                  ];
-          }), decl$1.typ_cstrs);
-    var list = decl$1.typ_kind;
-    var typ_kind;
-    if (typeof list === "number") {
-      typ_kind = list === /* Ttype_abstract */0 ? /* Ttype_abstract */0 : /* Ttype_open */1;
-    } else if (list.TAG === /* Ttype_variant */0) {
-      var list$1 = List.map(map_constructor_declaration, list._0);
-      typ_kind = {
-        TAG: /* Ttype_variant */0,
-        _0: list$1
-      };
-    } else {
-      var list$2 = List.map((function (ld) {
-              return {
-                      ld_id: ld.ld_id,
-                      ld_name: ld.ld_name,
-                      ld_mutable: ld.ld_mutable,
-                      ld_type: map_core_type(ld.ld_type),
-                      ld_loc: ld.ld_loc,
-                      ld_attributes: ld.ld_attributes
-                    };
-            }), list._0);
-      typ_kind = {
-        TAG: /* Ttype_record */1,
-        _0: list$2
-      };
-    }
-    var typ_manifest = may_map(map_core_type, decl$1.typ_manifest);
-    return Curry._1(funarg.leave_type_declaration, {
-                typ_id: decl$1.typ_id,
-                typ_name: decl$1.typ_name,
-                typ_params: typ_params,
-                typ_type: decl$1.typ_type,
-                typ_cstrs: typ_cstrs,
-                typ_kind: typ_kind,
-                typ_private: decl$1.typ_private,
-                typ_manifest: typ_manifest,
-                typ_loc: decl$1.typ_loc,
-                typ_attributes: decl$1.typ_attributes
+  var map_constructor_declaration = function (cd) {
+    return {
+            cd_id: cd.cd_id,
+            cd_name: cd.cd_name,
+            cd_args: List.map(map_core_type, cd.cd_args),
+            cd_res: may_map(map_core_type, cd.cd_res),
+            cd_loc: cd.cd_loc,
+            cd_attributes: cd.cd_attributes
+          };
+  };
+  var map_class_expr = function (cexpr) {
+    var cexpr$1 = Curry._1(funarg.enter_class_expr, cexpr);
+    var clstr = cexpr$1.cl_desc;
+    var cl_desc;
+    switch (clstr.TAG | 0) {
+      case /* Tcl_ident */0 :
+          cl_desc = {
+            TAG: /* Tcl_ident */0,
+            _0: clstr._0,
+            _1: clstr._1,
+            _2: List.map(map_core_type, clstr._2)
+          };
+          break;
+      case /* Tcl_structure */1 :
+          cl_desc = {
+            TAG: /* Tcl_structure */1,
+            _0: map_class_structure(clstr._0)
+          };
+          break;
+      case /* Tcl_fun */2 :
+          cl_desc = {
+            TAG: /* Tcl_fun */2,
+            _0: clstr._0,
+            _1: map_pattern(clstr._1),
+            _2: List.map((function (param) {
+                    return [
+                            param[0],
+                            param[1],
+                            map_expression(param[2])
+                          ];
+                  }), clstr._2),
+            _3: map_class_expr(clstr._3),
+            _4: clstr._4
+          };
+          break;
+      case /* Tcl_apply */3 :
+          cl_desc = {
+            TAG: /* Tcl_apply */3,
+            _0: map_class_expr(clstr._0),
+            _1: List.map((function (param) {
+                    return [
+                            param[0],
+                            may_map(map_expression, param[1]),
+                            param[2]
+                          ];
+                  }), clstr._1)
+          };
+          break;
+      case /* Tcl_let */4 :
+          var rec_flat = clstr._0;
+          cl_desc = {
+            TAG: /* Tcl_let */4,
+            _0: rec_flat,
+            _1: List.map(map_binding, clstr._1),
+            _2: List.map((function (param) {
+                    return [
+                            param[0],
+                            param[1],
+                            map_expression(param[2])
+                          ];
+                  }), clstr._2),
+            _3: map_class_expr(clstr._3)
+          };
+          break;
+      case /* Tcl_constraint */5 :
+          var clty = clstr._1;
+          var cl = clstr._0;
+          cl_desc = clty !== undefined ? ({
+                TAG: /* Tcl_constraint */5,
+                _0: map_class_expr(cl),
+                _1: map_class_type(clty),
+                _2: clstr._2,
+                _3: clstr._3,
+                _4: clstr._4
+              }) : ({
+                TAG: /* Tcl_constraint */5,
+                _0: map_class_expr(cl),
+                _1: undefined,
+                _2: clstr._2,
+                _3: clstr._3,
+                _4: clstr._4
               });
+          break;
+      
+    }
+    return Curry._1(funarg.leave_class_expr, {
+                cl_desc: cl_desc,
+                cl_loc: cexpr$1.cl_loc,
+                cl_type: cexpr$1.cl_type,
+                cl_env: cexpr$1.cl_env,
+                cl_attributes: cexpr$1.cl_attributes
+              });
+  };
+  var map_class_structure = function (cs) {
+    var cs$1 = Curry._1(funarg.enter_class_structure, cs);
+    var cstr_self = map_pattern(cs$1.cstr_self);
+    var cstr_fields = List.map(map_class_field, cs$1.cstr_fields);
+    return Curry._1(funarg.leave_class_structure, {
+                cstr_self: cstr_self,
+                cstr_fields: cstr_fields,
+                cstr_type: cs$1.cstr_type,
+                cstr_meths: cs$1.cstr_meths
+              });
+  };
+  var map_case = function (param) {
+    return {
+            c_lhs: map_pattern(param.c_lhs),
+            c_guard: may_map(map_expression, param.c_guard),
+            c_rhs: map_expression(param.c_rhs)
+          };
   };
   var map_module_expr = function (mexpr) {
     var mexpr$1 = Curry._1(funarg.enter_module_expr, mexpr);
@@ -26642,79 +26832,62 @@ function TypedtreeMap_MakeMap(funarg) {
                 mod_attributes: mexpr$1.mod_attributes
               });
   };
-  var map_class_type_declaration = function (cd) {
-    var cd$1 = Curry._1(funarg.enter_class_type_declaration, cd);
-    var ci_params = List.map(map_type_parameter, cd$1.ci_params);
-    var ci_expr = map_class_type(cd$1.ci_expr);
-    return Curry._1(funarg.leave_class_type_declaration, {
-                ci_virt: cd$1.ci_virt,
-                ci_params: ci_params,
-                ci_id_name: cd$1.ci_id_name,
-                ci_id_class: cd$1.ci_id_class,
-                ci_id_class_type: cd$1.ci_id_class_type,
-                ci_id_object: cd$1.ci_id_object,
-                ci_id_typesharp: cd$1.ci_id_typesharp,
-                ci_expr: ci_expr,
-                ci_decl: cd$1.ci_decl,
-                ci_type_decl: cd$1.ci_type_decl,
-                ci_loc: cd$1.ci_loc,
-                ci_attributes: cd$1.ci_attributes
-              });
-  };
-  var map_type_extension = function (tyext) {
-    var tyext$1 = Curry._1(funarg.enter_type_extension, tyext);
-    var tyext_params = List.map(map_type_parameter, tyext$1.tyext_params);
-    var tyext_constructors = List.map(map_extension_constructor, tyext$1.tyext_constructors);
-    return Curry._1(funarg.leave_type_extension, {
-                tyext_path: tyext$1.tyext_path,
-                tyext_txt: tyext$1.tyext_txt,
-                tyext_params: tyext_params,
-                tyext_constructors: tyext_constructors,
-                tyext_private: tyext$1.tyext_private,
-                tyext_attributes: tyext$1.tyext_attributes
-              });
-  };
-  var map_class_declaration = function (cd) {
-    var cd$1 = Curry._1(funarg.enter_class_declaration, cd);
-    var ci_params = List.map(map_type_parameter, cd$1.ci_params);
-    var ci_expr = map_class_expr(cd$1.ci_expr);
-    return Curry._1(funarg.leave_class_declaration, {
-                ci_virt: cd$1.ci_virt,
-                ci_params: ci_params,
-                ci_id_name: cd$1.ci_id_name,
-                ci_id_class: cd$1.ci_id_class,
-                ci_id_class_type: cd$1.ci_id_class_type,
-                ci_id_object: cd$1.ci_id_object,
-                ci_id_typesharp: cd$1.ci_id_typesharp,
-                ci_expr: ci_expr,
-                ci_decl: cd$1.ci_decl,
-                ci_type_decl: cd$1.ci_type_decl,
-                ci_loc: cd$1.ci_loc,
-                ci_attributes: cd$1.ci_attributes
-              });
-  };
-  var map_module_type_declaration = function (mtd) {
-    var mtd$1 = Curry._1(funarg.enter_module_type_declaration, mtd);
-    return Curry._1(funarg.leave_module_type_declaration, {
-                mtd_id: mtd$1.mtd_id,
-                mtd_name: mtd$1.mtd_name,
-                mtd_type: may_map(map_module_type, mtd$1.mtd_type),
-                mtd_attributes: mtd$1.mtd_attributes,
-                mtd_loc: mtd$1.mtd_loc
-              });
-  };
-  var map_value_description = function (v) {
-    var v$1 = Curry._1(funarg.enter_value_description, v);
-    var val_desc = map_core_type(v$1.val_desc);
-    return Curry._1(funarg.leave_value_description, {
-                val_id: v$1.val_id,
-                val_name: v$1.val_name,
-                val_desc: val_desc,
-                val_val: v$1.val_val,
-                val_prim: v$1.val_prim,
-                val_loc: v$1.val_loc,
-                val_attributes: v$1.val_attributes
-              });
+  var map_exp_extra = function (exp_extra) {
+    var attrs = exp_extra[2];
+    var loc = exp_extra[1];
+    var desc = exp_extra[0];
+    switch (desc.TAG | 0) {
+      case /* Texp_constraint */0 :
+          return [
+                  {
+                    TAG: /* Texp_constraint */0,
+                    _0: map_core_type(desc._0)
+                  },
+                  loc,
+                  attrs
+                ];
+      case /* Texp_coerce */1 :
+          var ct1 = desc._0;
+          if (ct1 !== undefined) {
+            return [
+                    {
+                      TAG: /* Texp_coerce */1,
+                      _0: map_core_type(ct1),
+                      _1: map_core_type(desc._1)
+                    },
+                    loc,
+                    attrs
+                  ];
+          } else {
+            return [
+                    {
+                      TAG: /* Texp_coerce */1,
+                      _0: undefined,
+                      _1: map_core_type(desc._1)
+                    },
+                    loc,
+                    attrs
+                  ];
+          }
+      case /* Texp_poly */3 :
+          var ct = desc._0;
+          if (ct !== undefined) {
+            return [
+                    {
+                      TAG: /* Texp_poly */3,
+                      _0: map_core_type(ct)
+                    },
+                    loc,
+                    attrs
+                  ];
+          } else {
+            return exp_extra;
+          }
+      case /* Texp_open */2 :
+      case /* Texp_newtype */4 :
+          return exp_extra;
+      
+    }
   };
   var map_binding = function (vb) {
     return {
@@ -26723,171 +26896,6 @@ function TypedtreeMap_MakeMap(funarg) {
             vb_attributes: vb.vb_attributes,
             vb_loc: vb.vb_loc
           };
-  };
-  var map_extension_constructor = function (ext) {
-    var ext$1 = Curry._1(funarg.enter_extension_constructor, ext);
-    var match = ext$1.ext_kind;
-    var ext_kind;
-    if (match.TAG === /* Text_decl */0) {
-      var args = List.map(map_core_type, match._0);
-      var ret = may_map(map_core_type, match._1);
-      ext_kind = {
-        TAG: /* Text_decl */0,
-        _0: args,
-        _1: ret
-      };
-    } else {
-      ext_kind = {
-        TAG: /* Text_rebind */1,
-        _0: match._0,
-        _1: match._1
-      };
-    }
-    return Curry._1(funarg.leave_extension_constructor, {
-                ext_id: ext$1.ext_id,
-                ext_name: ext$1.ext_name,
-                ext_type: ext$1.ext_type,
-                ext_kind: ext_kind,
-                ext_loc: ext$1.ext_loc,
-                ext_attributes: ext$1.ext_attributes
-              });
-  };
-  var map_module_binding = function (x) {
-    return {
-            mb_id: x.mb_id,
-            mb_name: x.mb_name,
-            mb_expr: map_module_expr(x.mb_expr),
-            mb_attributes: x.mb_attributes,
-            mb_loc: x.mb_loc
-          };
-  };
-  var map_module_type = function (mty) {
-    var mty$1 = Curry._1(funarg.enter_module_type, mty);
-    var sg = mty$1.mty_desc;
-    var mty_desc;
-    switch (sg.TAG | 0) {
-      case /* Tmty_signature */1 :
-          mty_desc = {
-            TAG: /* Tmty_signature */1,
-            _0: map_signature(sg._0)
-          };
-          break;
-      case /* Tmty_functor */2 :
-          mty_desc = {
-            TAG: /* Tmty_functor */2,
-            _0: sg._0,
-            _1: sg._1,
-            _2: may_map(map_module_type, sg._2),
-            _3: map_module_type(sg._3)
-          };
-          break;
-      case /* Tmty_with */3 :
-          mty_desc = {
-            TAG: /* Tmty_with */3,
-            _0: map_module_type(sg._0),
-            _1: List.map((function (param) {
-                    return [
-                            param[0],
-                            param[1],
-                            map_with_constraint(param[2])
-                          ];
-                  }), sg._1)
-          };
-          break;
-      case /* Tmty_typeof */4 :
-          mty_desc = {
-            TAG: /* Tmty_typeof */4,
-            _0: map_module_expr(sg._0)
-          };
-          break;
-      case /* Tmty_ident */0 :
-      case /* Tmty_alias */5 :
-          mty_desc = mty$1.mty_desc;
-          break;
-      
-    }
-    return Curry._1(funarg.leave_module_type, {
-                mty_desc: mty_desc,
-                mty_type: mty$1.mty_type,
-                mty_env: mty$1.mty_env,
-                mty_loc: mty$1.mty_loc,
-                mty_attributes: mty$1.mty_attributes
-              });
-  };
-  var map_class_description = function (cd) {
-    var cd$1 = Curry._1(funarg.enter_class_description, cd);
-    var ci_params = List.map(map_type_parameter, cd$1.ci_params);
-    var ci_expr = map_class_type(cd$1.ci_expr);
-    return Curry._1(funarg.leave_class_description, {
-                ci_virt: cd$1.ci_virt,
-                ci_params: ci_params,
-                ci_id_name: cd$1.ci_id_name,
-                ci_id_class: cd$1.ci_id_class,
-                ci_id_class_type: cd$1.ci_id_class_type,
-                ci_id_object: cd$1.ci_id_object,
-                ci_id_typesharp: cd$1.ci_id_typesharp,
-                ci_expr: ci_expr,
-                ci_decl: cd$1.ci_decl,
-                ci_type_decl: cd$1.ci_type_decl,
-                ci_loc: cd$1.ci_loc,
-                ci_attributes: cd$1.ci_attributes
-              });
-  };
-  var map_class_type_field = function (ctf) {
-    var ctf$1 = Curry._1(funarg.enter_class_type_field, ctf);
-    var ct = ctf$1.ctf_desc;
-    var ctf_desc;
-    switch (ct.TAG | 0) {
-      case /* Tctf_inherit */0 :
-          ctf_desc = {
-            TAG: /* Tctf_inherit */0,
-            _0: map_class_type(ct._0)
-          };
-          break;
-      case /* Tctf_val */1 :
-          var match = ct._0;
-          ctf_desc = {
-            TAG: /* Tctf_val */1,
-            _0: [
-              match[0],
-              match[1],
-              match[2],
-              map_core_type(match[3])
-            ]
-          };
-          break;
-      case /* Tctf_method */2 :
-          var match$1 = ct._0;
-          ctf_desc = {
-            TAG: /* Tctf_method */2,
-            _0: [
-              match$1[0],
-              match$1[1],
-              match$1[2],
-              map_core_type(match$1[3])
-            ]
-          };
-          break;
-      case /* Tctf_constraint */3 :
-          var match$2 = ct._0;
-          ctf_desc = {
-            TAG: /* Tctf_constraint */3,
-            _0: [
-              map_core_type(match$2[0]),
-              map_core_type(match$2[1])
-            ]
-          };
-          break;
-      case /* Tctf_attribute */4 :
-          ctf_desc = ct;
-          break;
-      
-    }
-    return Curry._1(funarg.leave_class_type_field, {
-                ctf_desc: ctf_desc,
-                ctf_loc: ctf$1.ctf_loc,
-                ctf_attributes: ctf$1.ctf_attributes
-              });
   };
   var map_signature_item = function (item) {
     var item$1 = Curry._1(funarg.enter_signature_item, item);
@@ -26989,6 +26997,157 @@ function TypedtreeMap_MakeMap(funarg) {
                 sig_loc: item$1.sig_loc
               });
   };
+  var map_extension_constructor = function (ext) {
+    var ext$1 = Curry._1(funarg.enter_extension_constructor, ext);
+    var match = ext$1.ext_kind;
+    var ext_kind;
+    if (match.TAG === /* Text_decl */0) {
+      var args = List.map(map_core_type, match._0);
+      var ret = may_map(map_core_type, match._1);
+      ext_kind = {
+        TAG: /* Text_decl */0,
+        _0: args,
+        _1: ret
+      };
+    } else {
+      ext_kind = {
+        TAG: /* Text_rebind */1,
+        _0: match._0,
+        _1: match._1
+      };
+    }
+    return Curry._1(funarg.leave_extension_constructor, {
+                ext_id: ext$1.ext_id,
+                ext_name: ext$1.ext_name,
+                ext_type: ext$1.ext_type,
+                ext_kind: ext_kind,
+                ext_loc: ext$1.ext_loc,
+                ext_attributes: ext$1.ext_attributes
+              });
+  };
+  var map_signature = function (sg) {
+    var sg$1 = Curry._1(funarg.enter_signature, sg);
+    var sig_items = List.map(map_signature_item, sg$1.sig_items);
+    return Curry._1(funarg.leave_signature, {
+                sig_items: sig_items,
+                sig_type: sg$1.sig_type,
+                sig_final_env: sg$1.sig_final_env
+              });
+  };
+  var map_with_constraint = function (cstr) {
+    var cstr$1 = Curry._1(funarg.enter_with_constraint, cstr);
+    var tmp;
+    switch (cstr$1.TAG | 0) {
+      case /* Twith_type */0 :
+          tmp = {
+            TAG: /* Twith_type */0,
+            _0: map_type_declaration(cstr$1._0)
+          };
+          break;
+      case /* Twith_typesubst */2 :
+          tmp = {
+            TAG: /* Twith_typesubst */2,
+            _0: map_type_declaration(cstr$1._0)
+          };
+          break;
+      case /* Twith_module */1 :
+      case /* Twith_modsubst */3 :
+          tmp = cstr$1;
+          break;
+      
+    }
+    return Curry._1(funarg.leave_with_constraint, tmp);
+  };
+  var map_class_field = function (cf) {
+    var cf$1 = Curry._1(funarg.enter_class_field, cf);
+    var exp = cf$1.cf_desc;
+    var cf_desc;
+    switch (exp.TAG | 0) {
+      case /* Tcf_inherit */0 :
+          cf_desc = {
+            TAG: /* Tcf_inherit */0,
+            _0: exp._0,
+            _1: map_class_expr(exp._1),
+            _2: exp._2,
+            _3: exp._3,
+            _4: exp._4
+          };
+          break;
+      case /* Tcf_val */1 :
+          var cty = exp._3;
+          var ident = exp._2;
+          var mut = exp._1;
+          var lab = exp._0;
+          cf_desc = cty.TAG === /* Tcfk_virtual */0 ? ({
+                TAG: /* Tcf_val */1,
+                _0: lab,
+                _1: mut,
+                _2: ident,
+                _3: {
+                  TAG: /* Tcfk_virtual */0,
+                  _0: map_core_type(cty._0)
+                },
+                _4: exp._4
+              }) : ({
+                TAG: /* Tcf_val */1,
+                _0: lab,
+                _1: mut,
+                _2: ident,
+                _3: {
+                  TAG: /* Tcfk_concrete */1,
+                  _0: cty._0,
+                  _1: map_expression(cty._1)
+                },
+                _4: exp._4
+              });
+          break;
+      case /* Tcf_method */2 :
+          var cty$1 = exp._2;
+          var priv = exp._1;
+          var lab$1 = exp._0;
+          cf_desc = cty$1.TAG === /* Tcfk_virtual */0 ? ({
+                TAG: /* Tcf_method */2,
+                _0: lab$1,
+                _1: priv,
+                _2: {
+                  TAG: /* Tcfk_virtual */0,
+                  _0: map_core_type(cty$1._0)
+                }
+              }) : ({
+                TAG: /* Tcf_method */2,
+                _0: lab$1,
+                _1: priv,
+                _2: {
+                  TAG: /* Tcfk_concrete */1,
+                  _0: cty$1._0,
+                  _1: map_expression(cty$1._1)
+                }
+              });
+          break;
+      case /* Tcf_constraint */3 :
+          cf_desc = {
+            TAG: /* Tcf_constraint */3,
+            _0: map_core_type(exp._0),
+            _1: map_core_type(exp._1)
+          };
+          break;
+      case /* Tcf_initializer */4 :
+          cf_desc = {
+            TAG: /* Tcf_initializer */4,
+            _0: map_expression(exp._0)
+          };
+          break;
+      case /* Tcf_attribute */5 :
+          cf_desc = exp;
+          break;
+      
+    }
+    return Curry._1(funarg.leave_class_field, {
+                cf_desc: cf_desc,
+                cf_loc: cf$1.cf_loc,
+                cf_attributes: cf$1.cf_attributes
+              });
+  };
   var map_pat_extra = function (pat_extra) {
     var ct = pat_extra[0];
     if (typeof ct === "number" || ct.TAG !== /* Tpat_constraint */0) {
@@ -27003,6 +27162,158 @@ function TypedtreeMap_MakeMap(funarg) {
               pat_extra[2]
             ];
     }
+  };
+  var map_class_type_declaration = function (cd) {
+    var cd$1 = Curry._1(funarg.enter_class_type_declaration, cd);
+    var ci_params = List.map(map_type_parameter, cd$1.ci_params);
+    var ci_expr = map_class_type(cd$1.ci_expr);
+    return Curry._1(funarg.leave_class_type_declaration, {
+                ci_virt: cd$1.ci_virt,
+                ci_params: ci_params,
+                ci_id_name: cd$1.ci_id_name,
+                ci_id_class: cd$1.ci_id_class,
+                ci_id_class_type: cd$1.ci_id_class_type,
+                ci_id_object: cd$1.ci_id_object,
+                ci_id_typesharp: cd$1.ci_id_typesharp,
+                ci_expr: ci_expr,
+                ci_decl: cd$1.ci_decl,
+                ci_type_decl: cd$1.ci_type_decl,
+                ci_loc: cd$1.ci_loc,
+                ci_attributes: cd$1.ci_attributes
+              });
+  };
+  var map_module_binding = function (x) {
+    return {
+            mb_id: x.mb_id,
+            mb_name: x.mb_name,
+            mb_expr: map_module_expr(x.mb_expr),
+            mb_attributes: x.mb_attributes,
+            mb_loc: x.mb_loc
+          };
+  };
+  var map_module_type_declaration = function (mtd) {
+    var mtd$1 = Curry._1(funarg.enter_module_type_declaration, mtd);
+    return Curry._1(funarg.leave_module_type_declaration, {
+                mtd_id: mtd$1.mtd_id,
+                mtd_name: mtd$1.mtd_name,
+                mtd_type: may_map(map_module_type, mtd$1.mtd_type),
+                mtd_attributes: mtd$1.mtd_attributes,
+                mtd_loc: mtd$1.mtd_loc
+              });
+  };
+  var map_value_description = function (v) {
+    var v$1 = Curry._1(funarg.enter_value_description, v);
+    var val_desc = map_core_type(v$1.val_desc);
+    return Curry._1(funarg.leave_value_description, {
+                val_id: v$1.val_id,
+                val_name: v$1.val_name,
+                val_desc: val_desc,
+                val_val: v$1.val_val,
+                val_prim: v$1.val_prim,
+                val_loc: v$1.val_loc,
+                val_attributes: v$1.val_attributes
+              });
+  };
+  var map_class_declaration = function (cd) {
+    var cd$1 = Curry._1(funarg.enter_class_declaration, cd);
+    var ci_params = List.map(map_type_parameter, cd$1.ci_params);
+    var ci_expr = map_class_expr(cd$1.ci_expr);
+    return Curry._1(funarg.leave_class_declaration, {
+                ci_virt: cd$1.ci_virt,
+                ci_params: ci_params,
+                ci_id_name: cd$1.ci_id_name,
+                ci_id_class: cd$1.ci_id_class,
+                ci_id_class_type: cd$1.ci_id_class_type,
+                ci_id_object: cd$1.ci_id_object,
+                ci_id_typesharp: cd$1.ci_id_typesharp,
+                ci_expr: ci_expr,
+                ci_decl: cd$1.ci_decl,
+                ci_type_decl: cd$1.ci_type_decl,
+                ci_loc: cd$1.ci_loc,
+                ci_attributes: cd$1.ci_attributes
+              });
+  };
+  var map_type_extension = function (tyext) {
+    var tyext$1 = Curry._1(funarg.enter_type_extension, tyext);
+    var tyext_params = List.map(map_type_parameter, tyext$1.tyext_params);
+    var tyext_constructors = List.map(map_extension_constructor, tyext$1.tyext_constructors);
+    return Curry._1(funarg.leave_type_extension, {
+                tyext_path: tyext$1.tyext_path,
+                tyext_txt: tyext$1.tyext_txt,
+                tyext_params: tyext_params,
+                tyext_constructors: tyext_constructors,
+                tyext_private: tyext$1.tyext_private,
+                tyext_attributes: tyext$1.tyext_attributes
+              });
+  };
+  var map_type_declaration = function (decl) {
+    var decl$1 = Curry._1(funarg.enter_type_declaration, decl);
+    var typ_params = List.map(map_type_parameter, decl$1.typ_params);
+    var typ_cstrs = List.map((function (param) {
+            return [
+                    map_core_type(param[0]),
+                    map_core_type(param[1]),
+                    param[2]
+                  ];
+          }), decl$1.typ_cstrs);
+    var list = decl$1.typ_kind;
+    var typ_kind;
+    if (typeof list === "number") {
+      typ_kind = list === /* Ttype_abstract */0 ? /* Ttype_abstract */0 : /* Ttype_open */1;
+    } else if (list.TAG === /* Ttype_variant */0) {
+      var list$1 = List.map(map_constructor_declaration, list._0);
+      typ_kind = {
+        TAG: /* Ttype_variant */0,
+        _0: list$1
+      };
+    } else {
+      var list$2 = List.map((function (ld) {
+              return {
+                      ld_id: ld.ld_id,
+                      ld_name: ld.ld_name,
+                      ld_mutable: ld.ld_mutable,
+                      ld_type: map_core_type(ld.ld_type),
+                      ld_loc: ld.ld_loc,
+                      ld_attributes: ld.ld_attributes
+                    };
+            }), list._0);
+      typ_kind = {
+        TAG: /* Ttype_record */1,
+        _0: list$2
+      };
+    }
+    var typ_manifest = may_map(map_core_type, decl$1.typ_manifest);
+    return Curry._1(funarg.leave_type_declaration, {
+                typ_id: decl$1.typ_id,
+                typ_name: decl$1.typ_name,
+                typ_params: typ_params,
+                typ_type: decl$1.typ_type,
+                typ_cstrs: typ_cstrs,
+                typ_kind: typ_kind,
+                typ_private: decl$1.typ_private,
+                typ_manifest: typ_manifest,
+                typ_loc: decl$1.typ_loc,
+                typ_attributes: decl$1.typ_attributes
+              });
+  };
+  var map_class_description = function (cd) {
+    var cd$1 = Curry._1(funarg.enter_class_description, cd);
+    var ci_params = List.map(map_type_parameter, cd$1.ci_params);
+    var ci_expr = map_class_type(cd$1.ci_expr);
+    return Curry._1(funarg.leave_class_description, {
+                ci_virt: cd$1.ci_virt,
+                ci_params: ci_params,
+                ci_id_name: cd$1.ci_id_name,
+                ci_id_class: cd$1.ci_id_class,
+                ci_id_class_type: cd$1.ci_id_class_type,
+                ci_id_object: cd$1.ci_id_object,
+                ci_id_typesharp: cd$1.ci_id_typesharp,
+                ci_expr: ci_expr,
+                ci_decl: cd$1.ci_decl,
+                ci_type_decl: cd$1.ci_type_decl,
+                ci_loc: cd$1.ci_loc,
+                ci_attributes: cd$1.ci_attributes
+              });
   };
   var map_structure_item = function (item) {
     var item$1 = Curry._1(funarg.enter_structure_item, item);
@@ -27124,317 +27435,6 @@ function TypedtreeMap_MakeMap(funarg) {
                 str_loc: item$1.str_loc,
                 str_env: item$1.str_env
               });
-  };
-  var map_class_signature = function (cs) {
-    var cs$1 = Curry._1(funarg.enter_class_signature, cs);
-    var csig_self = map_core_type(cs$1.csig_self);
-    var csig_fields = List.map(map_class_type_field, cs$1.csig_fields);
-    return Curry._1(funarg.leave_class_signature, {
-                csig_self: csig_self,
-                csig_fields: csig_fields,
-                csig_type: cs$1.csig_type
-              });
-  };
-  var map_class_expr = function (cexpr) {
-    var cexpr$1 = Curry._1(funarg.enter_class_expr, cexpr);
-    var clstr = cexpr$1.cl_desc;
-    var cl_desc;
-    switch (clstr.TAG | 0) {
-      case /* Tcl_ident */0 :
-          cl_desc = {
-            TAG: /* Tcl_ident */0,
-            _0: clstr._0,
-            _1: clstr._1,
-            _2: List.map(map_core_type, clstr._2)
-          };
-          break;
-      case /* Tcl_structure */1 :
-          cl_desc = {
-            TAG: /* Tcl_structure */1,
-            _0: map_class_structure(clstr._0)
-          };
-          break;
-      case /* Tcl_fun */2 :
-          cl_desc = {
-            TAG: /* Tcl_fun */2,
-            _0: clstr._0,
-            _1: map_pattern(clstr._1),
-            _2: List.map((function (param) {
-                    return [
-                            param[0],
-                            param[1],
-                            map_expression(param[2])
-                          ];
-                  }), clstr._2),
-            _3: map_class_expr(clstr._3),
-            _4: clstr._4
-          };
-          break;
-      case /* Tcl_apply */3 :
-          cl_desc = {
-            TAG: /* Tcl_apply */3,
-            _0: map_class_expr(clstr._0),
-            _1: List.map((function (param) {
-                    return [
-                            param[0],
-                            may_map(map_expression, param[1]),
-                            param[2]
-                          ];
-                  }), clstr._1)
-          };
-          break;
-      case /* Tcl_let */4 :
-          var rec_flat = clstr._0;
-          cl_desc = {
-            TAG: /* Tcl_let */4,
-            _0: rec_flat,
-            _1: List.map(map_binding, clstr._1),
-            _2: List.map((function (param) {
-                    return [
-                            param[0],
-                            param[1],
-                            map_expression(param[2])
-                          ];
-                  }), clstr._2),
-            _3: map_class_expr(clstr._3)
-          };
-          break;
-      case /* Tcl_constraint */5 :
-          var clty = clstr._1;
-          var cl = clstr._0;
-          cl_desc = clty !== undefined ? ({
-                TAG: /* Tcl_constraint */5,
-                _0: map_class_expr(cl),
-                _1: map_class_type(clty),
-                _2: clstr._2,
-                _3: clstr._3,
-                _4: clstr._4
-              }) : ({
-                TAG: /* Tcl_constraint */5,
-                _0: map_class_expr(cl),
-                _1: undefined,
-                _2: clstr._2,
-                _3: clstr._3,
-                _4: clstr._4
-              });
-          break;
-      
-    }
-    return Curry._1(funarg.leave_class_expr, {
-                cl_desc: cl_desc,
-                cl_loc: cexpr$1.cl_loc,
-                cl_type: cexpr$1.cl_type,
-                cl_env: cexpr$1.cl_env,
-                cl_attributes: cexpr$1.cl_attributes
-              });
-  };
-  var map_exp_extra = function (exp_extra) {
-    var attrs = exp_extra[2];
-    var loc = exp_extra[1];
-    var desc = exp_extra[0];
-    switch (desc.TAG | 0) {
-      case /* Texp_constraint */0 :
-          return [
-                  {
-                    TAG: /* Texp_constraint */0,
-                    _0: map_core_type(desc._0)
-                  },
-                  loc,
-                  attrs
-                ];
-      case /* Texp_coerce */1 :
-          var ct1 = desc._0;
-          if (ct1 !== undefined) {
-            return [
-                    {
-                      TAG: /* Texp_coerce */1,
-                      _0: map_core_type(ct1),
-                      _1: map_core_type(desc._1)
-                    },
-                    loc,
-                    attrs
-                  ];
-          } else {
-            return [
-                    {
-                      TAG: /* Texp_coerce */1,
-                      _0: undefined,
-                      _1: map_core_type(desc._1)
-                    },
-                    loc,
-                    attrs
-                  ];
-          }
-      case /* Texp_poly */3 :
-          var ct = desc._0;
-          if (ct !== undefined) {
-            return [
-                    {
-                      TAG: /* Texp_poly */3,
-                      _0: map_core_type(ct)
-                    },
-                    loc,
-                    attrs
-                  ];
-          } else {
-            return exp_extra;
-          }
-      case /* Texp_open */2 :
-      case /* Texp_newtype */4 :
-          return exp_extra;
-      
-    }
-  };
-  var map_class_structure = function (cs) {
-    var cs$1 = Curry._1(funarg.enter_class_structure, cs);
-    var cstr_self = map_pattern(cs$1.cstr_self);
-    var cstr_fields = List.map(map_class_field, cs$1.cstr_fields);
-    return Curry._1(funarg.leave_class_structure, {
-                cstr_self: cstr_self,
-                cstr_fields: cstr_fields,
-                cstr_type: cs$1.cstr_type,
-                cstr_meths: cs$1.cstr_meths
-              });
-  };
-  var map_case = function (param) {
-    return {
-            c_lhs: map_pattern(param.c_lhs),
-            c_guard: may_map(map_expression, param.c_guard),
-            c_rhs: map_expression(param.c_rhs)
-          };
-  };
-  var map_with_constraint = function (cstr) {
-    var cstr$1 = Curry._1(funarg.enter_with_constraint, cstr);
-    var tmp;
-    switch (cstr$1.TAG | 0) {
-      case /* Twith_type */0 :
-          tmp = {
-            TAG: /* Twith_type */0,
-            _0: map_type_declaration(cstr$1._0)
-          };
-          break;
-      case /* Twith_typesubst */2 :
-          tmp = {
-            TAG: /* Twith_typesubst */2,
-            _0: map_type_declaration(cstr$1._0)
-          };
-          break;
-      case /* Twith_module */1 :
-      case /* Twith_modsubst */3 :
-          tmp = cstr$1;
-          break;
-      
-    }
-    return Curry._1(funarg.leave_with_constraint, tmp);
-  };
-  var map_signature = function (sg) {
-    var sg$1 = Curry._1(funarg.enter_signature, sg);
-    var sig_items = List.map(map_signature_item, sg$1.sig_items);
-    return Curry._1(funarg.leave_signature, {
-                sig_items: sig_items,
-                sig_type: sg$1.sig_type,
-                sig_final_env: sg$1.sig_final_env
-              });
-  };
-  var map_class_field = function (cf) {
-    var cf$1 = Curry._1(funarg.enter_class_field, cf);
-    var exp = cf$1.cf_desc;
-    var cf_desc;
-    switch (exp.TAG | 0) {
-      case /* Tcf_inherit */0 :
-          cf_desc = {
-            TAG: /* Tcf_inherit */0,
-            _0: exp._0,
-            _1: map_class_expr(exp._1),
-            _2: exp._2,
-            _3: exp._3,
-            _4: exp._4
-          };
-          break;
-      case /* Tcf_val */1 :
-          var cty = exp._3;
-          var ident = exp._2;
-          var mut = exp._1;
-          var lab = exp._0;
-          cf_desc = cty.TAG === /* Tcfk_virtual */0 ? ({
-                TAG: /* Tcf_val */1,
-                _0: lab,
-                _1: mut,
-                _2: ident,
-                _3: {
-                  TAG: /* Tcfk_virtual */0,
-                  _0: map_core_type(cty._0)
-                },
-                _4: exp._4
-              }) : ({
-                TAG: /* Tcf_val */1,
-                _0: lab,
-                _1: mut,
-                _2: ident,
-                _3: {
-                  TAG: /* Tcfk_concrete */1,
-                  _0: cty._0,
-                  _1: map_expression(cty._1)
-                },
-                _4: exp._4
-              });
-          break;
-      case /* Tcf_method */2 :
-          var cty$1 = exp._2;
-          var priv = exp._1;
-          var lab$1 = exp._0;
-          cf_desc = cty$1.TAG === /* Tcfk_virtual */0 ? ({
-                TAG: /* Tcf_method */2,
-                _0: lab$1,
-                _1: priv,
-                _2: {
-                  TAG: /* Tcfk_virtual */0,
-                  _0: map_core_type(cty$1._0)
-                }
-              }) : ({
-                TAG: /* Tcf_method */2,
-                _0: lab$1,
-                _1: priv,
-                _2: {
-                  TAG: /* Tcfk_concrete */1,
-                  _0: cty$1._0,
-                  _1: map_expression(cty$1._1)
-                }
-              });
-          break;
-      case /* Tcf_constraint */3 :
-          cf_desc = {
-            TAG: /* Tcf_constraint */3,
-            _0: map_core_type(exp._0),
-            _1: map_core_type(exp._1)
-          };
-          break;
-      case /* Tcf_initializer */4 :
-          cf_desc = {
-            TAG: /* Tcf_initializer */4,
-            _0: map_expression(exp._0)
-          };
-          break;
-      case /* Tcf_attribute */5 :
-          cf_desc = exp;
-          break;
-      
-    }
-    return Curry._1(funarg.leave_class_field, {
-                cf_desc: cf_desc,
-                cf_loc: cf$1.cf_loc,
-                cf_attributes: cf$1.cf_attributes
-              });
-  };
-  var map_constructor_declaration = function (cd) {
-    return {
-            cd_id: cd.cd_id,
-            cd_name: cd.cd_name,
-            cd_args: List.map(map_core_type, cd.cd_args),
-            cd_res: may_map(map_core_type, cd.cd_res),
-            cd_loc: cd.cd_loc,
-            cd_attributes: cd.cd_attributes
-          };
   };
   return {
           map_structure: map_structure,
@@ -37267,8 +37267,8 @@ function memq_warn(t, visited) {
   }
 }
 
-function lid_of_path($staropt$star, id) {
-  var sharp = $staropt$star !== undefined ? $staropt$star : "";
+function lid_of_path(sharpOpt, id) {
+  var sharp = sharpOpt !== undefined ? sharpOpt : "";
   switch (id.TAG | 0) {
     case /* Pident */0 :
         return {


### PR DESCRIPTION
## Context

For sourcemaps my plan is to add back Levent on melange-compiler-libs and remove it on Lam_convert, making so that we have the locations data available on Melange.

## Problem

But if we do that, a bunch of pattern matching that were not expecting Levent now don't happen.

## Proposal

Always convert first to Lam.t and then match, this was mostly already implemented but here I finish the patch.

**warning** this change the order of some transformations, which matters because we use mutation in a couple places, so the artifact that changed looks reasonable to me.

But I didn't fully test it, ideally we could test it in some big projects.