### PR TITLE
melange: add `melassets` executable

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,6 +38,7 @@
    (>= "0.0.1-414"))
   (cmdliner
    (>= "1.1.0"))
+  csexp
   (meldep
    (= :version))
   (cppo :build)

--- a/jscomp/frontend/ast_external_process.mli
+++ b/jscomp/frontend/ast_external_process.mli
@@ -54,3 +54,35 @@ val pval_prim_of_labels : string Asttypes.loc list -> string list
 
 val pval_prim_of_option_labels :
   (bool * string Asttypes.loc) list -> bool -> string list
+
+type bundle_source =
+  [ `Nm_payload of string (* from payload [@@val "xx" ]*)
+  | `Nm_external of string (* from "" in external *)
+  | `Nm_val of string lazy_t (* from function name *) ]
+
+type name_source = [ bundle_source | `Nm_na ]
+
+type external_desc = {
+  val_name : name_source;
+  external_module_name : External_ffi_types.external_module_name option;
+  module_as_val : External_ffi_types.external_module_name option;
+  val_send : name_source;
+  val_send_pipe : Ast_core_type.t option;
+  splice : bool; (* mutable *)
+  scopes : string list;
+  set_index : bool; (* mutable *)
+  get_index : bool;
+  new_name : name_source;
+  call_name : name_source;
+  set_name : name_source;
+  get_name : name_source;
+  mk_obj : bool;
+  return_wrapper : External_ffi_types.return_wrapper;
+}
+
+val parse_external_attributes :
+  bool ->
+  string ->
+  bundle_source ->
+  Ast_attributes.t ->
+  Ast_attributes.t * external_desc

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -25,6 +25,15 @@
  (modules mel mel_watcher)
  (libraries mellib cmdliner luv))
 
