### PR TITLE
chore: vendor melange-compiler-libs

### DIFF
--- a/.github/workflows/esy-build.yml
+++ b/.github/workflows/esy-build.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ matrix.system == 'ubuntu' }}
         working-directory: melange-basic-template
         run: |
-          sed -i 's@"installConfig"@"resolutions": { "\@opam/dune": "ocaml/dune:dune.opam#a08e0f7f8a857b348267b30b10b9297ef881bb4d", "\@opam/melange-compiler-libs": "melange-re/melange-compiler-libs:melange-compiler-libs.opam#575ac4c24b296ea897821f9aaee1146ff258c704", "\@opam/reactjs-jsx-ppx": "melange-re/melange:reactjs-jsx-ppx.opam#'"$GITHUB_SHA"'","\@opam/melange": "melange-re/melange:melange.opam#'"$GITHUB_SHA"'"},"installConfig"@' esy.json
+          sed -i 's@"installConfig"@"resolutions": { "\@opam/dune": "ocaml/dune:dune.opam#a08e0f7f8a857b348267b30b10b9297ef881bb4d", "\@opam/reactjs-jsx-ppx": "melange-re/melange:reactjs-jsx-ppx.opam#'"$GITHUB_SHA"'","\@opam/melange": "melange-re/melange:melange.opam#'"$GITHUB_SHA"'"},"installConfig"@' esy.json
       - name: Build basic template
         if: ${{ matrix.system == 'ubuntu' }}
         working-directory: melange-basic-template

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -46,6 +46,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
     - uses: cachix/install-nix-action@v20
       with:
         extra_nix_config: |

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
     - uses: cachix/install-nix-action@v20
       with:
         extra_nix_config: |

--- a/.github/workflows/opam-build.yml
+++ b/.github/workflows/opam-build.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          submodules: 'recursive'
           path: melange
 
       - name: Use Node

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/melange-compiler-libs"]
+	path = vendor/melange-compiler-libs
+	url = git@github.com:melange-re/melange-compiler-libs.git

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 USER_SHELL = $(shell echo $$SHELL)
 
 nix-%:
-	nix develop -L .# --command $*
+	nix develop -L '.?submodules=1#' --command $*
 
 .PHONY: release-shell
 release-shell:
-	nix develop .#release --command $(USER_SHELL)
+	nix develop '.?submodules=1#release' --command $(USER_SHELL)
 
 .PHONY: vim
 vim:
@@ -30,7 +30,6 @@ opam-create-switch: ## Create opam switch
 .PHONY: opam-install-test
 opam-install-test: ## Install test dependencies
 	opam pin -y add dune.dev https://github.com/ocaml/dune.git#a08e0f7f8a857b348267b30b10b9297ef881bb4d
-	opam pin -y add melange-compiler-libs.dev https://github.com/melange-re/melange-compiler-libs.git#575ac4c24b296ea897821f9aaee1146ff258c704
 	opam pin add reactjs-jsx-ppx.dev . --with-test -y
 	opam pin add melange.dev . --with-test -y
 	opam pin add rescript-syntax.dev . --with-test -y

--- a/dune-project
+++ b/dune-project
@@ -2,6 +2,8 @@
 
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 
+(using menhir 2.1)
+
 (using melange 0.1)
 
 (executables_implicit_empty_intf true)
@@ -34,8 +36,6 @@
  (depends
   (ocaml
    (>= "4.13.0"))
-  (melange-compiler-libs
-   (>= "0.0.1-414"))
   (cmdliner
    (>= "1.1.0"))
   (base64

--- a/flake.lock
+++ b/flake.lock
@@ -18,29 +18,6 @@
         "type": "github"
       }
     },
