### PR TITLE
Allow multiple --bs-package-output options

### DIFF
--- a/jscomp/main/melc.ml
+++ b/jscomp/main/melc.ml
@@ -408,7 +408,7 @@ let main: Melc_cli.t -> _ Cmdliner.Term.ret
     if make_runtime_test then Js_packages_state.make_runtime_test ();
 
     Ext_option.iter bs_package_name Js_packages_state.set_package_name;
-    Ext_option.iter bs_package_output Js_packages_state.update_npm_package_path;
+    Ext_list.iter bs_package_output Js_packages_state.update_npm_package_path;
     Ext_option.iter bs_ns Js_packages_state.set_package_map;
 
     if as_ppx then Js_config.as_ppx := as_ppx;

--- a/jscomp/main/melc_cli.ml
+++ b/jscomp/main/melc_cli.ml
@@ -289,7 +289,7 @@ module Internal = struct
       "*internal* Set npm-output-path: [opt_module]:path, for example: \
        'lib/cjs', 'amdjs:lib/amdjs', 'es6:lib/es6' "
     in
-    Arg.(value & opt_all (string) [] & info [ "bs-package-output" ] ~doc)
+    Arg.(value & opt_all string [] & info [ "bs-package-output" ] ~doc)
 
   let bs_ast =
     let doc = "*internal* Generate binary .mli_ast and ml_ast and stop" in

--- a/jscomp/main/melc_cli.ml
+++ b/jscomp/main/melc_cli.ml
@@ -32,7 +32,7 @@ type t = {
   ppx : string list;
   open_modules : string list;
   bs_jsx : int option;
-  bs_package_output : string option;
+  bs_package_output : string list;
   bs_ast : bool;
   bs_syntax_only : bool;
   bs_g : bool;
@@ -289,7 +289,7 @@ module Internal = struct
       "*internal* Set npm-output-path: [opt_module]:path, for example: \
        'lib/cjs', 'amdjs:lib/amdjs', 'es6:lib/es6' "
     in
-    Arg.(value & opt (some string) None & info [ "bs-package-output" ] ~doc)
+    Arg.(value & opt_all (string) [] & info [ "bs-package-output" ] ~doc)
 
   let bs_ast =
     let doc = "*internal* Generate binary .mli_ast and ml_ast and stop" in


### PR DESCRIPTION
Given a `bsconfig.json` like [the following](https://github.com/ELLIOTTCABLE/excmd.js/blob/3cb1ef3bd8c41a3505776f57209588ae96955ea6/packages/bs-excmd/bsconfig.json#L85-L94),

```json5
   "package-specs": [
      {
         "module": "es6",
         "in-source": true
      },
      {
         "module": "commonjs",
         "in-source": false
      }
   ],
```

A bug is currently producing:

```
melc: option '--bs-package-output' cannot be repeated
```

This PR fixes that by iterating over all `--bs-package-output` flags.

([Discord ref](https://discord.com/channels/235176658175262720/825155604641218580/1015008383646044180).)