+(executable
+ (public_name melassets)
+ (name mel_assets)
+ (package melange)
+ (modes byte_complete native)
+ (flags :standard -open Melange_compiler_libs)
+ (libraries core cmdliner csexp)
+ (modules mel_assets))
+
 (test
  (name ounit_tests_main)
  (package melange)

--- a/jscomp/main/mel_assets.ml
+++ b/jscomp/main/mel_assets.ml
@@ -1,0 +1,78 @@
+let if_o ~f o = match o with None -> [] | Some v -> [ f v ]
+
+let assets_in_structure_item (str : Parsetree.structure_item) =
+  match str.pstr_desc with
+  | Pstr_primitive prim
+    when Ast_attributes.rs_externals prim.pval_attributes prim.pval_prim -> (
+      let { Parsetree.pval_type; pval_attributes; pval_loc = loc; _ } = prim in
+      match prim.pval_prim with
+      | [] -> Location.raise_errorf ~loc "empty primitive string"
+      | a :: b :: _ ->
+          Location.raise_errorf ~loc
+            "only a single string is allowed in bs external %S : %S" a b
+      | [ v ] ->
+          let pval_name = prim.pval_name.txt and prim_name = v in
+          let prim_name_or_pval_name =
+            if String.length prim_name = 0 then `Nm_val (lazy pval_name)
+            else `Nm_external prim_name
+          in
+          let _result_type, arg_types_ty =
+            Ast_core_type.list_of_arrow pval_type
+          in
+          let no_arguments = arg_types_ty = [] in
+          let _unused_attrs, external_desc =
+            Ast_external_process.parse_external_attributes no_arguments
+              prim_name prim_name_or_pval_name pval_attributes
+          in
+          let bundle { External_ffi_types.bundle; module_bind_name = _ } =
+            bundle
+          in
+          [
+            if_o external_desc.external_module_name ~f:bundle;
+            if_o external_desc.module_as_val ~f:bundle;
+          ]
+          |> List.concat
+          (* Filename.is_relative "foo" returns true *)
+          |> List.filter (String.starts_with ~prefix:"."))
+  | _ -> []
+
+let handle_structure stru = List.concat_map assets_in_structure_item stru
+
+let process_file sourcefile =
+  let kind =
+    Ext_file_extensions.classify_input
+      (Ext_filename.get_extension_maybe sourcefile)
+  in
+  match kind with
+  | Ml | Impl_ast ->
+      let stru = Pparse_driver.parse_implementation sourcefile in
+      let (assets : _ list) = handle_structure stru in
+      Csexp.List
+        [ Atom sourcefile; List (List.map (fun x -> Csexp.Atom x) assets) ]
+  | Mli ->
+      let _sig_ = Pparse_driver.parse_interface sourcefile in
+      Csexp.List []
+  | Intf_ast | Mlmap | Cmi | Cmj | Unknown ->
+      raise (Arg.Bad ("don't know what to do with " ^ sourcefile))
+
+module Cli = struct
+  open Cmdliner
+
+  let filenames =
+    let docv = "filename" in
+    Arg.(value & pos_all string [] & info [] ~docv)
+
+  let main filenames =
+    let impl = match filenames with [ impl ] -> impl | _ -> assert false in
+    let csexp = process_file impl in
+    Format.printf "%s" (Csexp.to_string csexp)
+
+  let cmd =
+    let term = Term.(const main $ filenames) in
+    let info = Cmd.info "melassets" in
+    Cmd.v info term
+
+  let () =
+    let argv = Ext_cli_args.normalize_argv Sys.argv in
+    exit (Cmdliner.Cmd.eval ~argv cmd)
+end

--- a/jscomp/main/melc.ml
+++ b/jscomp/main/melc.ml
@@ -41,7 +41,7 @@ let set_abs_input_name sourcefile =
 
 let process_file sourcefile
   ?(kind ) ppf =
-  (* This is a better default then "", it will be changed later
+  (* This is a better default than "", it will be changed later
      The {!Location.input_name} relies on that we write the binary ast
      properly
   *)

--- a/melange.opam
+++ b/melange.opam
@@ -11,6 +11,7 @@ depends: [
   "ocaml" {>= "4.14.0" & < "4.15.0"}
   "melange-compiler-libs" {>= "0.0.1-414"}
   "cmdliner" {>= "1.1.0"}
+  "csexp"
   "meldep" {= version}
   "cppo" {build}
   "ounit" {with-test}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,11 @@
 { stdenv, ocamlPackages, lib, tree, nix-filter, nodejs, doCheck ? true }:
 
+let
+  inherit (ocamlPackages) buildDunePackage;
+in
+
 rec {
-  melange = ocamlPackages.buildDunePackage rec {
+  melange = buildDunePackage rec {
     pname = "melange";
     version = "dev";
     duneVersion = "3";
@@ -42,6 +46,7 @@ rec {
 
     nativeBuildInputs = with ocamlPackages; [ cppo ];
     propagatedBuildInputs = with ocamlPackages; [
+      csexp
       melange-compiler-libs
       cmdliner
       meldep
@@ -49,7 +54,7 @@ rec {
     meta.mainProgram = "melc";
   };
 
-  mel = ocamlPackages.buildDunePackage rec {
+  mel = buildDunePackage rec {
     pname = "mel";
     version = "dev";
     duneVersion = "3";
@@ -93,7 +98,7 @@ rec {
     meta.mainProgram = "mel";
   };
 
-  meldep = ocamlPackages.buildDunePackage rec {
+  meldep = buildDunePackage rec {
     pname = "meldep";
     version = "dev";
     duneVersion = "3";

--- a/test/melassets.t
+++ b/test/melassets.t
@@ -1,0 +1,25 @@
+Demonstrate how to use `melc` with `refmt` and Reason files
+
+  $ export MELANGELIB="$INSIDE_DUNE/lib/melange"
+  $ cat > x.ml <<EOF
+  > external mySvg: string = "default" [@@bs.module "./assets/foo.svg"]
+  > external css: < .. > Js.t as 'a = "./App.module.scss" [@@bs.module]
+  > (* non-relative path, refers to module in node_modules, shouldn't appear
+  >  * in assets *)
+  > external x : string -> string = "foo" [@@bs.module "some_node_module"]
+  > EOF
+
+  $ melassets x.ml
+  (4:x.ml(16:./assets/foo.svg17:./App.module.scss))
+
+Works with (Reason) binary AST
+
+  $ cat > x.re <<EOF
+  > [@bs.module "./assets/foo.svg"] external mySvg: string = "default";
+  > [@bs.module] external css: Js.t({..}) as 'a = "./App.module.scss";
+  > EOF
+
+  $ refmt --print=binary x.re > x.re.ml
+  $ melassets x.re.ml
+  (7:x.re.ml(16:./assets/foo.svg17:./App.module.scss))
+


### PR DESCRIPTION
> $ melassets foo.ml

returns the "assets" required by external declarations in `foo.ml`, e.g. a file with
`external mySvg: string = "default" [@@bs.module "./assets/foo.svg"]` would return the sexp `(foo.ml (./assets/foo.svg))`.