### PR TITLE
add test with stack module

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -37,6 +37,8 @@ Unreleased
 - melange: build the Melange runtime / stdlib / runtime tests with the dune
   integration ([#493](https://github.com/melange-re/melange/pull/493)). Thus
   melange now requires Dune 3.8.
+- melange: allow shadowing sub-modules of Stdlib in user projects
+  ([#512](https://github.com/melange-re/melange/pull/512))
 
 0.3.2 2022-11-19
 ---------------

--- a/test/stack-module.t
+++ b/test/stack-module.t
@@ -1,0 +1,52 @@
+An example that uses a module with the same name as an stdlib one
+
+  $ cat > stack.ml <<EOF
+  > let f () =
+  >   Js.log "foo"
+  > EOF
+  $ cat > x.ml <<EOF
+  > let () = Stack.f ()
+  > EOF
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > (using melange 0.1)
+  > EOF
+
+Building when library is wrapped works
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name foo)
+  >  (modes melange)
+  >  (libraries melange)
+  >  (modules x stack))
+  > (melange.emit
+  >  (target melange)
+  >  (alias mel)
+  >  (modules )
+  >  (libraries foo))
+  > EOF
+
+  $ dune build @mel
+
+Building when library is unwrapped breaks
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name foo)
+  >  (modes melange)
+  >  (libraries melange)
+  >  (wrapped false)
+  >  (modules x stack))
+  > (melange.emit
+  >  (target melange)
+  >  (alias mel)
+  >  (modules )
+  >  (libraries foo))
+  > EOF
+  $ dune build @mel
+  File "x.ml", line 1, characters 9-16:
+  1 | let () = Stack.f ()
+               ^^^^^^^
+  Error: Unbound value Stack.f
+  [1]

--- a/test/stack-module.t
+++ b/test/stack-module.t
@@ -1,5 +1,6 @@
-An example that uses a module with the same name as an stdlib one
+Shadow Stdlib modules
 
+  $ . ./setup.sh
   $ cat > stack.ml <<EOF
   > let f () =
   >   Js.log "foo"
@@ -11,23 +12,6 @@ An example that uses a module with the same name as an stdlib one
   > (lang dune 3.7)
   > (using melange 0.1)
   > EOF
-
-Building when library is wrapped works
-
-  $ cat > dune <<EOF
-  > (library
-  >  (name foo)
-  >  (modes melange)
-  >  (libraries melange)
-  >  (modules x stack))
-  > (melange.emit
-  >  (target melange)
-  >  (alias mel)
-  >  (modules )
-  >  (libraries foo))
-  > EOF
-
-  $ dune build @mel
 
 Building when library is unwrapped breaks
 
@@ -41,12 +25,7 @@ Building when library is unwrapped breaks
   > (melange.emit
   >  (target melange)
   >  (alias mel)
-  >  (modules )
+  >  (modules)
   >  (libraries foo))
   > EOF
   $ dune build @mel
-  File "x.ml", line 1, characters 9-16:
-  1 | let () = Stack.f ()
-               ^^^^^^^
-  Error: Unbound value Stack.f
-  [1]


### PR DESCRIPTION
Something changed recently (since Feb 20) that breaks unwrapped libraries and it becomes impossible to define modules that overlap with those in stdlib.