### PR TITLE
Split bsbuild serialized cache in chunks

### DIFF
--- a/jscomp/bsb/bsb_db_encode.ml
+++ b/jscomp/bsb/bsb_db_encode.ml
@@ -111,24 +111,8 @@ let write_build_cache buf (bs_files : Bsb_db.t) : unit =
     Ext_buffer.contents buf
   in
 
-  let ic = Unix.open_process_in "mktemp" in
-  let all_input = ref [] in
-  let file_path = try
-    let () = while true do
-      all_input := input_line ic :: !all_input
-    done in 
-    String.concat "\n" !all_input
-  with
-    End_of_file ->
-    close_in ic;
-    String.concat "\n" !all_input in
-
-  let oc = open_out file_path in
-  Printf.fprintf oc "%s" bsbuild_cache;
-  close_out oc;
-
   let bsbuild_rule =
-    Format.asprintf "@\n(rule (with-stdout-to %s (cat \"%s\")))"
-      Literals.bsbuild_cache file_path
+    Format.asprintf "@\n(rule (with-stdout-to %s (bash \"cat <<EOF\n%s\nEOF\")))"
+      Literals.bsbuild_cache bsbuild_cache
   in
   Buffer.add_string buf bsbuild_rule

--- a/jscomp/bsb/bsb_db_encode.ml
+++ b/jscomp/bsb/bsb_db_encode.ml
@@ -111,8 +111,24 @@ let write_build_cache buf (bs_files : Bsb_db.t) : unit =
     Ext_buffer.contents buf
   in
 
+  let ic = Unix.open_process_in "mktemp" in
+  let all_input = ref [] in
+  let file_path = try
+    let () = while true do
+      all_input := input_line ic :: !all_input
+    done in 
+    String.concat "\n" !all_input
+  with
+    End_of_file ->
+    close_in ic;
+    String.concat "\n" !all_input in
+
+  let oc = open_out file_path in
+  Printf.fprintf oc "%s" bsbuild_cache;
+  close_out oc;
+
   let bsbuild_rule =
-    Format.asprintf "@\n(rule (with-stdout-to %s (run echo -n \"%s\")))"
-      Literals.bsbuild_cache bsbuild_cache
+    Format.asprintf "@\n(rule (with-stdout-to %s (cat \"%s\")))"
+      Literals.bsbuild_cache file_path
   in
   Buffer.add_string buf bsbuild_rule

--- a/jscomp/bsb/bsb_db_encode.ml
+++ b/jscomp/bsb/bsb_db_encode.ml
@@ -111,23 +111,8 @@ let write_build_cache buf (bs_files : Bsb_db.t) : unit =
     Ext_buffer.contents buf
   in
 
-  let split_string b =
-    let chunk_size = 65534 in
-    let rec isplit sofar ib =
-        let iblen = String.length ib in
-        if iblen > chunk_size then
-            let chunk = String.sub ib 0 chunk_size in
-            let rest = String.sub ib chunk_size (iblen - chunk_size) in
-            isplit (chunk :: sofar) rest
-        else
-            ib :: sofar
-    in
-    List.rev (isplit [] b) in
-
-  let run_stanzas = List.map (fun chunk -> Printf.sprintf "(run echo -n \"%s\")" chunk) (split_string bsbuild_cache) in
-
   let bsbuild_rule =
-    Format.asprintf "@\n(rule (with-stdout-to %s (progn %s)))"
-      Literals.bsbuild_cache (String.concat "" run_stanzas)
+    Format.asprintf "@\n(rule (write-file %s %s))"
+      Literals.bsbuild_cache bsbuild_cache
   in
   Buffer.add_string buf bsbuild_rule


### PR DESCRIPTION
To prevent "Argument list too long" errors for very large projects. This error happens due to `execve` used by dune hitting ARG_MAX (or MAX_ARG_STRLEN, not sure) limit.

Initially tried creating tmp file using `mktemp` but it's more intrusive approach, that also would break on windows.

Also tried using EOT/EOF but this would not fix the issue.

In the end, the simplest fix seems to be to split the string in smaller chunks and use `progn` to concatenate all `echo` runs.