### PR TITLE
dune.mel: use an Out_channel.t instead of a Buffer.t

### DIFF
--- a/dune.mel
+++ b/dune.mel
@@ -1,4 +1,4 @@
-;;;;{BSB GENERATED: NO EDIT
+
 (subdir jscomp/runtime/bs_stdlib_mini
 (rule
 (targets  bs_stdlib_mini.ast)
@@ -6000,4 +6000,3 @@
 (:sources-3 (glob_files jscomp/others/*))
 (:sources-4 (glob_files jscomp/runtime/*))
 (:sources-5 (glob_files jscomp/runtime/bs_stdlib_mini/*))))
-;;;;BSB GENERATED: NO EDIT}

--- a/jscomp/bsb/bsb_db_encode.ml
+++ b/jscomp/bsb/bsb_db_encode.ml
@@ -104,7 +104,7 @@ let encode (dbs : Bsb_db.t) buf =
    we should we avoid it in the first place, if we do start scanning,
    this operation seems affordable
 *)
-let write_build_cache buf (bs_files : Bsb_db.t) : unit =
+let write_build_cache oc (bs_files : Bsb_db.t) : unit =
   let bsbuild_cache =
     let buf = Ext_buffer.create 100_000 in
     encode bs_files buf;
@@ -115,4 +115,4 @@ let write_build_cache buf (bs_files : Bsb_db.t) : unit =
     Format.asprintf "@\n(rule (write-file %s %s))" Literals.bsbuild_cache
       bsbuild_cache
   in
-  Buffer.add_string buf bsbuild_rule
+  output_string oc bsbuild_rule

--- a/jscomp/bsb/bsb_db_encode.mli
+++ b/jscomp/bsb/bsb_db_encode.mli
@@ -23,4 +23,4 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 val encode : Bsb_db.t -> Ext_buffer.t -> unit
-val write_build_cache : Buffer.t -> Bsb_db.t -> unit
+val write_build_cache : Out_channel.t -> Bsb_db.t -> unit

--- a/jscomp/bsb/bsb_namespace_map_gen.ml
+++ b/jscomp/bsb/bsb_namespace_map_gen.ml
@@ -33,8 +33,7 @@ let pp_module_set fmt xs =
   [.mlmap] does not need to be changed too
 
 *)
-let output buf (namespace : string) (file_groups : Bsb_file_groups.file_groups)
-    =
+let output oc (namespace : string) (file_groups : Bsb_file_groups.file_groups) =
   let module_set =
     Ext_list.fold_left file_groups Set_string.empty (fun acc x ->
         Map_string.fold x.sources acc (fun k _ acc -> Set_string.add acc k))
@@ -43,4 +42,4 @@ let output buf (namespace : string) (file_groups : Bsb_file_groups.file_groups)
     Format.asprintf "@\n(rule (with-stdout-to %s%s (run echo \"%a\")))"
       namespace Literals.suffix_mlmap pp_module_set module_set
   in
-  Buffer.add_string buf mlmap_rule
+  output_string oc mlmap_rule

--- a/jscomp/bsb/bsb_namespace_map_gen.mli
+++ b/jscomp/bsb/bsb_namespace_map_gen.mli
@@ -22,7 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-val output : Buffer.t -> string -> Bsb_file_groups.file_groups -> unit
+val output : Out_channel.t -> string -> Bsb_file_groups.file_groups -> unit
 (** [output dir namespace file_groups]
     when [build.ninja] is generated, we output a module map [.mlmap] file
     such [.mlmap] file will be consumed by [bsc.exe] to generate [.cmi] file

--- a/jscomp/bsb/bsb_ninja_file_groups.mli
+++ b/jscomp/bsb/bsb_ninja_file_groups.mli
@@ -30,7 +30,7 @@ val rel_dependencies_alias :
   string list
 
 val handle_files_per_dir :
-  Buffer.t ->
+  Out_channel.t ->
   global_config:Bsb_ninja_global_vars.t ->
   db:Bsb_db.t ->
   rules:Bsb_ninja_rule.builtin ->

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -42,7 +42,7 @@ let bsc_lib_includes ~root_dir (bs_dependencies : Bsb_config_types.dependencies)
           in
           virtual_proj_dir // dir))
 
-let output_ninja_and_namespace_map ~buf ~per_proj_dir ~root_dir
+let output_ninja_and_namespace_map ~oc ~per_proj_dir ~root_dir
     ~(package_kind : Bsb_package_kind.Source_info.t)
     ({
        package_name;
@@ -103,11 +103,11 @@ let output_ninja_and_namespace_map ~buf ~per_proj_dir ~root_dir
       ~has_postbuild:js_post_build_cmd ~pp_file ~has_builtin:built_in_dependency
       ~reason_react_jsx ~package_specs generators
   in
-  Buffer.add_char buf '\n';
+  output_char oc '\n';
 
   (* Generate build statement for each file *)
   Ext_list.iter bs_file_groups (fun files_per_dir ->
-      Bsb_ninja_file_groups.handle_files_per_dir buf ~global_config ~rules
+      Bsb_ninja_file_groups.handle_files_per_dir oc ~global_config ~rules
         ~package_specs ~db:bs_groups ~js_post_build_cmd ~bs_dev_dependencies
         ~bs_dependencies files_per_dir);
 
@@ -115,54 +115,54 @@ let output_ninja_and_namespace_map ~buf ~per_proj_dir ~root_dir
     not
       (Mel_workspace.is_dep_inside_workspace ~root_dir ~package_dir:per_proj_dir)
   then (
-    Buffer.add_string buf "(subdir ";
-    Buffer.add_string buf (Mel_workspace.to_workspace_proj_dir ~package_name);
-    Buffer.add_string buf
+    output_string oc "(subdir ";
+    output_string oc (Mel_workspace.to_workspace_proj_dir ~package_name);
+    output_string oc
       "\n (copy_files (alias mel_copy_out_of_source_dir)\n (files ";
-    Buffer.add_string buf per_proj_dir;
-    Buffer.add_string buf Filename.dir_sep;
-    Buffer.add_string buf "*)))");
+    output_string oc per_proj_dir;
+    output_string oc Filename.dir_sep;
+    output_string oc "*)))");
 
-  Buffer.add_char buf '\n';
+  output_char oc '\n';
 
   let artifacts_dir =
     Mel_workspace.rel_artifacts_dir ~package_name ~root_dir
       ~proj_dir:per_proj_dir root_dir
   in
 
-  Buffer.add_string buf "(subdir ";
-  Buffer.add_string buf artifacts_dir;
+  output_string oc "(subdir ";
+  output_string oc artifacts_dir;
 
-  Bsb_ppxlib.ppxlib buf ~ppx_config;
+  Bsb_ppxlib.ppxlib oc ~ppx_config;
 
   Ext_option.iter namespace (fun ns ->
-      Bsb_namespace_map_gen.output buf ns bs_file_groups;
+      Bsb_namespace_map_gen.output oc ns bs_file_groups;
 
-      Bsb_ninja_targets.output_build artifacts_dir buf
+      Bsb_ninja_targets.output_build artifacts_dir oc
         ~outputs:[ ns ^ Literals.suffix_cmi ]
         ~inputs:[ ns ^ Literals.suffix_mlmap ]
         ~rule:rules.build_package);
 
-  Bsb_db_encode.write_build_cache buf bs_groups;
+  Bsb_db_encode.write_build_cache oc bs_groups;
 
   match package_kind with
   | Bsb_package_kind.Source_info.Toplevel source_meta ->
-      Buffer.add_string buf
+      output_string oc
         (Format.asprintf "\n(rule (write-file %s %S)) " Literals.sourcedirs_meta
            (source_meta |> Source_metadata.to_json |> Ext_json_noloc.to_string));
-      Buffer.add_string buf "\n)\n";
+      output_string oc "\n)\n";
 
       (* Add `(data_only_dirs node_modules)` because they could contain native
        * OCaml code that we do not want to build. *)
-      Buffer.add_string buf "\n(data_only_dirs ";
-      Buffer.add_string buf Literals.node_modules;
-      Buffer.add_char buf ' ';
-      Buffer.add_char buf ' ';
-      Buffer.add_string buf Literals.melange_eobjs_dir;
+      output_string oc "\n(data_only_dirs ";
+      output_string oc Literals.node_modules;
+      output_char oc ' ';
+      output_char oc ' ';
+      output_string oc Literals.melange_eobjs_dir;
       (* for the edge case of empty sources (either in user config or because a
          source dir is empty), we emit an empty `bsb_world` alias. This avoids
          showing the user an error when they haven't done anything. *)
-      Buffer.add_string buf
+      output_string oc
         (Format.asprintf ")\n(alias (name %s) (deps %s " Literals.mel_dune_alias
            (artifacts_dir // Literals.sourcedirs_meta));
 
@@ -170,9 +170,9 @@ let output_ninja_and_namespace_map ~buf ~per_proj_dir ~root_dir
       Ext_list.iter
         (Bsb_ninja_file_groups.rel_dependencies_alias ~root_dir
            ~proj_dir:root_dir ~cur_dir:root_dir bs_dependencies) (fun dep ->
-          Buffer.add_string buf (Format.asprintf "(alias %s)" dep));
-      Buffer.add_string buf "))\n"
-  | Dependency _ -> Buffer.add_string buf "\n)\n"
+          output_string oc (Format.asprintf "(alias %s)" dep));
+      output_string oc "))\n"
+  | Dependency _ -> output_string oc "\n)\n"
 
 let rel_include_dirs ~package_name ~root_dir ~per_proj_dir ~install_dir ~cur_dir
     ?namespace source_dirs =
@@ -192,15 +192,15 @@ let rel_include_dirs ~package_name ~root_dir ~per_proj_dir ~install_dir ~cur_dir
   in
   Bsb_build_util.include_dirs dirs
 
-let output_virtual_package ~root_dir ~package_spec ~buf
+let output_virtual_package ~root_dir ~package_spec ~oc
     ((config, configs) : Bsb_config_types.t * Bsb_config_types.t list) =
   let package_spec_dir = Bsb_package_specs.output_dir_of_spec package_spec in
   let package_spec_suffix = Ext_js_suffix.to_string package_spec.suffix in
-  Buffer.add_string buf "\n(rule (targets (dir ";
-  Buffer.add_string buf package_spec_dir;
-  Buffer.add_string buf "))\n (alias UNSTABLE_";
-  Buffer.add_string buf Literals.mel_dune_alias;
-  Buffer.add_string buf ")\n(action (chdir %{targets} (progn \n";
+  output_string oc "\n(rule (targets (dir ";
+  output_string oc package_spec_dir;
+  output_string oc "))\n (alias UNSTABLE_";
+  output_string oc Literals.mel_dune_alias;
+  output_string oc ")\n(action (chdir %{targets} (progn \n";
 
   let idx =
     let idx = ref 0 in
@@ -243,9 +243,9 @@ let output_virtual_package ~root_dir ~package_spec ~buf
                    (root_dir // rel_group_dir)
                in
 
-               Buffer.add_string buf
+               output_string oc
                  (Format.asprintf "(run mkdir -p %s)\n" rel_group_dir);
-               Buffer.add_string buf
+               output_string oc
                  (Format.asprintf
                     "(run cp %%{sources-%d} %s) (system \"rm -f \
                      %s/*.{ast,cm*,d}\")\n"
@@ -286,20 +286,20 @@ let output_virtual_package ~root_dir ~package_spec ~buf
                        (Ext_js_suffix.to_string package_spec.suffix)
                    in
 
-                   Buffer.add_string buf " (run rm -f ";
-                   Buffer.add_string buf (rel_group_dir // js_name);
-                   Buffer.add_string buf ")\n (run ";
-                   Buffer.add_string buf
+                   output_string oc " (run rm -f ";
+                   output_string oc (rel_group_dir // js_name);
+                   output_string oc ")\n (run ";
+                   output_string oc
                      (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsc);
-                   Buffer.add_string buf ns_flag;
-                   Buffer.add_char buf ' ';
+                   output_string oc ns_flag;
+                   output_char oc ' ';
                    if group.is_dev && source_dirs.dev <> [] then (
                      let dev_incls = rel_incls ?namespace source_dirs.dev in
-                     Buffer.add_string buf " ";
-                     Buffer.add_string buf dev_incls);
-                   Buffer.add_string buf (rel_incls ?namespace source_dirs.lib);
-                   Buffer.add_string buf " ";
-                   Buffer.add_string buf
+                     output_string oc " ";
+                     output_string oc dev_incls);
+                   output_string oc (rel_incls ?namespace source_dirs.lib);
+                   output_string oc " ";
+                   output_string oc
                      (Bsb_build_util.include_dirs
                         (Ext_list.map
                            (bsc_lib_includes ~root_dir bs_dependencies)
@@ -307,8 +307,8 @@ let output_virtual_package ~root_dir ~package_spec ~buf
                              Ext_path.rel_normalized_absolute_path
                                ~from:install_dir dir)));
                    if group.is_dev then (
-                     Buffer.add_string buf " ";
-                     Buffer.add_string buf
+                     output_string oc " ";
+                     output_string oc
                        (Bsb_build_util.include_dirs
                           (Ext_list.map
                              (bsc_lib_includes ~root_dir bs_dev_dependencies)
@@ -316,25 +316,25 @@ let output_virtual_package ~root_dir ~package_spec ~buf
                                Ext_path.rel_normalized_absolute_path
                                  ~from:install_dir dir))));
 
-                   Buffer.add_string buf " -bs-package-name ";
-                   Buffer.add_string buf (Ext_filename.maybe_quote package_name);
+                   output_string oc " -bs-package-name ";
+                   output_string oc (Ext_filename.maybe_quote package_name);
 
-                   Buffer.add_string buf
+                   output_string oc
                      (Format.asprintf " -bs-package-output %s:%s:%s"
                         (Bsb_package_specs.string_of_format package_spec.format)
                         rel_group_dir package_spec_suffix);
-                   Buffer.add_char buf ' ';
-                   Buffer.add_string buf rel_cmj;
-                   Buffer.add_string buf " -o ";
-                   Buffer.add_string buf (rel_group_dir // js_name);
-                   Buffer.add_string buf ")\n");
+                   output_char oc ' ';
+                   output_string oc rel_cmj;
+                   output_string oc " -o ";
+                   output_string oc (rel_group_dir // js_name);
+                   output_string oc ")\n");
                rel_group_dir)))
   in
 
-  Buffer.add_string buf
+  output_string oc
     (Format.asprintf " ))) (deps %s"
        (String.concat "\n"
           (Ext_list.mapi dirs (fun idx dir ->
                Format.asprintf "(:sources-%d (glob_files %s/*))" idx dir))));
 
-  Buffer.add_string buf "))\n"
+  output_string oc "))\n"

--- a/jscomp/bsb/bsb_ninja_gen.mli
+++ b/jscomp/bsb/bsb_ninja_gen.mli
@@ -23,7 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 val output_ninja_and_namespace_map :
-  buf:Buffer.t ->
+  oc:Out_channel.t ->
   per_proj_dir:string ->
   root_dir:string ->
   package_kind:Bsb_package_kind.Source_info.t ->
@@ -36,6 +36,6 @@ val output_ninja_and_namespace_map :
 val output_virtual_package :
   root_dir:string ->
   package_spec:Bsb_package_specs.spec ->
-  buf:Buffer.t ->
+  oc:Out_channel.t ->
   Bsb_config_types.t * Bsb_config_types.t list ->
   unit

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -27,7 +27,7 @@
 *)
 type t = {
   rule :
-    Buffer.t ->
+    Out_channel.t ->
     ?error_syntax_kind:Bsb_db.syntax_kind ->
     ?target:string ->
     string ->
@@ -36,7 +36,7 @@ type t = {
 
 val output_rule :
   t ->
-  Buffer.t ->
+  Out_channel.t ->
   ?error_syntax_kind:Bsb_db.syntax_kind ->
   ?target:string ->
   string ->

--- a/jscomp/bsb/bsb_ninja_targets.ml
+++ b/jscomp/bsb/bsb_ninja_targets.ml
@@ -65,79 +65,79 @@ let revise_dune dune new_content =
     output_string ochan "\n";
     close_out ochan
 
-let output_alias ?action buf ~name ~deps =
+let output_alias ?action oc ~name ~deps =
   (match action with
   | Some action ->
-      Buffer.add_string buf "\n(rule (alias ";
-      Buffer.add_string buf name;
-      Buffer.add_string buf ")\n (action ";
-      Buffer.add_string buf action
+      output_string oc "\n(rule (alias ";
+      output_string oc name;
+      output_string oc ")\n (action ";
+      output_string oc action
   | None ->
-      Buffer.add_string buf "\n(alias (name ";
-      Buffer.add_string buf name);
-  Buffer.add_string buf ")";
+      output_string oc "\n(alias (name ";
+      output_string oc name);
+  output_string oc ")";
   if deps <> [] then (
-    Buffer.add_string buf "(deps ";
+    output_string oc "(deps ";
     Ext_list.iter deps (fun x ->
-        Buffer.add_string buf Ext_string.single_space;
-        Buffer.add_string buf (Filename.basename x));
-    Buffer.add_string buf ")");
-  Buffer.add_char buf '\n';
-  Buffer.add_string buf enabled_if;
-  Buffer.add_string buf ")"
+        output_string oc Ext_string.single_space;
+        output_string oc (Filename.basename x));
+    output_string oc ")");
+  output_char oc '\n';
+  output_string oc enabled_if;
+  output_string oc ")"
 
 let output_build ?(implicit_deps = []) ?(rel_deps = []) ?(bs_dependencies = [])
     ?alias ?(implicit_outputs = []) ?(js_outputs = []) ?error_syntax_kind
-    ~outputs ~inputs ~rule cur_dir buf =
+    ~outputs ~inputs ~rule cur_dir oc =
   let just_js_outputs = List.map fst js_outputs in
-  Buffer.add_string buf "(rule\n(targets ";
+  output_string oc "(rule\n(targets ";
   Ext_list.iter outputs (fun s ->
-      Buffer.add_string buf Ext_string.single_space;
-      Buffer.add_string buf (Filename.basename s));
+      output_string oc Ext_string.single_space;
+      output_string oc (Filename.basename s));
   if implicit_outputs <> [] || js_outputs <> [] then
     Ext_list.iter (implicit_outputs @ just_js_outputs) (fun s ->
-        Buffer.add_string buf Ext_string.single_space;
-        Buffer.add_string buf (Filename.basename s));
-  Buffer.add_string buf ")\n ";
+        output_string oc Ext_string.single_space;
+        output_string oc (Filename.basename s));
+  output_string oc ")\n ";
   Ext_option.iter alias (fun alias ->
-      Buffer.add_string buf "(alias ";
-      Buffer.add_string buf alias;
-      Buffer.add_string buf ")\n ");
+      output_string oc "(alias ";
+      output_string oc alias;
+      output_string oc ")\n ");
   let in_source_outputs =
     List.filter_map
       (fun (js, in_source) -> if in_source then Some js else None)
       js_outputs
   in
   if in_source_outputs <> [] then (
-    Buffer.add_string buf "(mode (promote (until-clean) (only";
+    output_string oc "(mode (promote (until-clean) (only";
     Ext_list.iter in_source_outputs (fun s ->
-        Buffer.add_string buf Ext_string.single_space;
-        Buffer.add_string buf (Filename.basename s));
-    Buffer.add_string buf ")))");
-  Buffer.add_string buf "(deps (:inputs ";
+        output_string oc Ext_string.single_space;
+        output_string oc (Filename.basename s));
+    output_string oc ")))");
+  output_string oc "(deps (:inputs ";
   Ext_list.iter inputs (fun s ->
-      Buffer.add_string buf Ext_string.single_space;
-      Buffer.add_string buf s);
-  Buffer.add_string buf ") ";
+      output_string oc Ext_string.single_space;
+      output_string oc s);
+  output_string oc ") ";
   if implicit_deps <> [] then
     Ext_list.iter implicit_deps (fun s ->
-        Buffer.add_string buf Ext_string.single_space;
-        Buffer.add_string buf s);
+        output_string oc Ext_string.single_space;
+        output_string oc s);
   Ext_list.iter rel_deps (fun s ->
-      Buffer.add_string buf Ext_string.single_space;
-      Buffer.add_string buf s);
+      output_string oc Ext_string.single_space;
+      output_string oc s);
   if bs_dependencies <> [] then
     Ext_list.iter bs_dependencies (fun dir ->
-        Buffer.add_string buf "(alias ";
-        Buffer.add_string buf dir;
-        Buffer.add_string buf ")");
-  Buffer.add_string buf ")";
-  Buffer.add_string buf "\n";
+        output_string oc "(alias ";
+        output_string oc dir;
+        output_string oc ")");
+  output_string oc ")";
+  output_string oc "\n";
   Bsb_ninja_rule.output_rule
     ~target:
       (String.concat Ext_string.single_space
          (Ext_list.map outputs Filename.basename))
-    ?error_syntax_kind rule buf cur_dir;
-  Buffer.add_char buf '\n';
-  Buffer.add_string buf enabled_if;
-  Buffer.add_string buf " )\n "
+    ?error_syntax_kind rule oc cur_dir;
+  output_char oc '\n';
+  output_string oc enabled_if;
+  output_string oc " )\n "

--- a/jscomp/bsb/bsb_ninja_targets.mli
+++ b/jscomp/bsb/bsb_ninja_targets.mli
@@ -28,7 +28,7 @@
 *)
 
 val output_alias :
-  ?action:string -> Buffer.t -> name:string -> deps:string list -> unit
+  ?action:string -> Out_channel.t -> name:string -> deps:string list -> unit
 
 val output_build :
   ?implicit_deps:string list ->
@@ -42,7 +42,7 @@ val output_build :
   inputs:string list ->
   rule:Bsb_ninja_rule.t ->
   string ->
-  Buffer.t ->
+  Out_channel.t ->
   unit
 
 val revise_dune : string -> Buffer.t -> unit

--- a/jscomp/bsb/bsb_ppxlib.ml
+++ b/jscomp/bsb/bsb_ppxlib.ml
@@ -34,6 +34,5 @@ let generate_rules (ppx_config : Bsb_config_types.ppx_config) =
   in
   Format.asprintf "%s@\n%s" ppx_ml executable
 
-let ppxlib ~(ppx_config : Bsb_config_types.ppx_config) buf =
-  if ppx_config.ppxlib <> [] then
-    Buffer.add_string buf (generate_rules ppx_config)
+let ppxlib ~(ppx_config : Bsb_config_types.ppx_config) oc =
+  if ppx_config.ppxlib <> [] then output_string oc (generate_rules ppx_config)

--- a/jscomp/bsb/bsb_ppxlib.mli
+++ b/jscomp/bsb/bsb_ppxlib.mli
@@ -22,4 +22,4 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-val ppxlib : ppx_config:Bsb_config_types.ppx_config -> Buffer.t -> unit
+val ppxlib : ppx_config:Bsb_config_types.ppx_config -> Out_channel.t -> unit

--- a/jscomp/bsb/bsb_world.ml
+++ b/jscomp/bsb/bsb_world.ml
@@ -56,7 +56,7 @@ let maybe_warn_about_dependencies_outside_workspace ~cwd
          "`in-source: true` is not currently supported when dependencies exist \
           outside the workspace.")
 
-let build_bs_deps cwd ~buf (deps : Bsb_package_specs.t) =
+let build_bs_deps cwd ~oc (deps : Bsb_package_specs.t) =
   let queue = Bsb_build_util.walk_all_deps cwd in
   Queue.fold
     (fun (acc : _ list) ({ top; proj_dir } : Bsb_build_util.package_context) ->
@@ -69,13 +69,13 @@ let build_bs_deps cwd ~buf (deps : Bsb_package_specs.t) =
           in
           maybe_warn_about_dependencies_outside_workspace ~cwd config
             ~package_specs:deps;
-          Bsb_ninja_gen.output_ninja_and_namespace_map ~buf
+          Bsb_ninja_gen.output_ninja_and_namespace_map ~oc
             ~per_proj_dir:proj_dir ~root_dir:cwd ~package_kind:(Dependency deps)
             config;
           config :: acc)
     [] queue
 
-let make_world_deps ~cwd ~buf =
+let make_world_deps ~cwd ~oc =
   Bsb_log.info "Making the dependency world!@.";
   let config : Bsb_config_types.t =
     Bsb_config_parse.interpret_json ~package_kind:Toplevel ~per_proj_dir:cwd
@@ -84,7 +84,7 @@ let make_world_deps ~cwd ~buf =
     ~package_specs:config.package_specs;
 
   let deps = config.package_specs in
-  let dep_configs = build_bs_deps cwd ~buf deps in
+  let dep_configs = build_bs_deps cwd ~oc deps in
   let file_groups = ref [] in
   Ext_list.iter (config :: dep_configs)
     (fun (dep_config : Bsb_config_types.t) ->

--- a/jscomp/bsb/bsb_world.mli
+++ b/jscomp/bsb/bsb_world.mli
@@ -26,5 +26,5 @@ val install_targets : string list -> unit
 
 val make_world_deps :
   cwd:string ->
-  buf:Buffer.t ->
+  oc:Out_channel.t ->
   (Bsb_config_types.t * Bsb_config_types.t list) * Source_metadata.t

--- a/jscomp/main/mel.ml
+++ b/jscomp/main/mel.ml
@@ -36,12 +36,8 @@ let output_dune_project_if_does_not_exist proj_dir =
     output_string ochan "(lang dune 3.5)\n(using directory-targets 0.1)";
     close_out ochan
 
-let output_dune_file buf =
-  (* <root>/dune.bsb generation *)
+let output_dune_file () =
   let proj_dir = Mel_workspace.cwd in
-  let dune_bsb = proj_dir // Literals.dune_mel in
-  Bsb_ninja_targets.revise_dune dune_bsb buf;
-
   (* <root>/dune generation *)
   let dune = proj_dir // Literals.dune in
   let buf = Buffer.create 256 in
@@ -58,19 +54,22 @@ let dune_command ?on_exit dune_args =
 
 let build_whole_project () =
   let root_dir = Mel_workspace.cwd in
-  let buf = Buffer.create 0x1000 in
+  let dune_mel = root_dir // Literals.dune_mel in
+  let oc = open_out_bin dune_mel in
   let (config, dep_configs), source_meta =
-    Bsb_world.make_world_deps ~buf ~cwd:root_dir
+    Bsb_world.make_world_deps ~oc ~cwd:root_dir
   in
   if config.generate_merlin then
     Bsb_merlin_gen.merlin_file_gen ~per_proj_dir:root_dir config;
-  Bsb_ninja_gen.output_ninja_and_namespace_map ~buf ~per_proj_dir:root_dir
+  Bsb_ninja_gen.output_ninja_and_namespace_map ~oc ~per_proj_dir:root_dir
     ~root_dir ~package_kind:(Toplevel source_meta) config;
   Ext_list.iter (Bsb_package_specs.specs config.package_specs)
     (fun package_spec ->
-      Bsb_ninja_gen.output_virtual_package ~root_dir ~package_spec ~buf
+      Bsb_ninja_gen.output_virtual_package ~root_dir ~package_spec ~oc
         (config, dep_configs));
-  output_dune_file buf;
+  close_out oc;
+
+  output_dune_file ();
   source_meta
 
 module Common_opts = struct


### PR DESCRIPTION
Avoids buffering the entire contents of `dune.mel` in memory