-    "melange-compiler-libs": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1683850226,
-        "narHash": "sha256-EZ8JAeJQMfZQJr9CPwdWVnaa8bHdnr+FiiVbC1hG7oM=",
-        "owner": "melange-re",
-        "repo": "melange-compiler-libs",
-        "rev": "17a06ec6c8a5da27adeb76496ff7fab6c58091f5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "melange-re",
-        "repo": "melange-compiler-libs",
-        "type": "github"
-      }
-    },
     "nix-filter": {
       "locked": {
         "lastModified": 1681154353,
@@ -64,11 +41,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1684195226,
-        "narHash": "sha256-Bun9oYVKftqGY7rMB24VHHHTa9nQ5VreNK3u/EM/mSE=",
+        "lastModified": 1684360903,
+        "narHash": "sha256-F6BIRMUN38yYIbMWgQ8GJn39kgIZmcihRfWlYIenAuI=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "e00b5e0f0582a8fb72889dfe79b766d33a1d5861",
+        "rev": "08aad406e90d6684810885d4efe79487541767a1",
         "type": "github"
       },
       "original": {
@@ -79,24 +56,23 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1684164265,
-        "narHash": "sha256-ZqNSKSQM12040taiRvSgqwUCPlN1qZAw6nYniYuY1hs=",
+        "lastModified": 1684310454,
+        "narHash": "sha256-YeruPJ7iEIPIt2CKp66Nb5ZbRXu+tEYJ9/8evGxSH0k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "872c89e5a754a04058b4531e54897db5ca734100",
+        "rev": "b19ad2b00cd2b07c79095096e6155d40b7ee9a07",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "872c89e5a754a04058b4531e54897db5ca734100",
+        "rev": "b19ad2b00cd2b07c79095096e6155d40b7ee9a07",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "melange-compiler-libs": "melange-compiler-libs",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,18 +8,12 @@
       url = "github:nix-ocaml/nix-overlays";
       inputs.flake-utils.follows = "flake-utils";
     };
-    melange-compiler-libs = {
-      url = "github:melange-re/melange-compiler-libs";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix-filter, melange-compiler-libs }:
+  outputs = { self, nixpkgs, flake-utils, nix-filter }:
     {
       overlays.default = import ./nix/overlay.nix {
         nix-filter = nix-filter.lib;
-        inherit melange-compiler-libs;
       };
     } // (flake-utils.lib.eachDefaultSystem (system:
       let
@@ -31,7 +25,6 @@
               menhir = osuper.menhir_20230415;
             });
           })
-          melange-compiler-libs.overlays.default
         ];
       in
 

--- a/jscomp/ast_derive/dune
+++ b/jscomp/ast_derive/dune
@@ -3,4 +3,4 @@
  (package melange)
  (wrapped false)
  (flags :standard -w -9 -open Melange_compiler_libs)
- (libraries common astlib ast_extensions melange-compiler-libs melange.ext))
+ (libraries common ext astlib ast_extensions melange_compiler_libs))

--- a/jscomp/ast_extensions/dune
+++ b/jscomp/ast_extensions/dune
@@ -2,4 +2,4 @@
  (name ast_extensions)
  (package melange)
  (flags :standard -open Melange_compiler_libs)
- (libraries common astlib melange-compiler-libs melange.ext))
+ (libraries common astlib melange_compiler_libs ext))

--- a/jscomp/astlib/dune
+++ b/jscomp/astlib/dune
@@ -3,4 +3,4 @@
  (package melange)
  (wrapped false)
  (flags :standard -w -9 -open Melange_compiler_libs)
- (libraries common melange-compiler-libs melange.ext))
+ (libraries common melange_compiler_libs ext))

