### PR TITLE
[melc]: remove references to `Config.syntax_kind`

### DIFF
--- a/jscomp/core/bs_conditional_initial.ml
+++ b/jscomp/core/bs_conditional_initial.ml
@@ -33,14 +33,11 @@ let setup_env () =
   Matching.make_test_sequence_variant_constant := Polyvar_pattern_match.make_test_sequence_variant_constant;
   Matching.call_switcher_variant_constant := Polyvar_pattern_match.call_switcher_variant_constant;
   Matching.call_switcher_variant_constr := Polyvar_pattern_match.call_switcher_variant_constr;
-  Clflags.no_std_include := true;
-  (* TODO(anmonteiro): print alerts? *)
-  (* |> Option.iter Location.(prerr_alert none)  *)
+  Clflags.no_std_include := true; (* `-nostdlib` *)
   ignore @@ Warnings.parse_options false Bsc_warnings.defaults_w;
   ignore @@ Warnings.parse_options true Bsc_warnings.defaults_warn_error;
   Clflags.locations := false;
   Clflags.compile_only := true;
-  Config.syntax_kind := `rescript;
   Config.unsafe_empty_array := false;
   Config.bs_only := true;
 #ifdef BS_BROWSER

--- a/jscomp/frontend/bs_ast_invariant.ml
+++ b/jscomp/frontend/bs_ast_invariant.ml
@@ -112,19 +112,11 @@ let check_constant loc kind (const : Parsetree.constant) =
   | _ -> ()
 
 (* Note we only used Bs_ast_iterator here, we can reuse compiler-libs instead of
-   rolling our own*)
+   rolling our own *)
 let emit_external_warnings : iterator=
   {
     super with
     attribute = (fun _ attr -> warn_unused_attribute attr);
-    structure_item = (fun self str_item ->
-      match str_item.pstr_desc with
-       | Pstr_type (Nonrecursive, [{ptype_kind = Ptype_variant ({pcd_res = Some _} :: _)}])
-        when !Config.syntax_kind = `rescript ->
-          Location.raise_errorf ~loc:str_item.pstr_loc
-          "GADT has to be recursive types, please try `type rec'"
-      | _ -> super.structure_item self str_item
-    );
     expr = (fun self a ->
         match a.pexp_desc with
         | Pexp_constant(const) -> check_constant a.pexp_loc `expr const

--- a/jscomp/frontend/ppx_entry.ml
+++ b/jscomp/frontend/ppx_entry.ml
@@ -36,7 +36,6 @@ let rewrite_signature (ast : Parsetree.signature) : Parsetree.signature =
   if !Js_config.no_builtin_ppx then ast
   else
     let result = unsafe_mapper.signature unsafe_mapper ast in
-    (* Keep this check, since the check is not inexpensive*)
     Bs_ast_invariant.emit_external_warnings_on_signature result;
     result
 
@@ -51,6 +50,5 @@ let rewrite_implementation (ast : Parsetree.structure) : Parsetree.structure =
   if !Js_config.no_builtin_ppx then ast
   else
     let result = unsafe_mapper.structure unsafe_mapper ast in
-    (* Keep this check since it is not inexpensive*)
     Bs_ast_invariant.emit_external_warnings_on_structure result;
     result


### PR DESCRIPTION
- Part of the work to make the compiler agnostic to syntaxes
- counterpart to https://github.com/melange-re/melange-compiler-libs/pull/6