### PR TITLE
Opam dev flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest! Below we describe Melange's development setup for a fe
 
 ## Installation
 
-Melange can be set up with [nix](#Nix), [esy](#Esy) or [opam](#opam). Instructions for each are detailed below.
+Melange can be set up with [Nix](#Nix), [Esy](#Esy) or [opam](#opam). Instructions for each are detailed below.
 
 ### Nix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ In order to develop using [Esy](https://esy.sh/), you need to install it first. 
 
 ### opam
 
-To set up a development environment using [opam](https://opam.ocaml.org/), running `make opam-init` will set up an opam [local switch](https://opam.ocaml.org/blog/opam-local-switches/) and download the required dependencies.
+To set up a development environment using [opam](https://opam.ocaml.org/), run `make opam-init` to set up an opam [local switch](https://opam.ocaml.org/blog/opam-local-switches/) and download the required dependencies.
 
 ## Developing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest! Below we describe Melange's development setup for a fe
 
 ## Installation
 
-Melange can be set up with [#nix](Nix), [#esy](Esy) or [#opam](opam). Instructions for each are detailed below.
+Melange can be set up with [nix](#Nix), [esy](#Esy) or [opam](#opam). Instructions for each are detailed below.
 
 ### Nix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest! Below we describe Melange's development setup for a fe
 
 ## Installation
 
-Melange can be set up with [#nix](Nix) or [#esy](Esy). Instructions for both are detailed below.
+Melange can be set up with [#nix](Nix), [#esy](Esy) or [#opam](opam). Instructions for each are detailed below.
 
 ### Nix
 
@@ -38,6 +38,10 @@ In order to develop using [Esy](https://esy.sh/), you need to install it first. 
 
 1. `esy install` to get all the project's dependencies
 2. `esy build` to build the project.
+
+### opam
+
+To set up a development environment using [opam](https://opam.ocaml.org/), running `make opam-init` will set up an opam [local switch](https://opam.ocaml.org/blog/opam-local-switches/) and download the required dependencies.
 
 ## Developing
 

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,15 @@ dev:
 	dune build @install
 
 .PHONY: vim shell dev
+
+.PHONY: opam-create-switch
+opam-create-switch: ## Create opam switch
+	opam switch create . -y --deps-only --with-test
+
+.PHONY: opam-install
+opam-install: ## Install development dependencies
+	cd ocaml-tree && npm install
+	opam install -y ocaml-lsp-server
+
+.PHONY: opam-init
+opam-init: opam-create-switch opam-install ## Configure everything to develop this repository in local


### PR DESCRIPTION
- Adds some commands in `Makefile` to set up local switch
- Update contributing docs

We can remove manual install of `ocaml-lsp-server` once opam 2.2.0 is out, which will include a `--with-dev-setup` [flag](https://github.com/ocaml/opam/pull/5214).