### PR TITLE
test: don't run tests twice for the opam flow

### DIFF
--- a/.github/workflows/opam-build.yml
+++ b/.github/workflows/opam-build.yml
@@ -56,10 +56,6 @@ jobs:
           opam update
           make opam-install-test
 
-      - name: test
-        working-directory: melange
-        run: make test
-
       - name: Clone melange-opam-template
         run: |
           git clone https://github.com/melange-re/melange-opam-template.git

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dev:
 
 .PHONY: test
 test:
-	opam exec -- dune build @runtest -p melange
+	opam exec -- dune runtest -p melange
 
 .PHONY: opam-create-switch
 opam-create-switch: ## Create opam switch


### PR DESCRIPTION
`opam pin add melange --with-test` already runs the tests.