### PR TITLE
melc: actionable error message when no output is specified with `-impl`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,10 @@ Unreleased
   `-intf-suffix` flag, standard in OCaml
   ([#458](https://github.com/melange-re/melange/pull/458),
   [#460](https://github.com/melange-re/melange/pull/460))
+- [melange]: return an actionable error message when no output is specified
+  with `-impl` / `-intf`
+  ([#465](https://github.com/melange-re/melange/pull/465),
+  [#466](https://github.com/melange-re/melange/pull/466))
 
 0.3.2 2022-11-19
 ---------------

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
     "crane": {
       "flake": false,
       "locked": {
-        "lastModified": 1661875961,
-        "narHash": "sha256-f1h/2c6Teeu1ofAHWzrS8TwBPcnN+EEu+z1sRVmMQTk=",
+        "lastModified": 1670900067,
+        "narHash": "sha256-VXVa+KBfukhmWizaiGiHRVX/fuk66P8dgSFfkVN4/MY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "d9f394e4e20e97c2a60c3ad82c2b6ef99be19e24",
+        "rev": "59b31b41a589c0a65e4a1f86b0e5eac68081468b",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1669552249,
-        "narHash": "sha256-m5QSq1xY+jVEr5UMziUSDTYoR71xWuY40h8jrqJdMCc=",
+        "lastModified": 1672661134,
+        "narHash": "sha256-WqBUyKeiv+jI11ug+qP0OnZ4nngK6eBRVTGHgdzEGvc=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "7925ea3fe75cd77a57ac1d335c23b82dfc457fa5",
+        "rev": "9f6911c78dcb0832f7fcc955e847db1a5a9ce29a",
         "type": "github"
       },
       "original": {
@@ -300,11 +300,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1669739153,
-        "narHash": "sha256-88sgWtHFXUUrQzK6dgFaO45NYwBQiLoGPQ/lDY5r500=",
+        "lastModified": 1673369367,
+        "narHash": "sha256-w+NQkhcUvwVhMB0Q9psIzXzNHCufVPsrbX+rlKCDLmU=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "654a679d599756edcdf18ac0b8fc8e3f4dd15dba",
+        "rev": "6b5187a3e3b91a81b4b1f3a9165be3c8a27b900d",
         "type": "github"
       },
       "original": {
@@ -333,17 +333,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1669612762,
-        "narHash": "sha256-0q2lWQHxfq249KTbHzY51kRTNd63/BkJ/DHq0WRJnrM=",
+        "lastModified": 1673179929,
+        "narHash": "sha256-mkDqQat24NMqf4z5rK6M4Y+68qVauCSDYouqD3hl66c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2f39a2aff7a458d05f205a63d805029ae8f5be5",
+        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2f39a2aff7a458d05f205a63d805029ae8f5be5",
+        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -29,8 +29,8 @@
               {
                 dune_3 = osuper.dune_3.overrideAttrs (_: {
                   src = builtins.fetchurl {
-                    url = https://github.com/ocaml/dune/archive/405c0bc3.tar.gz;
-                    sha256 = "1camppviqyykw5m319jm8afq7f02smmp0a5hk4c1yhiw9caq7c4l";
+                    url = https://github.com/ocaml/dune/archive/b3af9e7.tar.gz;
+                    sha256 = "0fda4ll9lmz4nh3jbcfcgdzhav1cmfn8mqcjf91arlsv904l76fm";
                   };
                 });
               });

--- a/flake.nix
+++ b/flake.nix
@@ -29,8 +29,8 @@
               {
                 dune_3 = osuper.dune_3.overrideAttrs (_: {
                   src = builtins.fetchurl {
-                    url = https://github.com/ocaml/dune/archive/b3af9e7.tar.gz;
-                    sha256 = "0fda4ll9lmz4nh3jbcfcgdzhav1cmfn8mqcjf91arlsv904l76fm";
+                    url = https://github.com/ocaml/dune/archive/1e1101d.tar.gz;
+                    sha256 = "0wn6jwi0194wxazm5j1w06v6nkkm9jkchmbvfa4a37jxbm48yfb1";
                   };
                 });
               });

--- a/jscomp/core/lam_compile_main.ml
+++ b/jscomp/core/lam_compile_main.ml
@@ -318,7 +318,8 @@ let lambda_as_module
       ~output_info:Js_packages_info.default_output_info
       ~output_prefix
       lambda_output stdout
-  | false, None -> assert false
+  | false, None ->
+    raise (Arg.Bad ("no output specified (use -o <filename>.js)"))
   | (_, Some _) ->
     (* We use `-bs-module-type` to emit a single JS file after `.cmj`
        generation. In this case, we don't want the `package_info` from the

--- a/test/no-package-name-in-js-objs.t
+++ b/test/no-package-name-in-js-objs.t
@@ -15,8 +15,8 @@ If we don't have a package name, melc should allow not passing one
 Can't `-bs-module-type` and `-bs-package-output`
 
   $ melc -bs-module-type es6 -bs-package-output lib/ -bs-stop-after-cmj -nopervasives lib/a.ml -o lib/.objs/melange/a.cmj
-  Can't pass both `-bs-package-output` and `-bs-module-type`
-  [2]
+  melc: Can't pass both `-bs-package-output` and `-bs-module-type`
+  [124]
 
 Now compile for real
 

--- a/test/no-package-name-in-js.t
+++ b/test/no-package-name-in-js.t
@@ -16,8 +16,8 @@ If we don't have a package name, melc should allow not passing one
 Can't `-bs-module-type` and `-bs-package-output`
 
   $ melc -bs-module-type es6 -bs-package-output lib/ -bs-stop-after-cmj a.ml
-  Can't pass both `-bs-package-output` and `-bs-module-type`
-  [2]
+  melc: Can't pass both `-bs-package-output` and `-bs-module-type`
+  [124]
 
 Now compile for real
 


### PR DESCRIPTION
before:

```shell
$ melc --pp 'refmt --print=binary' -impl x.re
melc: internal error, uncaught exception:
      File "jscomp/core/lam_compile_main.ml", line 315, characters 19-25: Assertion failed
```

after:

```shell
$ melc -pp 'refmt --print=binary' -impl x.re
melc: no output specified (use -o <filename>.js)

```

fixes #465