### PR TITLE
Add pins to opam-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ nix-%:
 	nix develop -L .# --command $*
 
 release-shell:
-	nix develop '.?submodules=1#release' --command $(SHELL)
+	nix develop .#release --command $(SHELL)
 
 vim:
 	$(MAKE) nix-n$@

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ nix-%:
 	nix develop -L .# --command $*
 
 release-shell:
-	nix develop .#release --command $(SHELL)
+	nix develop '.?submodules=1#release' --command $(SHELL)
+
 vim:
 	$(MAKE) nix-n$@
 
@@ -24,6 +25,12 @@ opam-create-switch: ## Create opam switch
 opam-install: ## Install development dependencies
 	cd ocaml-tree && npm install
 	opam install -y ocaml-lsp-server
+	env IGNORECONSTRAINTS="melange,mel"
+	opam pin add dune https://github.com/ocaml/dune.git#0d44bbfdb2a68907a464aeb2dabe95388dac5712 -y
+	opam pin add melange-compiler-libs --dev-repo -y
+	opam install luv reason -y
+	opam pin add melange . --with-test -y
+	opam pin add mel . --with-test -y
 
 .PHONY: opam-init
 opam-init: opam-create-switch opam-install ## Configure everything to develop this repository in local


### PR DESCRIPTION
While setting up the dev enviroment in opam, I found helpful to have the pins as part of the install.

Note: one annoyance is keeping CI in sync with the dune hash. Maybe running make commands in CI is a good idea? or having an env var?