### PR TITLE
fix(opam-tests): install reason in OPAM tests

### DIFF
--- a/.github/workflows/opam-build.yml
+++ b/.github/workflows/opam-build.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: melange
         run: |
           opam pin add dune --dev-repo
-          opam install luv
+          opam install luv reason
           opam install ./melange.opam --deps-only --with-test
 
       - name: Pin melange to current


### PR DESCRIPTION
- We removed the reason dependency for melange 0.3 in #409 
- the opam tests rely on it