### PR TITLE
Update editor instructions to use released version of ocaml-lsp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To enable editor support via `ocaml-lsp`, add the following to your `esy.json`:
 // esy.json
 {
   "devDependencies": {
-    "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#c275140",
+    "@opam/ocaml-lsp-server": ">= 1.12.0",
     "@opam/dot-merlin-reader": "*"
   }
 }


### PR DESCRIPTION
[`ocaml-lsp-server 1.12.0`](https://github.com/ocaml/ocaml-lsp/releases/tag/1.12.0) includes the commit that adds the `--fallback-read-dot-merlin` flag, so we no longer need to use an unreleased version.

Related: melange-re/melange-basic-template#16