### PR TITLE
Revert "Fix Js.String.match_ return type" because it's a breaking change with ReScript

### DIFF
--- a/jscomp/others/js_string.ml
+++ b/jscomp/others/js_string.ml
@@ -274,7 +274,7 @@ external localeCompare : t -> float = "localeCompare" [@@bs.send.pipe: t]
 ]}
 
 *)
-external match_ : Js_re.t -> t option array option = "match" [@@bs.send.pipe: t] [@@bs.return {null_to_opt}]
+external match_ : Js_re.t -> t array option = "match" [@@bs.send.pipe: t] [@@bs.return {null_to_opt}]
 
 (** [normalize str] returns the normalized Unicode string using Normalization Form Canonical (NFC) Composition.
 

--- a/jscomp/others/js_string2.ml
+++ b/jscomp/others/js_string2.ml
@@ -273,7 +273,7 @@ external localeCompare : t -> t -> float = "localeCompare" [@@bs.send]
 ]}
 
 *)
-external match_ : t -> Js_re.t -> t option array option = "match" [@@bs.send] [@@bs.return {null_to_opt}]
+external match_ : t -> Js_re.t -> t array option = "match" [@@bs.send] [@@bs.return {null_to_opt}]
 
 (** [normalize str] returns the normalized Unicode string using Normalization Form Canonical (NFC) Composition.
 

--- a/jscomp/test/js_string_test.ml
+++ b/jscomp/test/js_string_test.ml
@@ -84,13 +84,10 @@ let suites = Mt.[
     );
 
     "match", (fun _ ->
-      Eq(Some [| Some "na"; Some "na" |], "banana" |. Js.String2.match_ [%re "/na+/g"])
+      Eq(Some [| "na"; "na" |], "banana" |. Js.String2.match_ [%re "/na+/g"])
     );
     "match - no match", (fun _ ->
       Eq(None, "banana" |. Js.String2.match_ [%re "/nanana+/g"])
-    );
-    "match - not found capture groups", (fun _ ->
-      Eq(Some [| Some "hello "; None |], "hello word" |. Js.String2.match_ [%re "/hello (world)?/"] |. Belt.Option.map Js.Array.copy )
     );
 
     (* es2015 *)


### PR DESCRIPTION
I think it's a good change in general, but I think we should be careful about breaking with ReScript, as it makes parallel use of both compilers impossible. Which is something companies/projects want to do to support both compilers when experimenting with melange. I would suggest when making these changes to the bindings to create a new function instead of changing the old one breaking compatibility.

This reverts commit ccceb69d85afdf7743259bb9faca6f975ebe541f.