### PR TITLE
ci: run tests in opam pipeline

### DIFF
--- a/.github/workflows/opam-build.yml
+++ b/.github/workflows/opam-build.yml
@@ -50,15 +50,13 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - name: Pin melange to current
+      - name: Install dependencies
         working-directory: melange
-        run: |
-          env IGNORECONSTRAINTS="melange,mel"
-          opam pin add dune https://github.com/ocaml/dune.git#5de6e9f0946727f3cab329f9442273c0bfcca3cf
-          opam pin add melange-compiler-libs --dev-repo
-          opam install luv reason
-          opam pin add melange . --with-test
-          opam pin add mel . --with-test
+        run: make opam-install-test
+
+      - name: test
+        working-directory: melange
+        run: make test
 
       - name: Clone melange-opam-template
         run: |

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ opam-create-switch: ## Create opam switch
 .PHONY: opam-install-test
 opam-install-test: ## Install test dependencies
 	cd ocaml-tree && npm install
-	opam install -y reason
 	opam pin -y add dune https://github.com/ocaml/dune.git#5de6e9f0946727f3cab329f9442273c0bfcca3cf
 	opam pin -y add melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#48ff923f2c25136de8ab96678f623f54cdac438c
+	opam pin add melange . --with-test -y
+	opam pin add mel . --with-test -y
 
 .PHONY: opam-install-dev
 opam-install-dev: opam-install-test ## Install development dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
+USER_SHELL = $(shell echo $$SHELL)
+
 nix-%:
 	nix develop -L .# --command $*
 
-.PHONY: release-shell 
+.PHONY: release-shell
 release-shell:
-	nix develop .#release --command $(shell echo $$SHELL)
+	nix develop .#release --command $(USER_SHELL)
 
-.PHONY: vim 
+.PHONY: vim
 vim:
 	$(MAKE) nix-n$@
 
@@ -19,9 +21,6 @@ dev:
 
 .PHONY: test
 test:
-	rm -rf node_modules/melange
-	mkdir -p node_modules/melange
-	ln -sfn $$(opam var prefix)/lib/melange/mel_runtime node_modules/melange
 	opam exec -- dune build @runtest -p melange
 
 .PHONY: opam-create-switch

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ opam-create-switch: ## Create opam switch
 .PHONY: opam-install-test
 opam-install-test: ## Install test dependencies
 	cd ocaml-tree && npm install
-	opam pin -y add dune https://github.com/ocaml/dune.git#5de6e9f0946727f3cab329f9442273c0bfcca3cf
+	opam pin -y add dune https://github.com/ocaml/dune.git#c7a0049e24e6d802a46f7ed34abf42bc525bf89d
 	opam pin -y add melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#48ff923f2c25136de8ab96678f623f54cdac438c
 	opam pin add melange . --with-test -y
 	opam pin add mel . --with-test -y

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,26 @@ dev:
 
 .PHONY: vim shell dev
 
+.PHONY: test
+test:
+	rm -rf node_modules/melange
+	mkdir -p node_modules/melange
+	ln -sfn $$(opam var prefix)/lib/melange/mel_runtime node_modules/melange
+	dune build @runtest -p melange
+
 .PHONY: opam-create-switch
 opam-create-switch: ## Create opam switch
 	opam switch create . -y --deps-only --with-test
 
-.PHONY: opam-install
-opam-install: ## Install development dependencies
+.PHONY: opam-install-test
+opam-install-test: ## Install test dependencies
 	cd ocaml-tree && npm install
+	opam install -y reason
+	opam pin -y add dune https://github.com/ocaml/dune.git#5de6e9f0946727f3cab329f9442273c0bfcca3cf
+	opam pin -y add melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#48ff923f2c25136de8ab96678f623f54cdac438c
+
+.PHONY: opam-install-dev
+opam-install-dev: opam-install-test ## Install development dependencies
 	opam install -y ocaml-lsp-server
 
 .PHONY: opam-init

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
-SHELL := $(shell echo $$SHELL)
-
 nix-%:
 	nix develop -L .# --command $*
 
+.PHONY: release-shell 
 release-shell:
-	nix develop .#release --command $(SHELL)
+	nix develop .#release --command $(shell echo $$SHELL)
+
+.PHONY: vim 
 vim:
 	$(MAKE) nix-n$@
 
+.PHONY: generate-dune-files
 generate-dune-files:
 	node scripts/ninja.js
 
+.PHONY: dev
 dev:
 	dune build @install
-
-.PHONY: vim shell dev
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test:
 	rm -rf node_modules/melange
 	mkdir -p node_modules/melange
 	ln -sfn $$(opam var prefix)/lib/melange/mel_runtime node_modules/melange
-	dune build @runtest -p melange
+	opam exec -- dune build @runtest -p melange
 
 .PHONY: opam-create-switch
 opam-create-switch: ## Create opam switch

--- a/dune-project
+++ b/dune-project
@@ -45,7 +45,8 @@
   (base64
    (>= "3.1.0"))
   (cppo :build)
-  (ounit :with-test)))
+  (ounit :with-test)
+  (reason :with-test)))
 
 (package
  (name mel)

--- a/melange.opam
+++ b/melange.opam
@@ -13,8 +13,8 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "base64" {>= "3.1.0"}
   "cppo" {build}
-  "reason" {with-test}
   "ounit" {with-test}
+  "reason" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/melange.opam
+++ b/melange.opam
@@ -13,6 +13,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "base64" {>= "3.1.0"}
   "cppo" {build}
+  "reason" {with-test}
   "ounit" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
- Consolidates installation of test/dev dependencies between Makefile and ci scripts
- Makes sure tests run in ci on the opam pipeline