--- a/jscomp/common/dune
+++ b/jscomp/common/dune
@@ -1,13 +1,13 @@
 (library
  (name common)
- (public_name melange.common)
+ (package melange)
  (wrapped false)
  (flags :standard -w -9 -open Melange_compiler_libs)
  (preprocess
   (action
    (run cppo %{env:CPPO_FLAGS=} %{input-file})))
  (modules_without_implementation js_raw_info lam_tag_info)
- (libraries ext melange-compiler-libs js_parser dune-build-info))
+ (libraries ext melange_compiler_libs js_parser dune-build-info))
 
 (rule
  (target js_config.ml)

--- a/jscomp/core/dune
+++ b/jscomp/core/dune
@@ -11,9 +11,9 @@
   ext
   common
   ast_derive
-  melange-compiler-libs
+  melange_compiler_libs
   melange.ppxlib-ast
-  melange.ppx-lib
+  melange.ppxlib
   ppxlib.ast))
 
 (rule

--- a/jscomp/ext/dune
+++ b/jscomp/ext/dune
@@ -2,12 +2,12 @@
 
 (library
  (name ext)
- (public_name melange.ext)
+ (package melange)
  (wrapped false)
  (flags
   (:standard -w -9 -open Melange_compiler_libs))
  (modules_without_implementation ext_js_file_kind)
- (libraries unix melange-compiler-libs)
+ (libraries unix melange_compiler_libs)
  (foreign_stubs
   (language c)
   (names ext_basic_hash_stubs)))

--- a/jscomp/frontend/dune
+++ b/jscomp/frontend/dune
@@ -1,6 +1,6 @@
 (library
  (name melange_ppx_lib)
- (public_name melange.ppx-lib)
+ (public_name melange.ppxlib)
  (flags
   (:standard -w -9 -open Melange_compiler_libs))
  (preprocess
@@ -11,7 +11,7 @@
   ext
   ast_derive
   common
-  melange-compiler-libs
+  melange_compiler_libs
   ast_extensions
   melange.ppxlib-ast))
 
@@ -19,7 +19,7 @@
  (name melange_ppxlib_ast)
  (public_name melange.ppxlib-ast)
  (modules melange_ppxlib_ast)
- (libraries ppxlib melange-compiler-libs))
+ (libraries ppxlib melange_compiler_libs))
 
 (library
  (name melange_ppx)
@@ -31,4 +31,4 @@
   (action
    (run cppo %{env:CPPO_FLAGS=} %{input-file})))
  (modules melange_ppx)
- (libraries melange.ppxlib-ast melange.ppx-lib ppxlib ast_extensions))
+ (libraries melange.ppxlib-ast melange.ppxlib ppxlib ast_extensions))

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -7,8 +7,8 @@
   js_parser
   ext
   common
-  melange.ppx-lib
-  melange-compiler-libs
+  melange.ppxlib
+  melange_compiler_libs
   core
   cmdliner)
  (modules melc melc_cli)
@@ -22,7 +22,7 @@
  (modes native)
  (modules melpp)
  (flags :standard -open Melange_compiler_libs)
- (libraries common core cmdliner melange.ppxlib-ast melange-compiler-libs))
+ (libraries common core cmdliner melange.ppxlib-ast melange_compiler_libs))
 
 (executable
  (public_name melppx)

--- a/jscomp/ounit_tests/dune
+++ b/jscomp/ounit_tests/dune
@@ -2,7 +2,7 @@
  (name ounit_tests)
  (flags
   (:standard -w -9 -open Melange_compiler_libs))
- (libraries ounit2 ext core str melange-compiler-libs))
+ (libraries ounit2 ext core str melange_compiler_libs))
 
 (rule
  (targets ounit_hash_set_tests.ml)

--- a/melange.opam
+++ b/melange.opam
@@ -9,7 +9,6 @@ bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "4.13.0"}
-  "melange-compiler-libs" {>= "0.0.1-414"}
   "cmdliner" {>= "1.1.0"}
   "base64" {>= "3.1.0"}
   "dune-build-info"

--- a/nix/ci/test.nix
+++ b/nix/ci/test.nix
@@ -28,15 +28,6 @@ let
             };
           });
 
-          melange-compiler-libs = osuper.melange-compiler-libs.overrideAttrs (_: {
-            src = super.fetchFromGitHub {
-              owner = "melange-re";
-              repo = "melange-compiler-libs";
-              rev = "17a06ec6c8a5da27adeb76496ff7fab6c58091f5";
-              hash = "sha256-EZ8JAeJQMfZQJr9CPwdWVnaa8bHdnr+FiiVbC1hG7oM=";
-            };
-          });
-
           menhirLib = osuper.menhirLib_20230415;
           menhirSdk = osuper.menhirSdk_20230415;
           menhir = osuper.menhir_20230415;
