### PR TITLE
Fix -bin-annot and -bs-no-bin-annot handling

### DIFF
--- a/jscomp/main/melc.ml
+++ b/jscomp/main/melc.ml
@@ -454,7 +454,7 @@ let main: Melc_cli.t -> _ Cmdliner.Term.ret
     if version then print_version_string ();
     Ext_option.iter pp (fun pp -> Clflags.preprocessor := Some pp);
     if absname then Clflags.absname := absname;
-    Ext_option.iter bin_annot (fun bin_annot ->  Clflags.binary_annotations := not bin_annot);
+    Ext_option.iter bin_annot (fun bin_annot ->  Clflags.binary_annotations := bin_annot);
     if i then Clflags.print_types := i;
     if nopervasives then Clflags.nopervasives := nopervasives;
     if modules then Js_config.modules := modules;


### PR DESCRIPTION
Quick repro:

```
cat > test.mli <<EOL
val t : string
EOL
```

In `fork`:
- calling ` melc -bin-annot -o test.cmi -c -intf test.mli` will not generate `test.cmti`
- calling `melc -bs-no-bin-annot -o test.cmi -c -intf test.mli` will generate `test.cmti`

This patch fixes it, so each action does the opposite from `fork`, while preserving default behavior (generate `cmti` when neither `-bin-annot` or `-bs-no-bin-annot` are passed).