### PR TITLE
bs.optional + bs.deriving abstract shows warning 69

### DIFF
--- a/jscomp/frontend/ast_tdcls.ml
+++ b/jscomp/frontend/ast_tdcls.ml
@@ -43,7 +43,9 @@ let disable_unused_type : Parsetree.attribute =
         [
           Str.eval
             (Exp.constant
-               (Pconst_string ("-unused-type-declaration", Location.none, None)));
+               (Pconst_string
+                  (* -unused-type-declaration -unused-field *)
+                  ("-34-69", Location.none, None)));
         ];
     attr_loc = Location.none;
   }

--- a/test/unused-record-fields.t
+++ b/test/unused-record-fields.t
@@ -1,0 +1,35 @@
+Test showing unused record fields error with bs.deriving abstract
+
+  $ cat > main.ml <<EOF
+  > type config =
+  >   { leading : bool
+  >   ; trailing : bool
+  >   }
+  > [@@bs.deriving abstract]
+  > type t
+  > external foo: config -> t = "foo"
+  > EOF
+
+  $ melc -nopervasives -w @69 main.ml -o main.cmj
+  File "main.ml", lines 2-3, characters 4-3:
+  2 | ....leading : bool
+  3 |   ;................
+  Error (warning 69 [unused-field]): unused record field leading.
+  File "main.ml", line 3, characters 4-19:
+  3 |   ; trailing : bool
+          ^^^^^^^^^^^^^^^
+  Error (warning 69 [unused-field]): unused record field trailing.
+  [2]
+
+When not using bs.deriving abstract it works fine
+
+  $ cat > main.ml <<EOF
+  > type config =
+  >   { leading : bool
+  >   ; trailing : bool
+  >   }
+  > type t
+  > external foo: config -> t = "foo"
+  > EOF
+
+  $ melc -nopervasives -w @69 main.ml -o main.cmj

--- a/test/unused-record-fields.t
+++ b/test/unused-record-fields.t
@@ -11,15 +11,6 @@ Test showing unused record fields error with bs.deriving abstract
   > EOF
 
   $ melc -nopervasives -w @69 main.ml -o main.cmj
-  File "main.ml", lines 2-3, characters 4-3:
-  2 | ....leading : bool
-  3 |   ;................
-  Error (warning 69 [unused-field]): unused record field leading.
-  File "main.ml", line 3, characters 4-19:
-  3 |   ; trailing : bool
-          ^^^^^^^^^^^^^^^
-  Error (warning 69 [unused-field]): unused record field trailing.
-  [2]
 
 When not using bs.deriving abstract it works fine
 


### PR DESCRIPTION
@anmonteiro I ran into this issue and thought on sharing it in case it can be fixed on Melange side.

As Melange in Dune is using [OCaml byte default flags](https://github.com/ocaml/dune/blob/9fb391c8ac0c2608481a62cb603de6d4bc95407b/src/dune_rules/module_compilation.ml#L167-L169), and warning 69 [was introduced in 4.13.0](https://github.com/ocaml/ocaml/pull/10232), these warnings that did not happen with ReScript are raised now on Melange.

Maybe the warning could be silenced at Melange ppx level? In `bs.optional` attrs?