@@ -77,6 +68,7 @@ stdenv.mkDerivation {
     ocaml
     findlib
     dune
+    git
     nodePackages.mocha
     ocamlPackages.reason
     tree

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , ocamlPackages
 , lib
+, git
 , tree
 , makeWrapper
 , nix-filter
@@ -27,6 +28,7 @@ rec {
         "lib"
         "test"
         "scripts"
+        "vendor"
       ];
       exclude = [ "jscomp/test" ];
     };
@@ -44,14 +46,14 @@ rec {
     ];
     checkInputs = [ ounit2 reactjs-jsx-ppx ];
 
-    nativeBuildInputs = [ cppo ];
+    nativeBuildInputs = [ menhir cppo git ];
     buildInputs = [ makeWrapper ];
     propagatedBuildInputs = [
       dune-build-info
       base64
-      melange-compiler-libs
       cmdliner
       ppxlib
+      menhirLib
     ];
     meta.mainProgram = "melc";
   };
@@ -67,6 +69,8 @@ rec {
         "dune-project"
         "rescript-syntax.opam"
         "rescript-syntax"
+        "vendor"
+        "jscomp"
       ];
     };
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,4 +1,4 @@
-{ nix-filter, melange-compiler-libs }:
+{ nix-filter }:
 
 final: prev:
 
@@ -14,7 +14,5 @@ final: prev:
         };
       });
     })).overrideScope' (oself: osuper:
-    {
-      melange-compiler-libs = (melange-compiler-libs.overlays.default final prev).ocamlPackages.melange-compiler-libs;
-    } // (prev.callPackage ./. { inherit nix-filter; }));
+    prev.callPackage ./. { inherit nix-filter; });
 }

--- a/rescript-syntax/dune
+++ b/rescript-syntax/dune
@@ -4,7 +4,7 @@
  (name napkin)
  (flags :standard -w -9)
  (modules :standard \ res_cli)
- (libraries ppxlib melange.ppx-lib melange.ppxlib-ast compiler-libs.common))
+ (libraries ppxlib melange.ppxlib melange.ppxlib-ast compiler-libs.common))
 
 (executable
  (name res_cli)

--- a/vendor/dune
+++ b/vendor/dune
@@ -1,0 +1,63 @@
+(data_only_dirs melange-compiler-libs)
+
+(subdir
+ melange-compiler-libs
+ (subdir
+  wrapper
+  (library
+   (name melange_wrapper)
+   (package melange)
+   (libraries compiler-libs.common)
+   (modules_without_implementation melange_wrapper)))
+ (subdir
+  lib
+  (copy_files# ../file_formats/*)
+  (copy_files# ../lambda/*)
+  ;; the `#` directive breaks menhir
+  (copy_files ../parsing/*)
+  (copy_files# ../typing/*)
+  (library
+   (name melange_compiler_libs)
+   (package melange)
+   (flags -w -9 -open Parsing0)
+   (libraries
+    menhirLib
+    melange_wrapper
+    (re_export parsing0))
+   (modules_without_implementation annot outcometree))
+  (ocamllex
+   (modules lexer)
+   (mode fallback))
+  (menhir
+   (modules parser)
+   ; flag reference:
+   ; https://github.com/ocaml/ocaml/blob/f0a1be6f0/Makefile.menhir#L76-L82
+   (flags
+    --lalr
+    --explain
+    --dump
+    --require-aliases
+    --strict
+    --table
+    -lg
+    1
+    -la
+    1
+    --unused-token
+    COMMENT
+    --unused-token
+    DOCSTRING
+    --unused-token
+    EOL
+    --unused-token
+    GREATERRBRACKET
+    --fixed-exception)))
+ (subdir
+  parsing0
+  (copy_files# ../utils/*)
+  (library
+   (name parsing0)
+   (flags -w -9)
+   (package melange)
+   (libraries melange_wrapper)
+   (modules_without_implementation parsetree))))


### PR DESCRIPTION
- Vendors https://github.com/melange-re/melange-compiler-libs
- converts some libraries back to private libraries


The main advantage of this change is that we can stop releasing the internal `melange-compiler-libs` package to opam.

We'll still maintain the repository and the git history over there to preserve authorship and keep it easy to merge with upstream OCaml. Otherwise all the melange internal libraries are considered internal, and keeping them as dune private libraries enforces that.