### PR TITLE
Generate warning parameters based on bsconfig

### DIFF
--- a/jscomp/bsb/bsb_warning.ml
+++ b/jscomp/bsb/bsb_warning.ml
@@ -93,8 +93,26 @@ let from_map (m : Ext_json_types.t Map_string.t) =
     Some {number; error }
 
 
-let to_bsb_string ~(package_kind: Bsb_package_kind.t) _warning =
+let to_bsb_string ~(package_kind: Bsb_package_kind.t) warning =
   match package_kind with
-    | Toplevel
+  | Toplevel ->
+    (match warning with
+    | None -> Ext_string.empty
+    | Some warning ->
+      (match warning.number with
+       | None ->
+         Ext_string.empty
+       | Some x ->
+         prepare_warning_concat ~beg:true x
+      ) ^
+      (
+        match warning.error with
+        | Warn_error_true ->
+          " -warn-error A"
+        | Warn_error_number y ->
+          " -warn-error " ^ y
+        | Warn_error_false ->
+          Ext_string.empty
+      ))
     | Dependency _ ->  " -w a"
   (* TODO: this is the current default behavior *)


### PR DESCRIPTION
Commit 3926929d6b37e010474a90643d48ffdfbb651d9e removed pinned dependencies.
It broke bsconfig warning configuration handling, all the warning codes
were parsed but not included into the dune rule generation.

Fixed the issue by bringing back the original warning handling excluding
the pinning dependencies part.

**Behavior before**
Code
```
type test = A | B | C;
let test = C;

let result =
  switch (test) {
  | A => "A"
  | B => "B"
  };
```
bsconfig.json
```
    "warnings": {
      "number" : "+8",
      "error" : "+8"
    }
```
Generated dune.mel
```
 (run melc  -w a -bs-jsx 3  -absname -bs-ast -o %{targets} %{inputs}))
```
No warnings or errors were reported because `-w a` disables all the warnings on top level.

**Behavior after the fix**
```
 (run melc -w +8 -warn-error +8 -bs-jsx 3  -absname -bs-ast -o %{targets} %{inputs}))
```
Build output reports the compilation error accordingly.
```
File "....../_build/default/src/Main.re", lines 5-8, characters 2-3:
5 | ..switch (test) {
6 |   | A => "A"
7 |   | B => "B"
8 |   }.
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
C
```