### PR TITLE
Revert warning hacks (pulled from upstream)

### DIFF
--- a/jscomp/core/lam_compile_main.ml
+++ b/jscomp/core/lam_compile_main.ml
@@ -321,13 +321,13 @@ let lambda_as_module
     Ext_list.iter (Js_packages_state.get_output_info ()) (fun output_info ->
       let basename = make_basename output_info.suffix in
       let target_file = Filename.dirname output_prefix // basename in
-      (if not !Clflags.dont_write_files then
-        write_to_file ~package_info ~output_info ~output_prefix lambda_output target_file );
-      if !Warnings.has_warnings  then begin
-        Warnings.has_warnings := false ;
-        if Sys.file_exists target_file then begin
-          Bs_hash_stubs.set_as_old_file target_file
-        end
+      if not !Clflags.dont_write_files then begin
+        write_to_file
+          ~package_info
+          ~output_info
+          ~output_prefix
+          lambda_output
+          target_file
       end)
 
 

--- a/jscomp/stubs/bs_hash_stubs.cppo.ml
+++ b/jscomp/stubs/bs_hash_stubs.cppo.ml
@@ -34,8 +34,5 @@ external
     int_unsafe_blit :
     int array -> int -> int array -> int -> int -> unit = "caml_int_array_blit" [@@noalloc];;
 
-
 #endif
 
-
-external set_as_old_file : string -> unit = "caml_stale_file"

--- a/jscomp/stubs/ext_basic_hash_stubs.c
+++ b/jscomp/stubs/ext_basic_hash_stubs.c
@@ -2,8 +2,6 @@
 #include "caml/mlvalues.h"
 #include <string.h>
 #include <stdint.h>
-#include "caml/memory.h"
-#include "caml/signals.h"
 typedef uint32_t uint32;
 
 #define FINAL_MIX(h) \
@@ -32,14 +30,14 @@ CAMLprim value caml_bs_hash_string (value obj){
 }
 
 CAMLprim value caml_bs_hash_int  ( value d){
-  uint32 h = 0; 
+  uint32 h = 0;
   h = caml_hash_mix_intnat(h,d);
   FINAL_MIX(h);
   return Val_int(h & 0x3FFFFFFFU);
 }
 
 CAMLprim value caml_bs_hash_string_and_int  (value obj, value d){
-  uint32 h = 0; 
+  uint32 h = 0;
   h = caml_hash_mix_string(h,obj);
   h = caml_hash_mix_intnat(h,d);
   FINAL_MIX(h);
@@ -55,8 +53,8 @@ CAMLprim value caml_bs_hash_string_and_small_int(value obj, value d){
 }
 
 CAMLprim value caml_bs_hash_small_int(value d){
-  uint32 h = 0; 
-  // intnat stamp = Long_val(d); 
+  uint32 h = 0;
+  // intnat stamp = Long_val(d);
   // FIXME: unused value
   MIX(h,d);
   FINAL_MIX(h);
@@ -64,7 +62,7 @@ CAMLprim value caml_bs_hash_small_int(value d){
 }
 
 CAMLprim value caml_int_array_blit(
-  value a1, value ofs1, 
+  value a1, value ofs1,
   value a2, value ofs2,
   value n)
   {
@@ -79,20 +77,20 @@ CAMLprim value caml_int_array_blit(
  * http://zimbry.blogspot.it/2011/09/better-bit-mixing-improving-on.html
  * http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx
  * We gave up the idea to  hash Ident.t (take only one argument)
- * customized hash function for Ident.t, first 
- * argument is stamp, second argument is string 
+ * customized hash function for Ident.t, first
+ * argument is stamp, second argument is string
  * It's not just introducing c stubs, we need make a clear line
  * which part of our libraries depends on Ident.t
  */
 CAMLprim value caml_bs_hash_stamp_and_name(value d, value obj ){
   uint32 h = 0;
-  intnat stamp = Long_val(d); 
+  intnat stamp = Long_val(d);
   if (stamp){
     MIX(h,d);
   } else {
     h = caml_hash_mix_string(h,obj);
   }
-  
+
   FINAL_MIX(h);
   return Val_int(h & 0x3FFFFFFFU);
 }
@@ -110,17 +108,17 @@ CAMLprim value caml_string_length_based_compare(value s1, value s2)
   mlsize_t temp;
   int res;
   if (s1 == s2) return Val_int(0);
-  
+
   len1 = Wosize_val(s1);
   temp = Bsize_wsize(len1) - 1 ;
   len1 = temp - Byte(s1,temp);
 
   len2 = Wosize_val(s2);
-  temp = Bsize_wsize(len2) - 1 ; 
+  temp = Bsize_wsize(len2) - 1 ;
   len2 = temp - Byte(s2,temp);
 
-  if (len1 != len2) 
-  { 
+  if (len1 != len2)
+  {
     if (len1 < len2 ) {
       return Val_long_clang(-1);
     } else {
@@ -128,53 +126,17 @@ CAMLprim value caml_string_length_based_compare(value s1, value s2)
     }
   }
   else {
-    
+
     res = memcmp(String_val(s1), String_val(s2), len1);
-    if(res < 0) return Val_long_clang(-1); 
+    if(res < 0) return Val_long_clang(-1);
     if(res > 0) return Val_long_clang(1);
     return Val_long_clang(0);
-    
+
   }
 }
 
 
 
-#include <sys/time.h>
-#ifdef _WIN32
-#include <sys/utime.h>
-CAMLprim value caml_stale_file(value path)
-{
-  CAMLparam1(path);
-  struct _utimbuf tv;
-  char * p = caml_stat_strdup(String_val(path));
-  tv.modtime = 0;  
-  caml_enter_blocking_section();
-  _utime(p, &tv);
-  caml_leave_blocking_section();
-  caml_stat_free(p);
-  CAMLreturn(Val_unit);
-}
-#else
-CAMLprim value caml_stale_file(value path)
-{
-  CAMLparam1(path);
-  struct timeval tv[2];
-  char * p = caml_stat_strdup_to_os(String_val(path));
-  // unicode friendly
-  tv[0].tv_sec = 0.0;
-  tv[0].tv_usec = 0.0;
-  tv[1].tv_sec = 0.0;
-  tv[1].tv_usec = 0.0;
-  // caml_enter_blocking_section();
-  // not needed for single thread
-  utimes(p, tv);
-  // caml_leave_blocking_section();
-  // not needed for single thread
-  caml_stat_free(p);
-  // TODO: error checking
-  CAMLreturn(Val_unit);
-}
-#endif
 /* local variables: */
 /* compile-command: "ocamlopt.opt -c ext_basic_hash_stubs.c" */
 /* end: */


### PR DESCRIPTION
Revert "add runtime support"

This reverts commit 47cdb1eb1af8c501d6fe005b37b0402e77fb3a61.


Companion to https://github.com/melange-re/melange-compiler-libs/pull/4