### PR TITLE
docs: remove example tags

### DIFF
--- a/jscomp/ext/ext_string.cppo.mli
+++ b/jscomp/ext/ext_string.cppo.mli
@@ -39,7 +39,6 @@ val ends_with_char : string -> char -> bool
 
 (**
   [ends_with_then_chop name ext]
-  @example:
    {[
      ends_with_then_chop "a.cmj" ".cmj"
      "a"

--- a/jscomp/others/belt_Array.mli
+++ b/jscomp/others/belt_Array.mli
@@ -32,7 +32,7 @@ val get: 'a t -> int -> 'a option
   If [i <= 0 <= length arr];returns [Some value] where [value] is the item at index [i]
   If [i] is out of range;returns [None]
 
-  @example {[
+  {[
     Belt.Array.get [|"a";"b";"c"|] 0 = Some "a";;
     Belt.Array.get [|"a";"b";"c"|] 3 = None;;
     Belt.Array.get [|"a";"b";"c"|] (-1) = None;;
@@ -85,7 +85,7 @@ val shuffle: 'a t -> 'a t
 val reverseInPlace: 'a t -> unit
 (** [reverseInPlace arr] reverses items in [arr] in place
 
-  @example {[
+  {[
     let arr = [|10;11;12;13;14|];;
     let () = reverseInPlace arr;;
     arr = [|14;13;12;11;10|];;
@@ -96,7 +96,7 @@ val reverse: 'a t -> 'a t
 (** [reverse arr]
     @return a fresh array with items in [arr] in reverse order
 
-    @example {[
+    {[
       reverse [|10;11;12;13;14|] = [|14;13;12;11;10|];;
     ]}
 *)
@@ -106,7 +106,7 @@ external makeUninitialized: int -> 'a Js.undefined array = "Array" [@@bs.new]
   [makeUninitialized n] creates an array of length [n] filled with the undefined value.
   You must specify the type of data that will eventually fill the array.
 
-  @example {[
+  {[
     let arr: string Js.undefined array = makeUninitialized 5;;
     getExn arr 0 = Js.undefined;;
   ]}
@@ -118,7 +118,7 @@ external makeUninitializedUnsafe: int -> 'a t = "Array" [@@bs.new]
 
     {b Unsafe}
 
-    @example {[
+    {[
     let arr = Belt.Array.makeUninitializedUnsafe 5;;
     let () = Js.log(Belt.Array.getExn arr 0);; (* undefined *)
     Belt.Array.setExn arr 0 "example";;
@@ -135,7 +135,7 @@ val make: int -> 'a  -> 'a t
 
 val range: int -> int -> int t
 (** [range start finish] create an inclusive array
-    @example {[
+    {[
       range 0 3 =  [|0;1;2;3|];;
       range 3 0 =  [||] ;;
       range 3 3 = [|3|];;
@@ -148,7 +148,7 @@ val rangeBy: int -> int -> step:int -> int t
     @return empty array when step is 0 or negative
     it also return empty array when [start > finish]
 
-    @example {[
+    {[
      rangeBy 0 10 ~step:3 = [|0;3;6;9|];;
      rangeBy 0 12 ~step:3 = [|0;3;6;9;12|];;
      rangeBy 33 0 ~step:1 =  [||];;
@@ -167,7 +167,7 @@ val makeBy: int -> (int -> 'a ) -> 'a t
     return an empty array when [n] is negative
     return an array of size [n] populated by [f i] start from [0] to [n - 1]
 
-    @example {[
+    {[
       makeBy 5 (fun i -> i) = [|0;1;2;3;4|];;
       makeBy 5 (fun i -> i * i) = [|0;1;4;9;16|]
     ]}
@@ -187,7 +187,7 @@ val zip: 'a t -> 'b array -> ('a * 'b) array
     Create an array of pairs from corresponding elements of [a] and [b].
     Stop with the shorter array
 
-    @example {[
+    {[
       zip [|1;2|] [|3;4;5|] = [|(1, 3);(2, 4)|]
     ]}
  *)
@@ -203,7 +203,7 @@ val zipBy: 'a t -> 'b array -> ('a -> 'b -> 'c ) -> 'c array
 
     Equivalent to [map (zip xs ys) (fun (a,b) -> f a b) ]
 
-    @example {[
+    {[
       zipBy [|1;2;3|] [|4;5|] (fun a b -> 2 * a + b) = [|6;9|];;
     ]}
  *)
@@ -211,7 +211,7 @@ val zipBy: 'a t -> 'b array -> ('a -> 'b -> 'c ) -> 'c array
 val unzip: ('a * 'b) array -> 'a t * 'b array
 (** [unzip a] takes an array of pairs and creates a pair of arrays. The first array contains all the first items of the pairs; the second array contains all the second items.
 
-    @example {[
+    {[
       unzip [|(1,2) ; (3,4)|] = ([|1;3|], [|2;4|]);;
       unzip [|(1,2) ; (3,4) ; (5,6) ; (7,8)|] = ([|1;3;5;7|], [|2;4;6;8|]);;
     ]}
@@ -224,7 +224,7 @@ val concat: 'a t -> 'a t -> 'a t
     concatenation of the arrays [v1] and [v2];so even if [v1] or [v2]
     is empty;it can not be shared
 
-    @example {[
+    {[
       concat [|1;2;3|] [|4;5|] = [|1;2;3;4;5|];;
       concat [| |] [|"a";"b";"c"|] = [|"a";"b";"c"|];;
     ]}
@@ -236,7 +236,7 @@ val concatMany: 'a t t -> 'a t
 
     @return a fresh array as the concatenation of [xss] (an array of arrays)
 
-    @example {[
+    {[
       concatMany [| [|1;2;3|]; [|4;5;6|]; [|7;8|] |] = [|1;2;3;4;5;6;7;8|];;
     ]}
 *)
@@ -254,7 +254,7 @@ val slice: 'a t -> offset:int -> len:int -> 'a t
 
     if [len] is negative;returns the empty array.
 
-    @example {[
+    {[
       slice [|10;11;12;13;14;15;16|] ~offset: 2 ~len: 3 = [|12;13;14|];;
       slice [|10;11;12;13;14;15;16|] ~offset: (-4) ~len: 3 = [|13;14;15|];;
       slice [|10;11;12;13;14;15;16|] ~offset:4  ~len:9 = [|14;15;16|];;
@@ -269,7 +269,7 @@ val sliceToEnd: 'a t -> int -> 'a t
 
     [sliceToEnd xs 0] will return a copy of the array
 
-    @example {[
+    {[
       sliceToEnd [|10;11;12;13;14;15;16|] 2 = [|12;13;14;15;16|];;
       sliceToEnd [|10;11;12;13;14;15;16|] (-4) = [|13;14;15;16|];;
     ]}
@@ -294,7 +294,7 @@ val fill: 'a t -> offset:int -> len:int -> 'a -> unit
     [fill arr ~offset:(-1) ~len:1] means fill the last element,
     if the array does not have enough data;[fill] will ignore it
 
-    @example {[
+    {[
 
       let arr = makeBy 5 (fun i -> i) ;;
       fill arr ~offset:2 ~len:2 9 ;;
@@ -322,7 +322,7 @@ val blit:
     For each of the examples;presume that [v1 = \[|10;11;12;13;14;15;16;17|\]] and
     [v2 = \[|20;21;22;23;24;25;26;27|\]]. The result shown is the content of the destination array.
 
-    @example {[
+    {[
       Belt.Array.blit ~src: v1 ~srcOffset: 4 ~dst: v2 ~dstOffset: 2 ~len: 3 |.
         [|20;21;14;15;16;25;26;27|]
       Belt.Array.blit ~src: v1 ~srcOffset: 4 ~dst: v1 ~dstOffset: 2 ~len: 3 |.
@@ -345,7 +345,7 @@ val forEach: 'a t ->  ('a -> unit ) -> unit
     new array is created. Use [forEach] when you are primarily concerned with repetitively
     creating side effects.
 
-    @example {[
+    {[
       forEach [|"a";"b";"c"|] (fun x -> Js.log("Item: " ^ x));;
       (*  prints:
         Item: a
@@ -367,7 +367,7 @@ val map: 'a t ->  ('a -> 'b ) -> 'b array
     @return a new array by calling [f] for each element of [xs] from
     the beginning to end
 
-    @example {[
+    {[
      map [|1;2|] (fun x-> x + 10) = [|11;12|]
    ]}
 *)
@@ -387,7 +387,7 @@ val getByU: 'a t -> ('a -> bool [@bs]) -> 'a option
 val getBy: 'a t -> ('a -> bool) -> 'a option
 (** [getBy xs p] returns [Some value] for the first value in [xs] that satisifies the predicate function [p]; returns [None] if no element satisifies the function.
 
-  @example {[
+  {[
       getBy [|1;4;3;2|] (fun x -> x mod 2 = 0) = Some 4
       getBy [|15;13;11|] (fun x -> x mod 2 = 0) = None
     ]}
@@ -397,7 +397,7 @@ val getIndexByU: 'a t -> ('a -> bool [@bs]) -> int option
 val getIndexBy: 'a t -> ('a -> bool) -> int option
 (** [getIndexBy xs p] returns [Some index] for the first value in [xs] that satisifies the predicate function [p]; returns [None] if no element satisifies the function.
 
-  @example {[
+  {[
       getIndexBy [|1;4;3;2|] (fun x -> x mod 2 = 0) = Some 1
       getIndexBy [|15;13;11|] (fun x -> x mod 2 = 0) = None
     ]}
@@ -408,7 +408,7 @@ val keep: 'a t -> ('a -> bool ) -> 'a t
 (** [keep xs p ]
     @return a new array that keeps all elements satisfying [p]
 
-    @example {[
+    {[
       keep [|1;2;3|] (fun x -> x mod  2 = 0) = [|2|]
     ]}
 *)
@@ -420,7 +420,7 @@ val keepWithIndex: 'a t -> ('a -> int -> bool ) -> 'a t
     The predicate [p] takes two arguments:
     the element from [xs] and the index starting from 0.
 
-    @example {[
+    {[
       keepWithIndex [|1;2;3|] (fun _x i -> i = 1) = [|2|]
     ]}
 *)
@@ -430,7 +430,7 @@ val keepMap: 'a t -> ('a -> 'b option) -> 'b array
 (** [keepMap xs p]
     @return a new array that keeps all elements that return a non-None when applied to [p]
 
-    @example {[
+    {[
       keepMap [|1;2;3|] (fun x -> if x mod 2 = 0 then Some x else None)
       = [| 2 |]
     ]}
@@ -443,7 +443,7 @@ val forEachWithIndex: 'a t ->  (int -> 'a -> unit ) -> unit
     The same as {!forEach}; except that [f] is supplied with two arguments:
     the index starting from 0 and the element from [xs]
 
-    @example {[
+    {[
 
       forEachWithIndex [|"a";"b";"c"|] (fun i x -> Js.log("Item " ^ (string_of_int i) ^ " is " ^ x));;
       (*  prints:
@@ -464,7 +464,7 @@ val mapWithIndex: 'a t ->  (int -> 'a -> 'b ) -> 'b t
 (** [mapWithIndex xs f] applies [f] to each element of [xs]. Function [f] takes two arguments:
   the index starting from 0 and the element from [xs].
 
-    @example {[
+    {[
       mapWithIndex [|1;2;3|] (fun i x -> i + x) =
       [|0 + 1; 1 + 2; 2 + 3|]
     ]}
@@ -475,7 +475,7 @@ val partitionU : 'a t -> ('a -> bool [@bs]) -> 'a t * 'a t
 val partition : 'a t ->  ('a -> bool) -> 'a t * 'a t
 (** [partition f a] split array into tuple of two arrays based on predicate f; first of tuple where predicate cause true, second where predicate cause false
 
-    @example {[
+    {[
       partition [|1;2;3;4;5|] (fun x -> x mod 2 = 0  ) = ([|2;4|], [|1;2;3|]);;
       partition [|1;2;3;4;5|] (fun x -> x mod 2 <> 0 ) = ([|1;2;3|], [|2;4|]);;
     ]}
@@ -489,7 +489,7 @@ val reduce:  'b array -> 'a -> ('a -> 'b -> 'a ) ->'a
     from the list and an “accumulator”;which starts with a value of [init]. [reduce]
     returns the final value of the accumulator.
 
-    @example {[
+    {[
       reduce [|2;3;4|] 1 (+) = 10;;
       reduce [|"a";"b";"c";"d"|] "" (^) = "abcd";;
     ]}
@@ -503,7 +503,7 @@ val reduceReverse: 'b array -> 'a -> ('a -> 'b ->  'a ) ->  'a
     Works like {!reduce};except that function [f] is applied to each item of [xs] from the last
     back to the first.
 
-    @example {[
+    {[
       reduceReverse [|"a";"b";"c";"d"|] "" (^) = "dcba";;
     ]}
 *)
@@ -517,7 +517,7 @@ val reduceReverse2:
    Reduces two arrays [xs] and [ys];taking items starting at [min (length xs) (length ys)]
    down to and including zero.
 
-   @example {[
+   {[
      reduceReverse2 [|1;2;3|] [|1;2|] 0 (fun acc x y -> acc + x + y) = 6
    ]}
 *)
@@ -530,7 +530,7 @@ val reduceWithIndex:  'a t -> 'b -> ('b -> 'a -> int -> 'b) -> 'b
     from the array and an “accumulator”, which starts with a value of [init] and the index of each element. [reduceWithIndex]
     returns the final value of the accumulator.
 
-    @example {[
+    {[
       reduceWithIndex [|1;2;3;4|] 0 (fun acc x i -> acc + x + i) = 16;
     ]}
 *)
@@ -544,7 +544,7 @@ val joinWith: 'a t -> string -> ('a -> string) -> string
     If the array has only one element, then that element will be returned
     without using the separator.
     If the array is empty, the empty string will be returned.
-    @example{[
+    {[
       joinWith [|0; 1|] ", " string_of_int = "0, 1"
       joinWith [||] " " string_of_int = ""
       joinWith [|1|] " " string_of_int = "1"
@@ -558,7 +558,7 @@ val some: 'a t -> ('a -> bool) -> bool
     @return true if at least one of the elements in [xs] satifies [p];where [p] is a {i predicate}: a function taking
     an element and returning a [bool].
 
-    @example {[
+    {[
       some [|2; 3; 4|] (fun x -> x mod 2 = 1) = true;;
       some [|-1; -3; -5|] (fun x -> x > 0) = false;;
     ]}
@@ -571,7 +571,7 @@ val every: 'a t -> ('a -> bool ) -> bool
     @return true if all elements satisfy [p];where [p] is a {i predicate}: a function taking
     an element and returning a [bool].
 
-    @example {[
+    {[
       every [|1; 3; 5|] (fun x -> x mod 2 = 1) = true;;
       every [|1; -3; 5|] (fun x -> x > 0) = false;;
     ]}
@@ -581,7 +581,7 @@ val every2U: 'a t -> 'b t -> ('a -> 'b -> bool [@bs]) -> bool
 val every2: 'a t -> 'b t -> ('a -> 'b -> bool ) -> bool
 (** [every2 xs ys p] returns true if [p xi yi] is true for all pairs of elements
   up to the shorter length (i.e. [min (length xs) (length ys)])
-    @example {[
+    {[
       every2 [|1;2;3|] [|0;1|] (>) = true;;
       every2 [||] [|1|] (fun  x y -> x > y) = true;;
       every2 [|2;3|] [|1|] (fun  x y -> x > y) = true;;
@@ -594,7 +594,7 @@ val some2: 'a t -> 'b t -> ('a -> 'b -> bool ) -> bool
 (** [some2 xs ys p] returns true if [p xi yi] is true for any pair of elements
   up to the shorter length (i.e. [min (length xs) (length ys)])
 
-    @example {[
+    {[
       some2 [|0;2|] [|1;0;3|] (>) = true ;;
       (some2 [||] [|1|] (fun   x y -> x > y)) =  false;;
       (some2 [|2;3|] [|1;4|] (fun   x y -> x > y)) = true;;
@@ -612,7 +612,7 @@ val cmp: 'a t -> 'a t -> ('a -> 'a -> int ) -> int
       - a positive number if [x] is “greater than” [y]
     - The comparison returns the first non-zero result of [f];or zero if [f] returns zero for all [x] and [y].
 
-    @example {[
+    {[
       cmp [|1; 3; 5|] [|1; 4; 2|] (fun a b -> compare a b) = -1;;
       cmp [|1; 3; 5|] [|1; 2; 3|] (fun a b -> compare a b) = 1;;
       cmp [|1; 3; 5|] [|1; 3; 5|] (fun a b -> compare a b) = 0;;
@@ -626,7 +626,7 @@ val eq:  'a t -> 'a t -> ('a -> 'a -> bool ) -> bool
     - return false if length is not the same
     - otherwise compare items one by one using [f xi yi];and return true if all results are true;false otherwise
 
-    @example {[
+    {[
       eq [|1; 2; 3|] [|-1; -2; -3|] (fun a b -> abs a = abs b) = true
     ]}
 *)
@@ -639,7 +639,7 @@ external truncateToLengthUnsafe: 'a t -> int ->  unit = "length" [@@bs.set]
 
   If [n] is less than zero;raises a [RangeError].
 
-  @example {[
+  {[
     let arr = [|"ant";"bee";"cat";"dog";"elk"|];;
     let () = truncateToLengthUnsafe arr 3;;
     arr = [|"ant";"bee";"cat"|];;

--- a/jscomp/others/belt_List.mli
+++ b/jscomp/others/belt_List.mli
@@ -49,7 +49,7 @@ val head: 'a t -> 'a option
 (**
   [head xs] returns [None] if [xs] is the empty list, otherwise it returns [Some value] where [value] is the first
   element in the list.
-   @example {[
+   {[
      head [] = None ;;
      head [1;2;3] = Some 1 ;;
    ]}
@@ -68,11 +68,10 @@ val tail: 'a t -> 'a t option
 (**  [tail xs] returns [None] if [xs] is empty;
   otherwise it returns [Some xs2] where [xs2] is everything except the first element of [xs];
 
-  @example{[
-
-      tail [] = None;;
-      tail [1;2;3;4] = Some [2;3;4];;
-    ]}
+  {[
+    tail [] = None;;
+    tail [1;2;3;4] = Some [2;3;4];;
+  ]}
 *)
     
 val tailExn: 'a t -> 'a t 
@@ -87,7 +86,7 @@ val add: 'a t -> 'a -> 'a t
 (**
   [add xs y] adds [y] to the beginning of list [xs]
   
-   @example{[
+   {[
      add [1] 3 = [3;1];;
    ]}
 *)
@@ -98,7 +97,7 @@ val get: 'a t -> int -> 'a option
     return the nth element in [xs],
     or [None] if [n] is larger than the length
 
-    @example {[
+    {[
       get [0;3;32] 2 = Some 32 ;;
       get [0;3;32] 3 = None;;
     ]}
@@ -118,7 +117,7 @@ val make: int -> 'a -> 'a t
     - return a list of length [n] with each element filled with value [v]  
     - return the empty list if [n] is negative
 
-     @example {[
+     {[
        make 3 1 =  [1;1;1]
      ]}
 *)
@@ -130,7 +129,7 @@ val makeBy: int -> (int -> 'a) -> 'a t
     - return a list of length [n] with element [i] initialized with [f i]
     - return the empty list if [n] is negative
 
-    @example {[
+    {[
       makeBy 5 (fun i -> i) = [0;1;2;3;4];;
       makeBy 5 (fun i -> i * i) = [0;1;4;9;16];;
     ]}
@@ -148,7 +147,7 @@ val drop: 'a t -> int -> 'a t option
     return the list obtained by dropping the first [n] elements,
     or [None] if [xs] has fewer than [n] elements
 
-    @example {[
+    {[
       drop [1;2;3] 2 = Some [3];;
       drop [1;2;3] 3 = Some [];;
       drop [1;2;3] 4 = None;;
@@ -161,7 +160,7 @@ val take: 'a t -> int -> 'a t option
     return a list with the first [n] elements from [xs],
     or [None] if [xs] has fewer than [n] elements
 
-    @example {[
+    {[
       take [1;2;3] 1 = Some [1];;
       take [1;2;3] 2 = Some [1;2];;
       take [1;2;3] 4 = None;;
@@ -174,7 +173,7 @@ val splitAt: 'a t -> int -> ('a list * 'a list) option
     split the list [xs] at position [n]
     return None when the length of [xs] is less than [n]
 
-   @example{[
+   {[
      splitAt [0;1;2;3;4] 2 = Some ([0;1], [2;3;4])
    ]} 
 *)
@@ -185,7 +184,7 @@ val concat: 'a t -> 'a t -> 'a t
 
     @return the list obtained by adding [ys] after [xs]
 
-   @example {[
+   {[
      concat [1;2;3] [4;5] = [1;2;3;4;5]
    ]}
 *)
@@ -195,7 +194,7 @@ val concatMany: 'a t array -> 'a t
     [concatMany a]
     return the list obtained by concatenating in order all the lists in array [a]
 
-   @example {[
+   {[
      concatMany [| [1;2;3] ; []; [3]; [4] |] = [1;2;3;3;4]
    ]}
 *)
@@ -203,7 +202,7 @@ val concatMany: 'a t array -> 'a t
 val reverseConcat: 'a t -> 'a t -> 'a t
 (**
    [reverseConcat xs ys] is  equivalent to [concat (reverse xs) ys]
-   @example {[
+   {[
      reverseConcat [1;2] [3;4] = [2;1;3;4]
    ]}
 *)
@@ -213,7 +212,7 @@ val flatten: 'a t t -> 'a t
     [flatten ls]
     return the list obtained by concatenating in order all the lists in list [ls]
 
-   @example {[
+   {[
      flatten [ [1;2;3] ; []; [3]; [4] ] = [1;2;3;3;4]
    ]}
 *)
@@ -225,7 +224,7 @@ val map: 'a t -> ('a -> 'b) -> 'b t
 
     return the list obtained by applying [f] to each element of [xs]
 
-   @example {[
+   {[
      map [1;2] (fun x-> x + 1) = [3;4]
    ]}
 *)
@@ -236,7 +235,7 @@ val zip: 'a t -> 'b t -> ('a * 'b) t
     @return a list of pairs from the two lists
     with the length of the shorter list
 
-    @example {[
+    {[
       zip [1;2] [3;4;5] = [(1,3); (2,4)]
     ]}
 *)
@@ -249,7 +248,7 @@ val zipBy: 'a t -> 'b t -> ('a -> 'b -> 'c) -> 'c t
     
     Equivalent to [zip xs ys |> List.map (fun (x,y) -> f x y)]
     
-    @example {[
+    {[
       zipBy [1;2;3] [4;5] (fun a b -> 2 * a + b) = [6;9];;
     ]}
 
@@ -260,7 +259,7 @@ val mapWithIndex: 'a t -> (int -> 'a -> 'b) -> 'b t
 (** [mapWithIndex xs f] applies [f] to each element of [xs]. Function [f] takes two arguments:
   the index starting from 0 and the element from [xs].
 
-    @example {[
+    {[
       mapWithIndex [1;2;3] (fun i x -> i + x) =
       [0 + 1; 1 + 2; 2 + 3 ]
     ]}
@@ -271,14 +270,14 @@ val mapWithIndex: 'a t -> (int -> 'a -> 'b) -> 'b t
 val fromArray: 'a array -> 'a t 
 (** [fromArray arr] converts the given array to a list
 
-  @example {[
+  {[
       fromArray [|1;2;3|]  = [1;2;3]
     ]}
 *)
 
 val toArray: 'a t -> 'a array
 (** [toArray xs] converts the given list to an array
-  @example {[
+  {[
       toArray [1;2;3] = [|1;2;3|]
     ]}
 *)
@@ -290,7 +289,7 @@ val toArray: 'a t -> 'a array
 
 val reverse: 'a t -> 'a t
 (** [reverse xs] returns a new list whose elements are those of [xs] in reverse order. 
-  @example {[
+  {[
       reverse [1;2;3] = [3;2;1]
     ]}
 *)
@@ -301,7 +300,7 @@ val mapReverse: 'a t -> ('a -> 'b) -> 'b t
 
     Equivalent to [reverse (map xs f)]
     
-    @example {[
+    {[
       mapReverse [3;4;5] (fun x -> x * x) = [25;16;9];;
     ]}
 *)
@@ -313,7 +312,7 @@ val forEach: 'a t -> ('a -> 'b) -> unit
     new array is created. Use [foreach] when you are primarily concerned with repetitively
     creating side effects.
     
-    @example {[
+    {[
       forEach ["a";"b";"c"] (fun x -> Js.log("Item: " ^ x));;
       (*  prints:
         Item: a
@@ -331,7 +330,7 @@ val forEachWithIndexU: 'a t -> (int -> 'a -> 'b [@bs]) -> unit
 val forEachWithIndex: 'a t -> (int -> 'a -> 'b) -> unit
 (** [forEachWithIndex xs f]
 
-    @example {[
+    {[
     
       forEach ["a";"b";"c"] (fun i x -> Js.log("Item " ^ (string_of_int i) ^ " is " ^ x));;
       (*  prints:
@@ -354,7 +353,7 @@ val reduce:  'a t -> 'b -> ('b -> 'a -> 'b) -> 'b
     from the list and an “accumulator”, which starts with a value of [init]. [reduce]
     returns the final value of the accumulator.
     
-    @example {[
+    {[
       reduce [1;2;3;4] 0 (+) = 10;;
       reduce [1;2;3;4] 10 (-) = 0;;
       reduce [1;2;3;4] [] add = [4;3;2;1];
@@ -369,7 +368,7 @@ val reduceWithIndex:  'a t -> 'b -> ('b -> 'a -> int -> 'b) -> 'b
     from the list and an “accumulator”, which starts with a value of [init] and the index of each element. [reduceWithIndex]
     returns the final value of the accumulator.
     
-    @example {[
+    {[
       reduceWithIndex [1;2;3;4] 0 (fun acc x i -> acc + x + i) = 16;;
     ]}
 *)
@@ -381,7 +380,7 @@ val reduceReverse: 'a t -> 'b -> ('b -> 'a ->  'b) -> 'b
     Works like {!reduce}, except that function [f] is applied to each item of [xs] from the last
     back to the first.
 
-    @example {[
+    {[
       reduceReverse [1;2;3;4] 0 (+) = 10;;
       reduceReverse [1;2;3;4] 10 (-) = 0;;
       reduceReverse [1;2;3;4] [] add = [1;2;3;4];;
@@ -394,7 +393,7 @@ val mapReverse2: 'a t -> 'b t -> ('a -> 'b -> 'c) -> 'c t
 
     equivalent to [reverse (zipBy xs ys f)]    
 
-    @example {[
+    {[
       mapReverse2 [1;2;3] [1;2] (+) = [4;2]
     ]}
 *)
@@ -415,7 +414,7 @@ val reduce2:
     Function [f] has three parameters: an “accumulator” which starts with a value of [init],
     an item from [xs], and an item from [ys]. [reduce2] returns the final value of the accumulator.
     
-    @example {[
+    {[
       reduce2 [1;2;3] [4;5] 0 (fun acc x y -> acc + x * x + y) =  0 + (1 * 1 + 4) + (2 * 2 + 5);;
       reduce2 [1;2;3] [4;5] [] (fun acc x y -> add acc (x + y) = [2 +5;1 + 4 ];; (*add appends at end *)
     ]}
@@ -432,7 +431,7 @@ val reduceReverse2:
     Function [f] has three parameters: an “accumulator” which starts with a value of [init],
     an item from [xs], and an item from [ys]. [reduce2] returns the final value of the accumulator.
     
-    @example {[
+    {[
       reduceReverse2 [1;2;3] [4;5] 0 (fun acc x y -> acc + x * x + y) =  0 + (1 * 1 + 4) + (2 * 2 + 5);;
       reduceReverse2 [1;2;3] [4;5] [] (fun acc x y -> add acc (x + y) = [1 + 4;2 + 5];; (*add appends at end *)
     ]}*)
@@ -444,7 +443,7 @@ val every: 'a t -> ('a -> bool ) ->  bool
     @return true if all elements satisfy [p], where [p] is a {i predicate}: a function taking
     an element and returning a [bool].
 
-    @example {[
+    {[
       every [] (fun x -> x mod 2 = 0) = true;;
       every [2;4;6] (fun x -> x mod 2 = 0 ) = true;;
       every [1;-3;5] (fun x -> x > 0) = false;;
@@ -457,7 +456,7 @@ val some: 'a t -> ('a -> bool ) -> bool
     @return true if at least one of the elements in [xs] satifies [p], where [p] is a {i predicate}: a function taking
     an element and returning a [bool].
 
-    @example {[
+    {[
       some [] (fun x -> x mod 2 = 0) = false ;;
       some [1;2;4] (fun x -> x mod 2 = 0) = true;;
       some [-1;-3;-5] (fun x -> x > 0) = false;;
@@ -468,7 +467,7 @@ val every2U: 'a t -> 'b t -> ('a -> 'b -> bool [@bs]) -> bool
 val every2: 'a t -> 'b t -> ('a -> 'b -> bool ) -> bool
 (** [every2 xs ys p] returns true if predicate [p xi yi] is true for all pairs of elements
   up to the shorter length (i.e. [min (length xs) (length ys)])
-    @example {[
+    {[
       every2 [1;2;3] [0;1] (>) = true;;
       every2 [] [1] (fun  x y -> x > y) = true;;
       every2 [2;3] [1] (fun  x y -> x > y) = true;;
@@ -481,7 +480,7 @@ val some2:  'a t -> 'b t -> ('a -> 'b -> bool) -> bool
 (** [some2 xs ys p] returns true if [p xi yi] is true for any pair of elements
   up to the shorter length (i.e. [min (length xs) (length ys)])
 
-    @example {[
+    {[
       some2 [0;2] [1;0;3] (>) = true ;;
       some2 [] [1] (fun  x y -> x > y) =  false;;
       some2 [2;3] [1;4] (fun  x y -> x > y) = true;;
@@ -494,7 +493,7 @@ val cmpByLength: 'a t -> 'a t -> int
     Compare two lists solely by length. Returns -1 if [length l1] is less than [length l2],
     0 if [length l1] equals [length l2], and 1 if [length l1] is greater than [length l2].
     
-    @example {[
+    {[
     cmpByLength [1;2] [3;4;5;6] = -1;;
     cmpByLength [1;2;3] [4;5;6] = 0;;
     cmpByLength [1;2;3;4] [5;6] = 1;;
@@ -514,7 +513,7 @@ val cmp: 'a t -> 'a t -> ('a -> 'a -> int) -> int
     If all items have compared equal, but [ys] is exhausted first, return 1 ([xs] is longer)
     
     
-    @example {[
+    {[
       cmp [3] [3;7] (fun a b -> compare a b) = -1
       cmp [5;3] [5] (fun a b -> compare a b)  = 1
       cmp [|1; 3; 5|] [|1; 4; 2|] (fun a b -> compare a b) = -1;;
@@ -536,7 +535,7 @@ val eq: 'a t -> 'a t -> ('a -> 'a -> bool) -> bool
    that returns true if items [x] and [y] meet some criterion for equality, false otherwise.
    [eq] false if length of [xs] and [ys] are not the same.
 
-    @example {[
+    {[
       eq [1;2;3] [1;2] (=) = false ;;
       eq [1;2] [1;2] (=) = true;;
       eq [1; 2; 3] [-1; -2; -3] (fun a b -> abs a = abs b) = true;;
@@ -549,7 +548,7 @@ val has:  'a t -> 'b -> ('a -> 'b -> bool) -> bool
 (** 
     [has xs eqFcn] returns true if the list contains at least one element for which [eqFcn x] returns
     true
-    @example {[
+    {[
       has [1;2;3] 2 (=) = true;;
       has [1;2;3] 4 (=) = false;;
       has [-1;-2;-3] 2 (fun a b -> abs a = abs b) = true;;
@@ -560,7 +559,7 @@ val getByU: 'a t -> ('a -> bool [@bs]) -> 'a option
 val getBy: 'a t -> ('a -> bool) -> 'a option
 (** [getBy xs p] returns [Some value] for the first value in [xs] that satisifies the predicate function [p]; returns [None] if no element satisifies the function.
 
-  @example {[
+  {[
       getBy [1;4;3;2] (fun x -> x mod 2 = 0) = Some 4
       getBy [15;13;11] (fun x -> x mod 2 = 0) = None
     ]}
@@ -570,7 +569,7 @@ val keepU: 'a t ->  ('a -> bool [@bs]) -> 'a t
 val keep: 'a t ->  ('a -> bool) -> 'a t
 (** [keep  xs p] returns a list of all elements in [xs] which satisfy the predicate function [p]
 
-    @example {[
+    {[
       keep [1;2;3;4] (fun x -> x mod 2 = 0) =
       [2;4]
     ]}
@@ -581,7 +580,7 @@ val filter: 'a t ->  ('a -> bool) -> 'a t
 [@@deprecated "This function will soon be deprecated. Please, use `List.keep` instead."]
 (** [filter  xs p] returns a list of all elements in [xs] which satisfy the predicate function [p]
 
-    @example {[
+    {[
       filter [1;2;3;4] (fun x -> x mod 2 = 0) =
       [2;4]
     ]}
@@ -591,7 +590,7 @@ val keepWithIndexU: 'a t ->  ('a -> int -> bool [@bs]) -> 'a t
 val keepWithIndex: 'a t ->  ('a -> int -> bool) -> 'a t
 (** [keepWithIndex xs p] returns a list of all elements in [xs] which satisfy the predicate function [p]
 
-    @example {[
+    {[
       keepWithIndex [1;2;3;4] (fun _x i -> i mod 2 = 0)
       =
       [1;3]
@@ -603,7 +602,7 @@ val filterWithIndex: 'a t ->  ('a -> int -> bool) -> 'a t
 [@@deprecated "This function will soon be deprecated. Please, use `List.keepWithIndex` instead."]
 (** [filterWithIndex xs p] returns a list of all elements in [xs] which satisfy the predicate function [p]
 
-    @example {[
+    {[
       filterWithIndex [1;2;3;4] (fun _x i -> i mod 2 = 0)
       =
       [1;3]
@@ -614,7 +613,7 @@ val keepMapU: 'a t -> ('a -> 'b option [@bs]) -> 'b t
 val keepMap: 'a t -> ('a -> 'b option) -> 'b t
 (** [keepMap xs f] applies [f] to each element of [xs]. If [f xi] returns [Some value], then [value] is kept in the resulting list; if [f xi] returns [None], the element is not retained in the result.
 
-    @example {[
+    {[
       keepMap [1;2;3;4] (fun x -> if x mod 2 = 0 then Some (-x ) else None)
       =
       [-2;-4]
@@ -625,7 +624,7 @@ val partitionU: 'a t -> ('a -> bool [@bs]) ->  'a t * 'a t
 val partition: 'a t -> ('a -> bool) ->  'a t * 'a t
 (** [partition xs p] creates a pair of lists; the first list consists of all elements of [xs] that satisfy the predicate function [p]; the second list consists of all elements of [xs] that do not satisfy [p]
 
-    @example {[
+    {[
       partition [1;2;3;4] (fun x -> x mod 2 = 0) =
       ([2;4], [1;3])
     ]}
@@ -634,7 +633,7 @@ val partition: 'a t -> ('a -> bool) ->  'a t * 'a t
 val unzip: ('a * 'b) t -> 'a t * 'b t
 (** [unzip xs] takes a list of pairs and creates a pair of lists. The first list contains all the first items of the pairs; the second list contains all the second items.
 
-    @example {[
+    {[
       unzip [(1,2) ; (3,4)] = ([1;3], [2;4]);;
       unzip [(1,2) ; (3,4) ; (5,6) ; (7,8)] = ([1;3;5;7], [2;4;6;8]);;
     ]}
@@ -646,7 +645,7 @@ val getAssoc: ('a * 'c) t -> 'b ->  ('a -> 'b -> bool)  -> 'c option
     
     return the second element of a pair in [xs] where the first element equals [x] as per the predicate
     function [eq], or [None] if not found
-    @example {[
+    {[
       getAssoc [ 1, "a"; 2, "b"; 3, "c"] 2 (=) = Some "b"
       getAssoc [9, "morning"; 15, "afternoon"; 22, "night"] 3 (fun a b -> a mod 12 = b mod 12) = Some "afternoon"
     ]}
@@ -657,7 +656,7 @@ val hasAssoc: ('a * 'c) t -> 'b -> ('a -> 'b -> bool ) -> bool
 (** [hasAssoc xs k eq]
      return true if there is a pair in [xs] where the first element equals [k] as per the predicate
      funtion [eq]
-    @example {[
+    {[
       hasAssoc [1, "a"; 2, "b"; 3,"c"] 1 (=) = true;;
       hasAssoc [9, "morning"; 15, "afternoon"; 22, "night"] 3 (fun a b -> a mod 12 = b mod 12) = true;;
     ]}
@@ -667,7 +666,7 @@ val removeAssocU:('a * 'c) t -> 'b -> ('a -> 'b -> bool [@bs]) -> ('a * 'c) t
 val removeAssoc: ('a * 'c) t -> 'b ->  ('a -> 'b -> bool) -> ('a * 'c) t
 (** [removeAssoc xs k eq]
     Return a list after removing the first pair whose first value is [k] per the equality predicate [eq]; if not found, return a new list identical to [xs].
-    @example {[
+    {[
       removeAssoc [1,"a"; 2, "b"; 3, "c" ] 1 (=) =
         [2, "b"; 3, "c"]
       removeAssoc [1,"a"; 2, "b"; 3, "c" ] 99 (=) =
@@ -681,7 +680,7 @@ val setAssoc: ('a * 'c) t -> 'a -> 'c -> ('a -> 'a -> bool) -> ('a * 'c) t
     if [k] exists in [xs] by satisfying the [eq] predicate, return a new list
     with the key and value replaced by the new [k] and [v]; otherwise, return a new
     list with the pair [k, v] added to the head of [xs].
-    @example {[
+    {[
       setAssoc [1,"a"; 2, "b"; 3, "c"] 2 "x" (=) =
       [1,"a"; 2, "x"; 3,"c"] ;; 
 
@@ -703,7 +702,7 @@ val sortU: 'a t -> ('a -> 'a -> int [@bs]) -> 'a t
 val sort: 'a t -> ('a -> 'a -> int) -> 'a t
 (** [sort xs]
     Returns a sorted list.
-    @example {[
+    {[
       sort [5; 4; 9; 3; 7] (fun a b -> a - b) = [3; 4; 5; 7; 9]
     ]}
 *)

--- a/jscomp/others/belt_Map.mli
+++ b/jscomp/others/belt_Map.mli
@@ -22,7 +22,7 @@
 
   Example usage:
 
-   @example {[
+   {[
     module PairComparator = Belt.Id.MakeComparable(struct
       type t = int * int
       let cmp (a0, a1) (b0, b1) =
@@ -97,7 +97,7 @@ type ('key, 'id) id = ('key, 'id) Belt_Id.comparable
 
 val make: id:('k, 'id) id -> ('k, 'v, 'id) t
 (** [make ~id] creates a new map by taking in the comparator
-    @example {[
+    {[
       let m = Belt.Map.make ~id:(module IntCmp)
     ]}
  *)
@@ -105,14 +105,14 @@ val make: id:('k, 'id) id -> ('k, 'v, 'id) t
 
 val isEmpty: _ t -> bool
 (** [isEmpty m] checks whether a map m is empty
-    @example {[
+    {[
       isEmpty (fromArray [|1,"1"|] ~id:(module IntCmp)) = false
     ]}
 *)
 
 val has: ('k, 'v, 'id) t -> 'k  -> bool
 (** [has m k] checks whether m has the key k
-    @example {[
+    {[
       has (fromArray [|1,"1"|] ~id:(module IntCmp)) 1 = true
     ]}
   *)
@@ -154,7 +154,7 @@ val findFirstBy : ('k, 'v, 'id) t -> ('k -> 'v -> bool ) -> ('k * 'v) option
 (** [findFirstBy m p] uses funcion [f] to find the first key value pair
     to match predicate [p].
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|4,"4";1,"1";2,"2,"3""|];;
       findFirstBy s0 (fun k v -> k = 4 ) = option (4, "4");;
     ]}
@@ -167,7 +167,7 @@ val forEach:  ('k, 'v, 'id) t -> ('k -> 'v -> unit) -> unit
     as second argument.  The bindings are passed to [f] in increasing
     order with respect to the ordering over the type of the keys.
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|4,"4";1,"1";2,"2,"3""|];;
       let acc = ref [] ;;
       forEach s0 (fun k v -> acc := (k,v) :: !acc);;
@@ -182,7 +182,7 @@ val reduce: ('k, 'v, 'id) t -> 'acc -> ('acc -> 'k -> 'v -> 'acc) -> 'acc
     where [k1 ... kN] are the keys of all bindings in [m]
     (in increasing order), and [d1 ... dN] are the associated data.
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|4,"4";1,"1";2,"2,"3""|];;
       reduce s0 [] (fun acc k v -> (k,v) acc ) = [4,"4";3,"3";2,"2";1,"1"];;
     ]}
@@ -201,7 +201,7 @@ val some: ('k, 'v, 'id) t -> ('k -> 'v -> bool) ->  bool
 val size: ('k, 'v, 'id) t -> int
 (** [size s]
 
-    @example {[
+    {[
       size (fromArray [2,"2"; 2,"1"; 3,"3"] ~id:(module IntCmp)) = 2 ;;
     ]}
 *)
@@ -209,7 +209,7 @@ val size: ('k, 'v, 'id) t -> int
 val toArray: ('k, 'v, 'id) t -> ('k * 'v) array
 (** [toArray s]
 
-    @example {[
+    {[
       toArray (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) = [1,"1";2,"2";3,"3"]
     ]}
 
@@ -224,14 +224,14 @@ val toList: ('k, 'v, 'id) t -> ('k * 'v) list
 
 val fromArray:  ('k * 'v) array -> id:('k,'id) id -> ('k,'v,'id) t
 (** [fromArray kvs ~id]
-    @example {[
+    {[
       toArray (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) = [1,"1";2,"2";3,"3"]
     ]}
 *)
 
 val keysToArray: ('k, 'v, 'id) t -> 'k  array
 (** [keysToArray s]
-    @example {[
+    {[
       keysToArray (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) =
       [|1;2;3|];;
     ]}
@@ -239,7 +239,7 @@ val keysToArray: ('k, 'v, 'id) t -> 'k  array
 
 val valuesToArray: ('k, 'v, 'id) t -> 'v  array
 (** [valuesToArray s]
-    @example {[
+    {[
       valuesToArray (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) =
       [|"1";"2";"3"|];;
     ]}
@@ -282,7 +282,7 @@ val maxUndefined:('k, 'v, _) t -> ('k * 'v) Js.undefined
 val get:  ('k, 'v, 'id) t -> 'k -> 'v option
 (** [get s k]
 
-    @example {[
+    {[
       get (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) 2 =
       Some "2";;
       get (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp)) 2 =
@@ -319,7 +319,7 @@ val getExn:  ('k, 'v, 'id) t -> 'k -> 'v
 val remove:  ('k, 'v, 'id) t -> 'k -> ('k, 'v, 'id) t
 (** [remove m x] when [x] is not in [m], [m] is returned reference unchanged.
 
-    @example {[
+    {[
       let s0 =  (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp));;
 
       let s1 = remove s0 1;;
@@ -344,7 +344,7 @@ val set:
     [m], with a new binding of [x] to [y]. If [x] was already bound
     in [m], its previous binding disappears.
 
-    @example {[
+    {[
       let s0 =  (fromArray [2,"2"; 1,"1"; 3,"3"] ~id:(module IntCmp));;
 
       let s1 = set s0 2 "3";;

--- a/jscomp/others/belt_MapDict.mli
+++ b/jscomp/others/belt_MapDict.mli
@@ -70,7 +70,7 @@ val findFirstBy : ('k, 'v, 'id) t -> ('k -> 'v -> bool ) -> ('k * 'v) option
 (** [findFirstBy m p] uses funcion [f] to find the first key value pair
     to match predicate [p].
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|4,"4";1,"1";2,"2,"3""|];;
       findFirstBy s0 (fun k v -> k = 4 ) = option (4, "4");;
     ]}

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -37,7 +37,7 @@ val keep : 'a option -> ('a -> bool) -> 'a option
   
   If [optionValue] is [Some value] and [p value = true], it returns [Some value]; otherwise returns [None]
   
-  @example {[
+  {[
     keep (Some 10)(fun x -> x > 5);; (* returns [Some 10] *)
     keep (Some 4)(fun x -> x > 5);; (* returns [None] *)
     keep None (fun x -> x > 5);; (* returns [None] *)
@@ -53,7 +53,7 @@ val forEach : 'a option -> ('a -> unit) -> unit
   
   If [optionValue] is [Some value], it calls [f value]; otherwise returns [()]
   
-  @example {[
+  {[
     forEach (Some "thing")(fun x -> Js.log x);; (* logs "thing" *)
     forEach None (fun x -> Js.log x);; (* returns () *)
   ]}
@@ -63,7 +63,7 @@ val getExn : 'a option -> 'a
 (** [getExn optionalValue]
   Returns [value] if [optionalValue] is [Some value], otherwise raises [getExn]
   
-  @example {[
+  {[
     getExn (Some 3) = 3;;
     getExn None (* Raises getExn error *)
   ]}
@@ -85,7 +85,7 @@ val mapWithDefault : 'a option -> 'b -> ('a -> 'b) -> 'b
   
   If [optionValue] is [Some value], returns [f value]; otherwise returns [default]
   
-  @example {[
+  {[
     mapWithDefault (Some 3) 0 (fun x -> x + 5) = 8;;
     mapWithDefault None 0 (fun x -> x + 5) = 0;;
   ]}
@@ -100,7 +100,7 @@ val map : 'a option -> ('a -> 'b) -> 'b option
   
   If [optionValue] is [Some value], returns [Some (f value)]; otherwise returns [None]
   
-  @example {[
+  {[
     map (Some 3) (fun x -> x * x) = (Some 9);;
     map None (fun x -> x * x) = None;;
   ]}
@@ -116,7 +116,7 @@ val flatMap : 'a option -> ('a -> 'b option) -> 'b option
   If [optionValue] is [Some value], returns [f value]; otherwise returns [None]
   The function [f] must have a return type of ['a option]
   
-  @example {[
+  {[
     let f (x : float) =
         if x >= 0.0 then
           Some (sqrt x)
@@ -135,7 +135,7 @@ val getWithDefault : 'a option -> 'a -> 'a
   
   If [optionalValue] is [Some value], returns [value], otherwise [default]
   
-  @example {[
+  {[
     getWithDefault (Some 1812) 1066 = 1812;;
     getWithDefault None 1066 = 1066;;
   ]}
@@ -147,7 +147,7 @@ val orElse : 'a option -> 'a option -> 'a option
 
    If [optionalValue] is [Some value], returns [Some value], otherwise [otherOptional]
 
-   @example {[
+   {[
      orElse (Some 1812) (Some 1066) = Some 1812;;
      orElse None (Some 1066) = Some 1066;;
      orElse None None = None;;
@@ -182,7 +182,7 @@ val eq : 'a option -> 'b option -> ('a -> 'b -> bool) -> bool
   If arguments are [Some value1] and [Some value2], returns the result of [predicate value1 value2];
   the [predicate] function must return a [bool]
   
-  @example {[
+  {[
     let clockEqual = (fun a b -> a mod 12 = b mod 12);;
     eq (Some 3) (Some 15) clockEqual = true;;
     eq (Some 3) None clockEqual = false;;
@@ -208,7 +208,7 @@ val cmp : 'a option -> 'b option -> ('a -> 'b -> int) -> int
   
   If the arguments are [Some value1] and [Some value2], returns the result of [comparisonFcn value1 value2]; [comparisonFcn] takes two arguments and returns -1 if the first argument is less than the second, 0 if the arguments are equal, and 1 if the first argument is greater than the second.
     
-  @example {[
+  {[
     let clockCompare = fun a b -> compare (a mod 12) (b mod 12);;
     cmp (Some 3) (Some 15) clockCompare = 0;;
     cmp (Some 3) (Some 14) clockCompare = 1;;

--- a/jscomp/others/belt_Result.mli
+++ b/jscomp/others/belt_Result.mli
@@ -36,7 +36,7 @@
   
   In the examples, we presume the existence of two variables:
   
-  @example {[
+  {[
   let good = Ok 42
   let bad = Error "Invalid data"
   ]}
@@ -51,7 +51,7 @@ val getExn : ('a, 'b) t -> 'a
   when [res] is [Ok n], returns [n]
   when [res] is [Error m], {b raise} an exception
   
-  @example {[
+  {[
     getExn good = 42;;
     getExn bad;; (* raises exception *)
   ]}
@@ -64,7 +64,7 @@ val mapWithDefault : ('a, 'c) t -> 'b -> ('a -> 'b) -> 'b
   
   When [res] is [Ok n], returns [f n], otherwise [default].
   
-  @example{[
+  {[
     mapWithDefault good 0 (fun x -> x / 2) = 21
     mapWithDefault bad 0 (fun x -> x / 2) = 0
   ]}
@@ -78,7 +78,7 @@ val map : ('a, 'c) t -> ('a -> 'b) -> ('b, 'c) t
   When [res] is [Ok n], returns [Ok (f n)]. Otherwise returns [res] unchanged.
   Function [f] takes a value of the same type as [n] and returns an ordinary value.
   
-  @example{[
+  {[
     let f x = sqrt (float_of_int x)
     map (Ok 64) f = Ok 8.0
     map (Error "Invalid data") f = Error "Invalid data"
@@ -93,7 +93,7 @@ val flatMap : ('a, 'c) t -> ('a -> ('b, 'c) t) -> ('b, 'c) t
   When [res] is [Ok n], returns [f n]. Otherwise, returns [res] unchanged.
   Function [f] takes a value of the same type as [n] and returns a [Belt.Result].
   
-  @example {[
+  {[
 let recip x = 
   if x != 0.0
   then
@@ -113,7 +113,7 @@ val getWithDefault : ('a, 'b) t -> 'a -> 'a
   
   if [res] is [Ok n], returns [n], otherwise [default]
   
-  @example {[
+  {[
     getWithDefault (Ok 42) 0 = 42
     getWithDefault (Error "Invalid Data") = 0
   ]}
@@ -143,7 +143,7 @@ val eq : ('a, 'c) t -> ('b, 'd) t -> ('a -> 'b -> bool) -> bool
   If one of [res1] and [res2] are of the form [Error e], return false
   If both [res1] and [res2] are of the form [Error e], return true
   
-  @example {[
+  {[
     let good1 = Ok 42
     let good2 = Ok 32
     let bad1 = Error "invalid"
@@ -173,7 +173,7 @@ val cmp : ('a, 'c) t -> ('b, 'd) t -> ('a -> 'b -> int) -> int
   If [res1] is of the form [Ok n] and [res2] of the form [Error e], return 1 (something is greater than nothing)
   If both [res1] and [res2] are of the form [Error e], return 0 (equal)
   
-  @example {[
+  {[
     let good1 = Ok 59
     let good2 = Ok 37
     let bad1 = Error "invalid"

--- a/jscomp/others/belt_Set.mli
+++ b/jscomp/others/belt_Set.mli
@@ -32,7 +32,7 @@
 
   Example usage:
 
-   @example {[
+   {[
     module PairComparator = Belt.Id.MakeComparable(struct
       type t = int * int
       let cmp (a0, a1) (b0, b1) =
@@ -81,7 +81,7 @@ type ('value, 'id) id = ('value, 'id) Belt_Id.comparable
 
 val make: id:('value, 'id) id -> ('value, 'id) t
 (** [make ~id] creates a new set by taking in the comparator
-    @example {[
+    {[
       let s = make ~id:(module IntCmp)
     ]}
 
@@ -92,7 +92,7 @@ val make: id:('value, 'id) id -> ('value, 'id) t
 val fromArray:  'value array -> id:('value, 'id) id ->  ('value, 'id) t
 (** [fromArray xs ~id]
 
-    @example{[
+    {[
      toArray (fromArray [1;3;2;4] (module IntCmp)) = [1;2;3;4]
     ]}
 *)
@@ -110,7 +110,7 @@ val fromSortedArrayUnsafe: 'value array -> id:('value, 'id) id -> ('value,'id) t
 
 val isEmpty: _ t -> bool
 (**
-   @example {[
+   {[
      isEmpty (fromArray [||] ~id:(module IntCmp)) = true;;
      isEmpty (fromArray [|1|] ~id:(module IntCmp)) = true;;
    ]}
@@ -118,7 +118,7 @@ val isEmpty: _ t -> bool
 
 val has: ('value, 'id) t -> 'value ->  bool
 (**
-   @example {[
+   {[
      let v = fromArray [|1;4;2;5|] ~id:(module IntCmp);;
      has v 3 = false;;
      has v 1 = true;;
@@ -129,7 +129,7 @@ val add:
   ('value, 'id) t -> 'value -> ('value, 'id) t
 (** [add s x] If [x] was already in [s], [s] is returned unchanged.
 
-    @example {[
+    {[
      let s0 = make ~id:(module IntCmp);;
      let s1 = add s0 1 ;;
      let s2 = add s1 2;;
@@ -154,7 +154,7 @@ val mergeMany: ('value, 'id) t -> 'value array -> ('value, 'id) t
 val remove: ('value, 'id) t -> 'value -> ('value, 'id) t
 (** [remove m x] If [x] was not in [m], [m] is returned reference unchanged.
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|2;3;1;4;5|];;
       let s1 = remove s0 1 ;;
       let s2 = remove s1 3 ;;
@@ -179,7 +179,7 @@ val union: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
 (**
    [union s0 s1]
 
-   @example {[
+   {[
      let s0 = fromArray ~id:(module IntCmp) [|5;2;3;5;6|]];;
      let s1 = fromArray ~id:(module IntCmp) [|5;2;3;1;5;4;|];;
      toArray (union s0 s1) =  [|1;2;3;4;5;6|]
@@ -188,7 +188,7 @@ val union: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
 
 val intersect: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
 (** [intersect s0 s1]
-   @example {[
+   {[
      let s0 = fromArray ~id:(module IntCmp) [|5;2;3;5;6|]];;
      let s1 = fromArray ~id:(module IntCmp) [|5;2;3;1;5;4;|];;
      toArray (intersect s0 s1) =  [|2;3;5|]
@@ -198,7 +198,7 @@ val intersect: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
 
 val diff: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
 (** [diff s0 s1]
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|5;2;3;5;6|]];;
       let s1 = fromArray ~id:(module IntCmp) [|5;2;3;1;5;4;|];;
       toArray (diff s0 s1) = [|6|];;
@@ -209,7 +209,7 @@ val diff: ('value, 'id) t -> ('value, 'id) t -> ('value, 'id) t
 val subset: ('value, 'id) t -> ('value, 'id) t -> bool
 (** [subset s0 s1]
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|5;2;3;5;6|]];;
       let s1 = fromArray ~id:(module IntCmp) [|5;2;3;1;5;4;|];;
       let s2 = intersect s0 s1;;
@@ -237,7 +237,7 @@ val forEach: ('value, 'id) t -> ('value -> unit ) ->  unit
 (** [forEach s f] applies [f] in turn to all elements of [s].
     In increasing order
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|5;2;3;5;6|]];;
       let acc = ref [] ;;
       forEach s0 (fun x -> acc := x !acc);;
@@ -249,7 +249,7 @@ val reduceU: ('value, 'id) t -> 'a  -> ('a -> 'value -> 'a [@bs]) ->  'a
 val reduce: ('value, 'id) t -> 'a  -> ('a -> 'value -> 'a ) ->  'a
 (** In increasing order.
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|5;2;3;5;6|]];;
       reduce s0 [] Bs.List.add = [6;5;3;2];;
     ]}
@@ -281,7 +281,7 @@ val partition: ('value, 'id) t -> ('value -> bool) ->  ('value, 'id) t * ('value
 val size:  ('value, 'id) t -> int
 (** [size s]
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|5;2;3;5;6|]];;
       size s0 = 4;;
     ]}
@@ -289,7 +289,7 @@ val size:  ('value, 'id) t -> int
 
 val toArray: ('value, 'id) t -> 'value array
 (** [toArray s0]
-   @example {[
+   {[
       let s0 = fromArray ~id:(module IntCmp) [|5;2;3;5;6|]];;
       toArray s0 = [|2;3;5;6|];;
     ]}*)

--- a/jscomp/others/belt_SortArray.mli
+++ b/jscomp/others/belt_SortArray.mli
@@ -47,7 +47,7 @@ val strictlySortedLength:
   return [+n] means increasing order
   [-n] means negative order
 
-  @example{[
+  {[
      strictlySortedLength [|1;2;3;4;3|] (fun x y -> x < y) = 4;;
      strictlySortedLength [||] (fun x y -> x < y) = 0;;
      strictlySortedLength [|1|] (fun x y -> x < y) = 1;;
@@ -59,7 +59,7 @@ val isSortedU: 'a array -> ('a -> 'a -> int [@bs]) -> bool
 val isSorted: 'a array -> ('a -> 'a -> int) -> bool
 (** [isSorted arr cmp]
     @return true if array is increasingly sorted (equal is okay )
-    @example {[
+    {[
      isSorted [|1;1;2;3;4|] (fun x y -> compare x y) = true
    ]}
 *)
@@ -99,7 +99,7 @@ val binarySearchBy:
   for example, if [key] is smaller than all elements return [-1] since [lnot (-1) = 0]
   if [key] is larger than all elements return [- (len + 1)] since [lnot (-(len+1)) = len]
 
-   @example {[
+   {[
      binarySearchBy [|1;2;3;4;33;35;36|] 33 = 4;;
      lnot (binarySearchBy [|1;3;5;7|] 4) = 2;;
    ]}

--- a/jscomp/others/js_dict.mli
+++ b/jscomp/others/js_dict.mli
@@ -45,7 +45,7 @@ external unsafeGet : 'a t -> key -> 'a = "" [@@bs.get_index]
     when the existence of a key is certain. (i.e. when having called [keys]
     function previously. 
 
-@example {[
+{[
 Array.iter (fun key -> Js.log (Js_dict.unsafeGet dic key)) (Js_dict.keys dict) 
 ]} 
 *)

--- a/jscomp/others/js_exn.mli
+++ b/jscomp/others/js_exn.mli
@@ -55,13 +55,13 @@ val anyToExnInternal: 'a -> exn
  *
  * IMPORTANT: This is an internal API and may be changed / removed any time in the future.
  *
- * @example {[
+ * {[
  *   switch (Js.Exn.unsafeAnyToExn("test")) {
- *     | Js.Exn.Error(v) =>
- *       switch(Js.Exn.message(v)) {
- *         | Some(str) => Js.log("We won't end up here")
-           | None => Js.log2("We will land here: ", v)
- *       }
+ *   | Js.Exn.Error(v) =>
+ *     switch (Js.Exn.message(v)) {
+ *     | Some(str) => Js.log("We won't end up here")
+ *     | None => Js.log2("We will land here: ", v)
+ *     }
  *   }
  * ]}
  * **)

--- a/jscomp/others/js_float.ml
+++ b/jscomp/others/js_float.ml
@@ -46,7 +46,7 @@ external isNaN : float -> bool = "isNaN" [@@bs.val] [@@bs.scope "Number"]
 
 {b Returns} [true] if the given value is a finite number, [false] otherwise
 
-@example {[
+{[
 (* returns [false] *)
 let _ = Js.Float.isFinite infinity
 
@@ -70,7 +70,7 @@ external isFinite : float -> bool = "isFinite" [@@bs.val] [@@bs.scope "Number"]
 
 @raise RangeError if digits is not in the range \[0, 20\] (inclusive)
 
-@example {[
+{[
   (* prints "7.71234e+1" *)
   let _ = Js.log (Js.Float.toExponential 77.1234)
 
@@ -93,7 +93,7 @@ The output will be rounded or padded with zeroes if necessary.
 
 @raise RangeError if digits is not in the range \[0, 20\] (inclusive)
 
-@example {[
+{[
   ```
   (* prints "7.71e+1" *)
   let _ = Js.log (Js.Float.toExponentialWithPrecision 77.1234 ~digits:2)
@@ -109,7 +109,7 @@ external toExponentialWithPrecision : float -> digits:int -> string = "toExponen
 
 @raise RangeError if digits is not in the range \[0, 20\] (inclusive)
 
-@example {[
+{[
   (* prints "12346" (note the rounding) *)
   let _ = Js.log (Js.Float.toFixed 12345.6789)
 
@@ -132,7 +132,7 @@ The output will be rounded or padded with zeroes if necessary.
 
 @raise RangeError if digits is not in the range \[0, 20\] (inclusive)
 
-@example {[
+{[
   (* prints "12345.7" (note the rounding) *)
   let _ = Js.log (Js.Float.toFixedWithPrecision 12345.6789 ~digits:1)
 
@@ -154,7 +154,7 @@ decimal point.
 
 @raise RangeError if digits is not in the range accepted by this function (what do you mean "vague"?)
 
-@example {[
+{[
   (* prints "12345.6789" *)
   let _ = Js.log (Js.Float.toPrecision 12345.6789)
 
@@ -184,7 +184,7 @@ before the decimal point.
 
 @raise RangeError if digits is not in the range accepted by this function (what do you mean "vague"?)
 
-@example {[
+{[
   (* prints "1e+4" *)
   let _ = Js.log (Js.Float.toPrecisionWithPrecision 12345.6789 ~digits:1)
 
@@ -201,7 +201,7 @@ external toPrecisionWithPrecision : float -> digits:int -> string = "toPrecision
 
 {b Returns} a [string] representing the given value in fixed-point (usually)
 
-@example {[
+{[
   (* prints "12345.6789" *)
   let _ = Js.log (Js.Float.toString 12345.6789)
 ]}
@@ -219,7 +219,7 @@ value must be in the range \[2, 36\] (inclusive).
 
 @raise RangeError if radix is not in the range \[2, 36\] (inclusive)
 
-@example {[
+{[
   (* prints "110" *)
   let _ = Js.log (Js.Float.toStringWithRadix 6. ~radix:2)
 
@@ -241,7 +241,7 @@ external toStringWithRadix : float -> radix:int -> string = "toString" [@@bs.sen
 
 {b Returns} the number as a [float] if successfully parsed, [_NaN] otherwise.
 
-@example {[
+{[
 (* returns 123 *)
 let _ = Js.Float.fromString "123"
 

--- a/jscomp/others/js_global.ml
+++ b/jscomp/others/js_global.ml
@@ -37,7 +37,7 @@ type timeoutId
 
 (** Clear an interval started by {! setInterval}
 
-@example {[
+{[
 (* API for a somewhat aggressive snoozing alarm clock *)
 
 let interval = ref Js.Nullable.null
@@ -59,7 +59,7 @@ external clearInterval : intervalId -> unit = "clearInterval" [@@bs.val]
 
 
 (** Clear a timeout started by {! setTimeout}
-@example {[
+{[
 (* A simple model of a code monkey's brain *)
 
 let timer = ref Js.Nullable.null
@@ -83,7 +83,7 @@ external clearTimeout : timeoutId -> unit = "clearTimeout" [@@bs.val]
 
 @see <https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval> MDN
 
-@example {[
+{[
 (* Will count up and print the count to the console every second *)
 
 let count = ref 0
@@ -103,7 +103,7 @@ external setInterval : (unit -> unit) -> int -> intervalId = "setInterval" [@@bs
 
 @see <https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval> MDN
 
-@example {[
+{[
 (* Will count up and print the count to the console every second *)
 
 let count = ref 0
@@ -124,7 +124,7 @@ external setIntervalFloat : (unit -> unit) -> float -> intervalId = "setInterval
 
 @see <https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout> MDN
 
-@example {[
+{[
 (* Prints "Timed out!" in the console after one second *)
 
 let message = "Timed out!"
@@ -141,7 +141,7 @@ external setTimeout : (unit -> unit) -> int -> timeoutId = "setTimeout" [@@bs.va
 
 @see <https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout> MDN
 
-@example {[
+{[
 (* Prints "Timed out!" in the console after one second *)
 
 let message = "Timed out!"

--- a/jscomp/others/js_int.ml
+++ b/jscomp/others/js_int.ml
@@ -37,7 +37,7 @@
 
 @raise RangeError if digits is not in the range \[0, 20\] (inclusive)
 
-@example {[
+{[
   (* prints "7.7e+1" *)
   let _ = Js.log (Js.Int.toExponential 77)
 ]}
@@ -57,7 +57,7 @@ The output will be rounded or padded with zeroes if necessary.
 
 @raise RangeError if digits is not in the range \[0, 20\] (inclusive)
 
-@example {[
+{[
   (* prints "7.70e+1" *)
   let _ = Js.log  (Js.Int.toExponentialWithPrecision 77 ~digits:2)
 
@@ -79,7 +79,7 @@ decimal point.
 
 @raise RangeError if digits is not in the range accepted by this function (what do you mean "vague"?)
 
-@example {[
+{[
   (* prints "123456789" *)
   let _ = Js.log (Js.Int.toPrecision 123456789)
 ]}
@@ -106,7 +106,7 @@ before the decimal point.
 
 @raise RangeError if digits is not in the range accepted by this function (what do you mean "vague"?)
 
-@example {[
+{[
   (* prints "1.2e+8" *)
   let _ = Js.log (Js.Int.toPrecisionWithPrecision 123456789 ~digits:2)
 
@@ -123,7 +123,7 @@ external toPrecisionWithPrecision : int -> digits:int -> string = "toPrecision" 
 
 {b Returns} a [string] representing the given value in fixed-point (usually)
 
-@example {[
+{[
   (* prints "123456789" *)
   let _ = Js.log (Js.Int.toString 123456789)
 ]}
@@ -141,7 +141,7 @@ value must be in the range \[2, 36\] (inclusive).
 
 @raise RangeError if radix is not in the range \[2, 36\] (inclusive)
 
-@example {[
+{[
   (* prints "110" *)
   let _ = Js.log (Js.Int.toStringWithRadix 6 ~radix:2)
 

--- a/jscomp/others/js_json.mli
+++ b/jscomp/others/js_json.mli
@@ -133,7 +133,7 @@ external parseExn : string -> t = "parse" [@@bs.val] [@@bs.scope "JSON"]
 
 @raise SyntaxError if given string is not a valid JSON. Note [SyntaxError] is a JavaScript exception.
 
-@example {[
+{[
 (* parse a simple JSON string *)
 
 let json =
@@ -147,7 +147,7 @@ match Js.Json.classify json with
 | _ -> failwith "Expected a string"
 ]}
 
-@example {[
+{[
 (* parse a complex JSON string *)
 
 let getIds s =
@@ -185,7 +185,7 @@ external stringify: t -> string = "stringify"
 
 {b Returns} the string representation of a given JSON data structure
 
-@example {[
+{[
 (* Creates and stringifies a simple JS object *)
 
 let dict = Js.Dict.empty () in
@@ -206,7 +206,7 @@ external stringifyWithSpace: t -> (_ [@bs.as {json|null|json}]) -> int -> string
 
 {b Returns} the string representation of a given JSON data structure
 
-@example {[
+{[
 (* Creates and stringifies a simple JS object with spacing *)
 
 let dict = Js.Dict.empty () in
@@ -226,7 +226,7 @@ external stringifyAny : 'a -> string option = "stringify"
   [@@bs.val]  [@@bs.scope "JSON"]
 (** [stringifyAny value] formats any [value] into a JSON string
 
-@example {[
+{[
   (* prints ``"foo", "bar"`` *)
   Js.log (Js.Json.stringifyAny [| "foo"; "bar" |])
 ]}

--- a/jscomp/others/js_null.mli
+++ b/jscomp/others/js_null.mli
@@ -50,7 +50,7 @@ val getExn : 'a t -> 'a
 If ['a Js.null] contains a value, that value is unwrapped, mapped to a ['b] using
 the given function [a' -> 'b], then wrapped back up and returned as ['b Js.null]
 
-@example {[
+{[
 let maybeGreetWorld (maybeGreeting: string Js.null) =
   Js.Null.bind maybeGreeting (fun greeting -> greeting ^ " world!")
 ]}
@@ -62,7 +62,7 @@ val bind : 'a t -> ('a -> 'b [@bs]) -> 'b t
 If ['a Js.null] contains a value, that value is unwrapped and applied to
 the given function.
 
-@example {[
+{[
 let maybeSay (maybeMessage: string Js.null) =
   Js.Null.iter maybeMessage (fun message -> Js.log message)
 ]}

--- a/jscomp/others/js_null_undefined.mli
+++ b/jscomp/others/js_null_undefined.mli
@@ -47,7 +47,7 @@ external undefined : 'a t = "#undefined"
 If ['a Js.null_undefined] contains a value, that value is unwrapped, mapped to a ['b] using
 the given function [a' -> 'b], then wrapped back up and returned as ['b Js.null_undefined]
 
-@example {[
+{[
 let maybeGreetWorld (maybeGreeting: string Js.null_undefined) =
   Js.Undefined.bind maybeGreeting (fun greeting -> greeting ^ " world!")
 ]}
@@ -59,7 +59,7 @@ val bind : 'a t -> ('a -> 'b [@bs]) -> 'b t
 If ['a Js.null_undefined] contains a value, that value is unwrapped and applied to
 the given function.
 
-@example {[
+{[
 let maybeSay (maybeMessage: string Js.null_undefined) =
   Js.Null_undefined.iter maybeMessage (fun message -> Js.log message)
 ]}

--- a/jscomp/others/js_obj.ml
+++ b/jscomp/others/js_obj.ml
@@ -35,7 +35,7 @@ have the same key.
 
 {b Returns} [target]
 
-@example {[
+{[
 (* Copy an object *)
 
 let obj = [%obj { a = 1 }]
@@ -46,7 +46,7 @@ let copy = Js.Obj.assign (Js.Obj.empty ()) obj
 let _ = Js.log copy
 ]}
 
-@example {[
+{[
 (* Merge objects with same properties *)
 
 let target = [%obj { a = 1; b = 1; }]

--- a/jscomp/others/js_re.ml
+++ b/jscomp/others/js_re.ml
@@ -32,7 +32,7 @@ will evaluate to a {! t} that can be passed around and used like usual.
 flag set will modify the {! lastIndex} property when the RegExp object is used,
 and subsequent uses will ocntinue the search from the previous {! lastIndex}.
 
-@example {[
+{[
 let maybeMatches = "banana" |> Js.String.match_ [\[%re "/na+/g"\]]
 ]}
 
@@ -72,7 +72,7 @@ external input : result -> string = "input" [@@bs.get]
 Regex literals ([\[%re "/.../"\]]) should generally be preferred, but
 [fromString] is very useful when you need to insert a string into a regex.
 
-@example {[
+{[
 (* A function that extracts the content of the first element with the given tag *)
 
 let contentOf tag xmlString =
@@ -116,7 +116,7 @@ external ignoreCase : t -> bool = "ignoreCase" [@@bs.get]
 This property will be modified when the RegExp object is used, if the [global] ("g")
 flag is set.
 
-@example {[
+{[
 (* Finds and prints successive matches *)
 
 let re = [%re "/ab*/g"] in
@@ -156,7 +156,7 @@ external unicode : t -> bool = "unicode" [@@bs.get]
 
 {b returns} [Some] {! result} if a match is found, [None] otherwise
 
-@example {[
+{[
 (* Match "quick brown" followed by "jumps", ignoring characters in between
  * Remember "brown" and "jumps"
  * Ignore case
@@ -178,7 +178,7 @@ external exec : string -> result option = "exec" [@@bs.send.pipe: t] [@@bs.retur
 
 {b returns} [true] if a match is found, [false] otherwise
 
-@example {[
+{[
 (* A simple implementation of Js.String.startsWith *)
 
 let str = "hello world!"

--- a/jscomp/others/js_string.ml
+++ b/jscomp/others/js_string.ml
@@ -28,7 +28,7 @@ type t = string
 
 (** [make value] converts the given value to a string
 
-@example {[
+{[
   make 3.5 = "3.5";;
   make [|1;2;3|]) = "1,2,3";;
 ]}
@@ -38,7 +38,7 @@ external make : 'a -> t = "String" [@@bs.val]
 (** [fromCharCode n]
   creates a string containing the character corresponding to that number; {i n} ranges from 0 to 65535. If out of range, the lower 16 bits of the value are used. Thus, [fromCharCode 0x1F63A] gives the same result as [fromCharCode 0xF63A].
 
-@example {[
+{[
   fromCharCode 65 = "A";;
   fromCharCode 0x3c8 = {js|ψ|js};;
   fromCharCode 0xd55c = {js|한|js};;
@@ -50,7 +50,7 @@ external fromCharCode : int -> t = "String.fromCharCode" [@@bs.val]
 external fromCharCodeMany : int array -> t = "String.fromCharCode" [@@bs.val] [@@bs.splice]
 (** [fromCharCodeMany \[|n1;n2;n3|\]] creates a string from the characters corresponding to the given numbers, using the same rules as [fromCharCode].
 
-@example {[
+{[
   fromCharCodeMany([|0xd55c, 0xae00, 33|]) = {js|한글!|js};;
 ]}
 *)
@@ -58,7 +58,7 @@ external fromCharCodeMany : int array -> t = "String.fromCharCode" [@@bs.val] [@
 (** [fromCodePoint n]
   creates a string containing the character corresponding to that numeric code point. If the number is not a valid code point, {b raises} [RangeError]. Thus, [fromCodePoint 0x1F63A] will produce a correct value, unlike [fromCharCode 0x1F63A], and [fromCodePoint -5] will raise a [RangeError].
 
-@example {[
+{[
   fromCodePoint 65 = "A";;
   fromCodePoint 0x3c8 = {js|ψ|js};;
   fromCodePoint 0xd55c = {js|한|js};;
@@ -70,7 +70,7 @@ external fromCodePoint : int -> t = "String.fromCodePoint" [@@bs.val] (** ES2015
 
 (** [fromCharCodeMany \[|n1;n2;n3|\]] creates a string from the characters corresponding to the given code point numbers, using the same rules as [fromCodePoint].
 
-@example {[
+{[
   fromCodePointMany([|0xd55c; 0xae00; 0x1f63a|]) = {js|한글😺|js}
 ]}
 *)
@@ -81,7 +81,7 @@ external fromCodePointMany : int array -> t = "String.fromCodePoint" [@@bs.val] 
 
 (** [length s] returns the length of the given string.
 
-@example {[
+{[
   length "abcd" = 4;;
 ]}
 
@@ -90,7 +90,7 @@ external length : t -> int = "length" [@@bs.get]
 
 (** [get s n] returns as a string the character at the given index number. If [n] is out of range, this function returns [undefined], so at some point this function may be modified to return [t option].
 
-@example {[
+{[
   get "Reason" 0 = "R";;
   get "Reason" 4 = "o";;
   get {js|Rẽasöń|js} 5 = {js|ń|js};;
@@ -100,7 +100,7 @@ external get : t -> int -> t = "" [@@bs.get_index]
 
 (** [charAt n s] gets the character at index [n] within string [s]. If [n] is negative or greater than the length of [s], returns the empty string. If the string contains characters outside the range [\u0000-\uffff], it will return the first 16-bit value at that position in the string.
 
-@example {[
+{[
   charAt 0, "Reason" = "R"
   charAt( 12, "Reason") = "";
   charAt( 5, {js|Rẽasöń|js} = {js|ń|js}
@@ -111,7 +111,7 @@ external charAt : int ->  t = "charAt" [@@bs.send.pipe: t]
 (** [charCodeAt n s] returns the character code at position [n] in string [s]; the result is in the range 0-65535, unlke [codePointAt], so it will not work correctly for characters with code points greater than or equal to [0x10000].
 The return type is [float] because this function returns [NaN] if [n] is less than zero or greater than the length of the string.
 
-@example {[
+{[
   charCodeAt 0 {js|😺|js} returns 0xd83d
   codePointAt 0 {js|😺|js} returns Some 0x1f63a
 ]}
@@ -121,7 +121,7 @@ external charCodeAt : int -> float  = "charCodeAt" [@@bs.send.pipe: t]
 
 (** [codePointAt n s] returns the code point at position [n] within string [s] as a [Some] value. The return value handles code points greater than or equal to [0x10000]. If there is no code point at the given position, the function returns [None].
 
-@example {[
+{[
   codePointAt 1 {js|¿😺?|js} = Some 0x1f63a
   codePointAt 5 "abc" = None
 ]}
@@ -130,7 +130,7 @@ external codePointAt : int -> int option = "codePointAt" [@@bs.send.pipe: t] (**
 
 (** [concat append original] returns a new string with [append] added after [original].
 
-@example {[
+{[
   concat "bell" "cow" = "cowbell";;
 ]}
 *)
@@ -138,7 +138,7 @@ external concat : t -> t = "concat" [@@bs.send.pipe: t]
 
 (** [concat arr original] returns a new string consisting of each item of an array of strings added to the [original] string.
 
-@example {[
+{[
   concatMany [|"2nd"; "3rd"; "4th"|] "1st" = "1st2nd3rd4th";;
 ]}
 *)
@@ -147,7 +147,7 @@ external concatMany : t array -> t = "concat" [@@bs.send.pipe: t] [@@bs.splice]
 (** ES2015:
     [endsWith substr str] returns [true] if the [str] ends with [substr], [false] otherwise.
 
-@example {[
+{[
   endsWith "Script" "ReScript" = true;;
   endsWith "Script" "ReShoes" = false;;
 ]}
@@ -156,7 +156,7 @@ external endsWith : t -> bool = "endsWith" [@@bs.send.pipe: t]
 
 (** [endsWithFrom ending len str] returns [true] if the first [len] characters of [str] end with [ending], [false] otherwise. If [n] is greater than or equal to the length of [str], then it works like [endsWith]. (Honestly, this should have been named [endsWithAt], but oh well.)
 
-@example {[
+{[
   endsWithFrom "cd" 4 "abcd" = true;;
   endsWithFrom "cd" 3 "abcde" = false;;
   endsWithFrom "cde" 99 "abcde" = true;;
@@ -168,7 +168,7 @@ external endsWithFrom : t -> int -> bool = "endsWith" [@@bs.send.pipe: t] (** ES
 (**
   [includes searchValue s] returns [true] if [searchValue] is found anywhere within [s], [false] otherwise.
 
-@example {[
+{[
   includes "gram" "programmer" = true;;
   includes "er" "programmer" = true;;
   includes "pro" "programmer" = true;;
@@ -180,7 +180,7 @@ external includes : t -> bool = "includes" [@@bs.send.pipe: t] (** ES2015 *)
 (**
   [includes searchValue start s] returns [true] if [searchValue] is found anywhere within [s] starting at character number [start] (where 0 is the first character), [false] otherwise.
 
-@example {[
+{[
   includesFrom "gram" 1 "programmer" = true;;
   includesFrom "gram" 4 "programmer" = false;;
   includesFrom {js|한|js} 1 {js|대한민국|js} = true;;
@@ -191,7 +191,7 @@ external includesFrom : t -> int -> bool = "includes" [@@bs.send.pipe: t] (** ES
 (**
   [indexOf searchValue s] returns the position at which [searchValue] was first found within [s], or [-1] if [searchValue] is not in [s].
 
-@example {[
+{[
   indexOf "ok" "bookseller" = 2;;
   indexOf "sell" "bookseller" = 4;;
   indexOf "ee" "beekeeper" = 1;;
@@ -203,7 +203,7 @@ external indexOf : t -> int = "indexOf" [@@bs.send.pipe: t]
 (**
   [indexOfFrom searchValue start s] returns the position at which [searchValue] was found within [s] starting at character position [start], or [-1] if [searchValue] is not found in that portion of [s]. The return value is relative to the beginning of the string, no matter where the search started from.
 
-@example {[
+{[
   indexOfFrom "ok" 1 "bookseller" = 2;;
   indexOfFrom "sell" 2 "bookseller" = 4;;
   indexOfFrom "sell" 5 "bookseller" = -1;;
@@ -215,7 +215,7 @@ external indexOfFrom : t -> int -> int = "indexOf" [@@bs.send.pipe: t]
 (**
   [lastIndexOf searchValue s] returns the position of the {i last} occurrence of [searchValue] within [s], searching backwards from the end of the string. Returns [-1] if [searchValue] is not in [s]. The return value is always relative to the beginning of the string.
 
-@example {[
+{[
   lastIndexOf "ok" "bookseller" = 2;;
   lastIndexOf "ee" "beekeeper" = 4;;
   lastIndexOf "xyz" "abcdefg" = -1;;
@@ -226,7 +226,7 @@ external lastIndexOf : t -> int = "lastIndexOf" [@@bs.send.pipe: t]
 (**
   [lastIndexOfFrom searchValue start s] returns the position of the {i last} occurrence of [searchValue] within [s], searching backwards from the given [start] position. Returns [-1] if [searchValue] is not in [s]. The return value is always relative to the beginning of the string.
 
-@example {[
+{[
   lastIndexOfFrom "ok" 6 "bookseller" = 2;;
   lastIndexOfFrom "ee" 8 "beekeeper" = 4;;
   lastIndexOfFrom "ee" 3 "beekeeper" = 1;;
@@ -245,7 +245,7 @@ external lastIndexOfFrom : t -> int -> int = "lastIndexOf" [@@bs.send.pipe: t]
   {- zero if [reference] and [comparison] have the same sort order}
   {- a positive value if [reference] comes after [comparison] in sort order}}
 
-@example {[
+{[
   (localeCompare "ant" "zebra") > 0.0;;
   (localeCompare "zebra" "ant") < 0.0;;
   (localeCompare "cat" "cat") = 0.0;;
@@ -265,7 +265,7 @@ external localeCompare : t -> float = "localeCompare" [@@bs.send.pipe: t]
 
   For regular expressions with the [g] modifier, a matched expression returns [Some array] with all the matched substrings and no capture groups.
 
-@example {[
+{[
   match [%re "/b[aeiou]t/"] "The better bats" = Some [|"bet"|]
   match [%re "/b[aeiou]t/g"] "The better bats" = Some [|"bet";"bat"|]
   match [%re "/(\\d+)-(\\d+)-(\\d+)/"] "Today is 2018-04-05." =
@@ -301,7 +301,7 @@ external normalizeByForm : t -> t = "normalize" [@@bs.send.pipe: t]
 (**
   [repeat n s] returns a string that consists of [n] repetitions of [s]. Raises [RangeError] if [n] is negative.
 
-@example {[
+{[
   repeat 3 "ha" = "hahaha"
   repeat 0 "empty" = ""
 ]}
@@ -315,7 +315,7 @@ replaced by [newSubstr].
 [substr] is treated as a verbatim string to match, not a regular
 expression.
 
-@example {[
+{[
   replace "old" "new" "old string" = "new string"
   replace "the" "this" "the cat and the dog" = "this cat and the dog"
 ]}
@@ -325,7 +325,7 @@ external replace : t ->  t ->  t = "replace" [@@bs.send.pipe: t]
 (** [replaceByRe regex replacement string] returns a new string where occurrences matching [regex]
 have been replaced by [replacement].
 
-@example {[
+{[
   replaceByRe [%re "/[aeiou]/g"] "x" "vowels be gone" = "vxwxls bx gxnx"
   replaceByRe [%re "/(\\w+) (\\w+)/"] "$2, $1" "Juan Fulano" = "Fulano, Juan"
 ]}
@@ -337,7 +337,7 @@ parentheses replaced by the value returned from the given function.
 The function receives as its parameters the matched string, the offset at which the
 match begins, and the whole string being matched
 
-@example {[
+{[
 let str = "beautiful vowels"
 let re = [%re "/[aeiou]/g"]
 let matchFn matchPart offset wholeString =
@@ -357,7 +357,7 @@ parentheses replaced by the value returned from the given function.
 The function receives as its parameters the matched string, the captured string,
 the offset at which the match begins, and the whole string being matched.
 
-@example {[
+{[
 let str = "increment 23"
 let re = [%re "/increment (\\d+)/g"]
 let matchFn matchPart p1 offset wholeString =
@@ -377,7 +377,7 @@ parentheses replaced by the value returned from the given function.
 The function receives as its parameters the matched string, the captured strings,
 the offset at which the match begins, and the whole string being matched.
 
-@example {[
+{[
 let str = "7 times 6"
 let re = [%re "/(\\d+) times (\\d+)/"]
 let matchFn matchPart p1 p2 offset wholeString =
@@ -403,7 +403,7 @@ external unsafeReplaceBy3 : Js_re.t -> (t -> t -> t -> t -> int -> t -> t [@bs.u
 
 (** [search regexp str] returns the starting position of the first match of [regexp] in the given [str], or -1 if there is no match.
 
-@example {[
+{[
 search [%re "/\\d+/"] "testing 1 2 3" = 8;;
 search [%re "/\\d+/"] "no numbers" = -1;;
 ]}
@@ -418,7 +418,7 @@ If [n2] is greater than the length of [str], then it is treated as [length str].
 
 If [n1] is greater than [n2], [slice] returns the empty string.
 
-@example {[
+{[
   slice ~from:2 ~to_:5 "abcdefg" == "cde";;
   slice ~from:2 ~to_:9 "abcdefg" == "cdefg";;
   slice ~from:(-4) ~to_:(-2) "abcdefg" == "de";;
@@ -433,7 +433,7 @@ If [n] is negative, then it is evaluated as [length str - n].
 
 If [n] is greater than the length of [str], then [sliceToEnd] returns the empty string.
 
-@example {[
+{[
   sliceToEnd ~from: 4 "abcdefg" == "efg";;
   sliceToEnd ~from: (-2) "abcdefg" == "fg";;
   sliceToEnd ~from: 7 "abcdefg" == "";;
@@ -445,7 +445,7 @@ external sliceToEnd : from:int ->  t = "slice" [@@bs.send.pipe: t]
   [split delimiter str] splits the given [str] at every occurrence of [delimiter] and returns an
   array of the resulting substrings.
 
-@example {[
+{[
   split "-" "2018-01-02" = [|"2018"; "01"; "02"|];;
   split "," "a,b,,c" = [|"a"; "b"; ""; "c"|];;
   split "::" "good::bad as great::awful" = [|"good"; "bad as great"; "awful"|];;
@@ -457,7 +457,7 @@ external split : t -> t array  = "split" [@@bs.send.pipe: t]
 (**
   [splitAtMost delimiter ~limit: n str] splits the given [str] at every occurrence of [delimiter] and returns an array of the first [n] resulting substrings. If [n] is negative or greater than the number of substrings, the array will contain all the substrings.
 
-@example {[
+{[
   splitAtMost "/" ~limit: 3 "ant/bee/cat/dog/elk" = [|"ant"; "bee"; "cat"|];;
   splitAtMost "/" ~limit: 0 "ant/bee/cat/dog/elk" = [| |];;
   splitAtMost "/" ~limit: 9 "ant/bee/cat/dog/elk" = [|"ant"; "bee"; "cat"; "dog"; "elk"|];;
@@ -475,7 +475,7 @@ external splitLimited : t -> int -> t array = "split" [@@bs.send.pipe: t]
   [splitByRe regex str] splits the given [str] at every occurrence of [regex] and returns an
   array of the resulting substrings.
 
-@example {[
+{[
   splitByRe [%re "/\\s*[,;]\\s*/"] "art; bed , cog ;dad" = [|Some "art"; Some "bed"; Some "cog"; Some "dad"|];;
   splitByRe [%re "/[,;]/"] "has:no:match" = [|Some "has:no:match"|];;
   splitByRe [%re "/(#)(:)?/"] "a#b#:c" = [|Some "a"; Some "#"; None; Some "b"; Some "#"; Some ":"; Some "c"|];;
@@ -487,7 +487,7 @@ external splitByRe : Js_re.t ->  t option array = "split" [@@bs.send.pipe: t]
   [splitByReAtMost regex ~limit: n str] splits the given [str] at every occurrence of [regex] and returns an
   array of the first [n] resulting substrings. If [n] is negative or greater than the number of substrings, the array will contain all the substrings.
 
-@example {[
+{[
   splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 3 "one: two: three: four" = [|Some "one"; Some "two"; Some "three"|];;
   splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 0 "one: two: three: four" = [| |];;
   splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 8 "one: two: three: four" = [|Some "one"; Some "two"; Some "three"; Some "four"|];;
@@ -505,7 +505,7 @@ external splitRegexpLimited : Js_re.t -> int ->  t array = "split" [@@bs.send.pi
 (** ES2015:
     [startsWith substr str] returns [true] if the [str] starts with [substr], [false] otherwise.
 
-@example {[
+{[
   startsWith "Re" "ReScript" = true;;
   startsWith "" "ReScript" = true;;
   startsWith "Re" "JavaScript" = false;;
@@ -516,7 +516,7 @@ external startsWith : t -> bool = "startsWith" [@@bs.send.pipe: t]
 (** ES2015:
     [startsWithFrom substr n str] returns [true] if the [str] starts with [substr] starting at position [n], [false] otherwise. If [n] is negative, the search starts at the beginning of [str].
 
-@example {[
+{[
   startsWithFrom "cri" 3 "ReScript" = true;;
   startsWithFrom "" 3 "ReScript" = true;;
   startsWithFrom "Re" 2 "JavaScript" = false;;
@@ -531,7 +531,7 @@ external startsWithFrom : t -> int -> bool = "startsWith" [@@bs.send.pipe: t]
 
   If [n] is greater than or equal to the length of [str], returns the empty string.
 
-@example {[
+{[
   substr ~from: 3 "abcdefghij" = "defghij"
   substr ~from: (-3) "abcdefghij" = "hij"
   substr ~from: 12 "abcdefghij" = ""
@@ -548,7 +548,7 @@ external substr : from:int -> t = "substr" [@@bs.send.pipe: t]
 
   If [n] is less than or equal to zero, returns the empty string.
 
-@example {[
+{[
   substrAtMost ~from: 3 ~length: 4 "abcdefghij" = "defghij"
   substrAtMost ~from: (-3) ~length: 4 "abcdefghij" = "hij"
   substrAtMost ~from: 12 ~ length: 2 "abcdefghij" = ""
@@ -565,7 +565,7 @@ external substrAtMost : from:int -> length:int -> t = "substr" [@@bs.send.pipe: 
 
   If [start] is greater than [finish], the start and finish points are swapped.
 
-@example {[
+{[
   substring ~from: 3 ~to_: 6 "playground" = "ygr";;
   substring ~from: 6 ~to_: 3 "playground" = "ygr";;
   substring ~from: 4 ~to_: 12 "playground" = "ground";;
@@ -580,7 +580,7 @@ external substring : from:int -> to_:int ->  t = "substring" [@@bs.send.pipe: t]
 
   If [start] is greater than or equal to the length of [str], the empty string is returned.
 
-@example {[
+{[
   substringToEnd ~from: 4 "playground" = "ground";;
   substringToEnd ~from: (-3) "playground" = "playground";;
   substringToEnd ~from: 12 "playground" = "";
@@ -591,7 +591,7 @@ external substringToEnd : from:int ->  t = "substring" [@@bs.send.pipe: t]
 (**
   [toLowerCase str] converts [str] to lower case using the locale-insensitive case mappings in the Unicode Character Database. Notice that the conversion can give different results depending upon context, for example with the Greek letter sigma, which has two different lower case forms when it is the last character in a string or not.
 
-@example {[
+{[
   toLowerCase "ABC" = "abc";;
   toLowerCase {js|ΣΠ|js} = {js|σπ|js};;
   toLowerCase {js|ΠΣ|js} = {js|πς|js};;
@@ -607,7 +607,7 @@ external toLocaleLowerCase : t = "toLocaleLowerCase" [@@bs.send.pipe: t]
 (**
   [toUpperCase str] converts [str] to upper case using the locale-insensitive case mappings in the Unicode Character Database. Notice that the conversion can expand the number of letters in the result; for example the German [ß] capitalizes to two [S]es in a row.
 
-@example {[
+{[
   toUpperCase "abc" = "ABC";;
   toUpperCase {js|Straße|js} = {js|STRASSE|js};;
   toLowerCase {js|πς|js} = {js|ΠΣ|js};;
@@ -623,7 +623,7 @@ external toLocaleUpperCase : t = "toLocaleUpperCase" [@@bs.send.pipe: t]
 (**
   [trim str] returns a string that is [str] with whitespace stripped from both ends. Internal whitespace is not removed.
 
-@example {[
+{[
   trim "   abc def   " = "abc def"
   trim "\n\r\t abc def \n\n\t\r " = "abc def"
 ]}
@@ -635,7 +635,7 @@ external trim : t = "trim" [@@bs.send.pipe: t]
 (**
   [anchor anchorName anchorText] creates a string with an HTML [<a>] element with [name] attribute of [anchorName] and [anchorText] as its content.
 
-@example {[
+{[
   anchor "page1" "Page One" = "<a name=\"page1\">Page One</a>"
 ]}
 *)
@@ -644,7 +644,7 @@ external anchor : t -> t = "anchor" [@@bs.send.pipe: t] (** ES2015 *)
 (**
   [link urlText linkText] creates a string withan HTML [<a>] element with [href] attribute of [urlText] and [linkText] as its content.
 
-@example {[
+{[
   link "page2.html" "Go to page two" = "<a href=\"page2.html\">Go to page two</a>"
 ]}
 *)

--- a/jscomp/others/js_string2.ml
+++ b/jscomp/others/js_string2.ml
@@ -28,7 +28,7 @@ type t = string
 
 (** [make value] converts the given value to a string
 
-@example {[
+{[
   make 3.5 = "3.5";;
   make [|1;2;3|]) = "1,2,3";;
 ]}
@@ -38,7 +38,7 @@ external make : 'a -> t = "String" [@@bs.val]
 (** [fromCharCode n]
   creates a string containing the character corresponding to that number; {i n} ranges from 0 to 65535. If out of range, the lower 16 bits of the value are used. Thus, [fromCharCode 0x1F63A] gives the same result as [fromCharCode 0xF63A].
 
-@example {[
+{[
   fromCharCode 65 = "A";;
   fromCharCode 0x3c8 = {js|ψ|js};;
   fromCharCode 0xd55c = {js|한|js};;
@@ -50,7 +50,7 @@ external fromCharCode : int -> t = "String.fromCharCode" [@@bs.val]
 external fromCharCodeMany : int array -> t = "String.fromCharCode" [@@bs.val] [@@bs.splice]
 (** [fromCharCodeMany \[|n1;n2;n3|\]] creates a string from the characters corresponding to the given numbers, using the same rules as [fromCharCode].
 
-@example {[
+{[
   fromCharCodeMany([|0xd55c, 0xae00, 33|]) = {js|한글!|js};;
 ]}
 *)
@@ -58,7 +58,7 @@ external fromCharCodeMany : int array -> t = "String.fromCharCode" [@@bs.val] [@
 (** [fromCodePoint n]
   creates a string containing the character corresponding to that numeric code point. If the number is not a valid code point, {b raises} [RangeError]. Thus, [fromCodePoint 0x1F63A] will produce a correct value, unlike [fromCharCode 0x1F63A], and [fromCodePoint -5] will raise a [RangeError].
 
-@example {[
+{[
   fromCodePoint 65 = "A";;
   fromCodePoint 0x3c8 = {js|ψ|js};;
   fromCodePoint 0xd55c = {js|한|js};;
@@ -70,7 +70,7 @@ external fromCodePoint : int -> t = "String.fromCodePoint" [@@bs.val] (** ES2015
 
 (** [fromCharCodeMany \[|n1;n2;n3|\]] creates a string from the characters corresponding to the given code point numbers, using the same rules as [fromCodePoint].
 
-@example {[
+{[
   fromCodePointMany([|0xd55c; 0xae00; 0x1f63a|]) = {js|한글😺|js}
 ]}
 *)
@@ -81,7 +81,7 @@ external fromCodePointMany : int array -> t = "String.fromCodePoint" [@@bs.val] 
 
 (** [length s] returns the length of the given string.
 
-@example {[
+{[
   length "abcd" = 4;;
 ]}
 
@@ -90,7 +90,7 @@ external length : t -> int = "length" [@@bs.get]
 
 (** [get s n] returns as a string the character at the given index number. If [n] is out of range, this function returns [undefined], so at some point this function may be modified to return [t option].
 
-@example {[
+{[
   get "Reason" 0 = "R";;
   get "Reason" 4 = "o";;
   get {js|Rẽasöń|js} 5 = {js|ń|js};;
@@ -100,7 +100,7 @@ external get : t -> int -> t = "" [@@bs.get_index]
 
 (** [charAt n s] gets the character at index [n] within string [s]. If [n] is negative or greater than the length of [s], returns the empty string. If the string contains characters outside the range [\u0000-\uffff], it will return the first 16-bit value at that position in the string.
 
-@example {[
+{[
   charAt "Reason" 0 = "R"
   charAt "Reason" 12 = "";
   charAt {js|Rẽasöń|js} 5 = {js|ń|js}
@@ -111,7 +111,7 @@ external charAt : t -> int -> t = "charAt" [@@bs.send]
 (** [charCodeAt n s] returns the character code at position [n] in string [s]; the result is in the range 0-65535, unlke [codePointAt], so it will not work correctly for characters with code points greater than or equal to [0x10000].
 The return type is [float] because this function returns [NaN] if [n] is less than zero or greater than the length of the string.
 
-@example {[
+{[
   charCodeAt {js|😺|js} 0 returns 0xd83d
   codePointAt {js|😺|js} 0 returns Some 0x1f63a
 ]}
@@ -121,7 +121,7 @@ external charCodeAt : t -> int -> float = "charCodeAt" [@@bs.send]
 
 (** [codePointAt n s] returns the code point at position [n] within string [s] as a [Some] value. The return value handles code points greater than or equal to [0x10000]. If there is no code point at the given position, the function returns [None].
 
-@example {[
+{[
   codePointAt {js|¿😺?|js} 1 = Some 0x1f63a
   codePointAt "abc" 5 = None
 ]}
@@ -130,7 +130,7 @@ external codePointAt : t -> int -> int option = "codePointAt" [@@bs.send]  (** E
 
 (** [concat append original] returns a new string with [append] added after [original].
 
-@example {[
+{[
   concat "cow" "bell" = "cowbell";;
 ]}
 *)
@@ -138,7 +138,7 @@ external concat : t -> t -> t = "concat" [@@bs.send]
 
 (** [concat arr original] returns a new string consisting of each item of an array of strings added to the [original] string.
 
-@example {[
+{[
   concatMany "1st" [|"2nd"; "3rd"; "4th"|] = "1st2nd3rd4th";;
 ]}
 *)
@@ -147,7 +147,7 @@ external concatMany : t -> t array -> t = "concat" [@@bs.send] [@@bs.splice]
 (** ES2015:
     [endsWith substr str] returns [true] if the [str] ends with [substr], [false] otherwise.
 
-@example {[
+{[
   endsWith "ReScript" "Script" = true;;
   endsWith "ReShoes" "Script" = false;;
 ]}
@@ -156,7 +156,7 @@ external endsWith : t -> t -> bool = "endsWith" [@@bs.send]
 
 (** [endsWithFrom ending len str] returns [true] if the first [len] characters of [str] end with [ending], [false] otherwise. If [n] is greater than or equal to the length of [str], then it works like [endsWith]. (Honestly, this should have been named [endsWithAt], but oh well.)
 
-@example {[
+{[
   endsWithFrom "abcd" "cd" 4 = true;;
   endsWithFrom "abcde" "cd" 3 = false;;
   endsWithFrom "abcde" "cde" 99 = true;;
@@ -168,7 +168,7 @@ external endsWithFrom : t -> t -> int -> bool = "endsWith" [@@bs.send] (** ES201
 (**
   [includes searchValue s] returns [true] if [searchValue] is found anywhere within [s], [false] otherwise.
 
-@example {[
+{[
   includes "programmer" "gram" = true;;
   includes "programmer" "er" = true;;
   includes "programmer" "pro" = true;;
@@ -180,7 +180,7 @@ external includes : t -> t -> bool = "includes" [@@bs.send] (** ES2015 *)
 (**
   [includes searchValue start s] returns [true] if [searchValue] is found anywhere within [s] starting at character number [start] (where 0 is the first character), [false] otherwise.
 
-@example {[
+{[
   includesFrom "programmer" "gram" 1 = true;;
   includesFrom "programmer" "gram" 4 = false;;
   includesFrom {js|대한민국|js} {js|한|js} 1 = true;;
@@ -191,7 +191,7 @@ external includesFrom : t -> t -> int -> bool = "includes" [@@bs.send] (** ES201
 (**
   [indexOf searchValue s] returns the position at which [searchValue] was first found within [s], or [-1] if [searchValue] is not in [s].
 
-@example {[
+{[
   indexOf "bookseller" "ok" = 2;;
   indexOf "bookseller" "sell" = 4;;
   indexOf "beekeeper" "ee" = 1;;
@@ -203,7 +203,7 @@ external indexOf : t -> t -> int = "indexOf" [@@bs.send]
 (**
   [indexOfFrom searchValue start s] returns the position at which [searchValue] was found within [s] starting at character position [start], or [-1] if [searchValue] is not found in that portion of [s]. The return value is relative to the beginning of the string, no matter where the search started from.
 
-@example {[
+{[
   indexOfFrom "bookseller" "ok" 1 = 2;;
   indexOfFrom "bookseller" "sell" 2 = 4;;
   indexOfFrom "bookseller" "sell" 5 = -1;;
@@ -215,7 +215,7 @@ external indexOfFrom : t -> t -> int -> int = "indexOf" [@@bs.send]
 (**
   [lastIndexOf searchValue s] returns the position of the {i last} occurrence of [searchValue] within [s], searching backwards from the end of the string. Returns [-1] if [searchValue] is not in [s]. The return value is always relative to the beginning of the string.
 
-@example {[
+{[
   lastIndexOf "bookseller" "ok" = 2;;
   lastIndexOf "beekeeper" "ee" = 4;;
   lastIndexOf "abcdefg" "xyz" = -1;;
@@ -226,7 +226,7 @@ external lastIndexOf : t -> t -> int = "lastIndexOf" [@@bs.send]
 (**
   [lastIndexOfFrom searchValue start s] returns the position of the {i last} occurrence of [searchValue] within [s], searching backwards from the given [start] position. Returns [-1] if [searchValue] is not in [s]. The return value is always relative to the beginning of the string.
 
-@example {[
+{[
   lastIndexOfFrom "bookseller" "ok" 6 = 2;;
   lastIndexOfFrom "beekeeper" "ee" 8 = 4;;
   lastIndexOfFrom "beekeeper" "ee" 3 = 1;;
@@ -245,7 +245,7 @@ external lastIndexOfFrom : t -> t -> int -> int = "lastIndexOf" [@@bs.send]
   {- zero if [reference] and [comparison] have the same sort order}
   {- a positive value if [reference] comes after [comparison] in sort order}}
 
-@example {[
+{[
   (localeCompare "zebra" "ant") > 0.0;;
   (localeCompare "ant" "zebra") < 0.0;;
   (localeCompare "cat" "cat") = 0.0;;
@@ -265,7 +265,7 @@ external localeCompare : t -> t -> float = "localeCompare" [@@bs.send]
 
   For regular expressions with the [g] modifier, a matched expression returns [Some array] with all the matched substrings and no capture groups.
 
-@example {[
+{[
   match "The better bats" [%re "/b[aeiou]t/"] = Some [|"bet"|]
   match "The better bats" [%re "/b[aeiou]t/g"] = Some [|"bet";"bat"|]
   match "Today is 2018-04-05." [%re "/(\\d+)-(\\d+)-(\\d+)/"] = Some [|"2018-04-05"; "2018"; "04"; "05"|]
@@ -300,7 +300,7 @@ external normalizeByForm : t -> t -> t = "normalize" [@@bs.send]
 (**
   [repeat n s] returns a string that consists of [n] repetitions of [s]. Raises [RangeError] if [n] is negative.
 
-@example {[
+{[
   repeat "ha" 3 = "hahaha"
   repeat "empty" 0 = ""
 ]}
@@ -314,7 +314,7 @@ replaced by [newSubstr].
 [substr] is treated as a verbatim string to match, not a regular
 expression.
 
-@example {[
+{[
   replace "old string" "old" "new" = "new string"
   replace "the cat and the dog" "the" "this" = "this cat and the dog"
 ]}
@@ -324,7 +324,7 @@ external replace : t -> t -> t -> t = "replace" [@@bs.send]
 (** [replaceByRe regex replacement string] returns a new string where occurrences matching [regex]
 have been replaced by [replacement].
 
-@example {[
+{[
   replaceByRe "vowels be gone" [%re "/[aeiou]/g"] "x" = "vxwxls bx gxnx"
   replaceByRe "Juan Fulano" [%re "/(\\w+) (\\w+)/"] "$2, $1" = "Fulano, Juan"
 ]}
@@ -336,7 +336,7 @@ parentheses replaced by the value returned from the given function.
 The function receives as its parameters the matched string, the offset at which the
 match begins, and the whole string being matched
 
-@example {[
+{[
 let str = "beautiful vowels"
 let re = [%re "/[aeiou]/g"]
 let matchFn matchPart offset wholeString =
@@ -356,7 +356,7 @@ parentheses replaced by the value returned from the given function.
 The function receives as its parameters the matched string, the captured string,
 the offset at which the match begins, and the whole string being matched.
 
-@example {[
+{[
 let str = "increment 23"
 let re = [%re "/increment (\\d+)/g"]
 let matchFn matchPart p1 offset wholeString =
@@ -376,7 +376,7 @@ parentheses replaced by the value returned from the given function.
 The function receives as its parameters the matched string, the captured strings,
 the offset at which the match begins, and the whole string being matched.
 
-@example {[
+{[
 let str = "7 times 6"
 let re = [%re "/(\\d+) times (\\d+)/"]
 let matchFn matchPart p1 p2 offset wholeString =
@@ -402,7 +402,7 @@ external unsafeReplaceBy3 : t -> Js_re.t -> (t -> t -> t -> t -> int -> t -> t [
 
 (** [search regexp str] returns the starting position of the first match of [regexp] in the given [str], or -1 if there is no match.
 
-@example {[
+{[
 search "testing 1 2 3" [%re "/\\d+/"] = 8;;
 search "no numbers" [%re "/\\d+/"] = -1;;
 ]}
@@ -417,7 +417,7 @@ If [n2] is greater than the length of [str], then it is treated as [length str].
 
 If [n1] is greater than [n2], [slice] returns the empty string.
 
-@example {[
+{[
   slice "abcdefg" ~from:2 ~to_:5 == "cde";;
   slice "abcdefg" ~from:2 ~to_:9 == "cdefg";;
   slice "abcdefg" ~from:(-4) ~to_:(-2) == "de";;
@@ -432,7 +432,7 @@ If [n] is negative, then it is evaluated as [length str - n].
 
 If [n] is greater than the length of [str], then [sliceToEnd] returns the empty string.
 
-@example {[
+{[
   sliceToEnd "abcdefg" ~from: 4 == "efg";;
   sliceToEnd "abcdefg" ~from: (-2) == "fg";;
   sliceToEnd "abcdefg" ~from: 7 == "";;
@@ -444,7 +444,7 @@ external sliceToEnd : t -> from:int ->  t = "slice" [@@bs.send]
   [split delimiter str] splits the given [str] at every occurrence of [delimiter] and returns an
   array of the resulting substrings.
 
-@example {[
+{[
   split "2018-01-02" "-" = [|"2018"; "01"; "02"|];;
   split "a,b,,c" "," = [|"a"; "b"; ""; "c"|];;
   split "good::bad as great::awful" "::" = [|"good"; "bad as great"; "awful"|];;
@@ -456,7 +456,7 @@ external split : t -> t -> t array  = "split" [@@bs.send]
 (**
   [splitAtMost delimiter ~limit: n str] splits the given [str] at every occurrence of [delimiter] and returns an array of the first [n] resulting substrings. If [n] is negative or greater than the number of substrings, the array will contain all the substrings.
 
-@example {[
+{[
   splitAtMost "ant/bee/cat/dog/elk" "/" ~limit: 3 = [|"ant"; "bee"; "cat"|];;
   splitAtMost "ant/bee/cat/dog/elk" "/" ~limit: 0 = [| |];;
   splitAtMost "ant/bee/cat/dog/elk" "/" ~limit: 9 = [|"ant"; "bee"; "cat"; "dog"; "elk"|];;
@@ -468,7 +468,7 @@ external splitAtMost: t -> t -> limit:int -> t array = "split" [@@bs.send]
   [splitByRe regex str] splits the given [str] at every occurrence of [regex] and returns an
   array of the resulting substrings.
 
-@example {[
+{[
   splitByRe "art; bed , cog ;dad" [%re "/\\s*[,;]\\s*/"] = [|"art"; "bed"; "cog"; "dad"|];;
   splitByRe "has:no:match" [%re "/[,;]/"] = [|"has:no:match"|];;
 ]};
@@ -479,7 +479,7 @@ external splitByRe : t -> Js_re.t -> t option array = "split" [@@bs.send]
   [splitByReAtMost regex ~limit: n str] splits the given [str] at every occurrence of [regex] and returns an
   array of the first [n] resulting substrings. If [n] is negative or greater than the number of substrings, the array will contain all the substrings.
 
-@example {[
+{[
   splitByReAtMost "one: two: three: four" [%re "/\\s*:\\s*/"] ~limit: 3 = [|"one"; "two"; "three"|];;
   splitByReAtMost "one: two: three: four" [%re "/\\s*:\\s*/"] ~limit: 0 = [| |];;
   splitByReAtMost "one: two: three: four" [%re "/\\s*:\\s*/"] ~limit: 8 = [|"one"; "two"; "three"; "four"|];;
@@ -490,7 +490,7 @@ external splitByReAtMost : t -> Js_re.t -> limit:int ->  t option array = "split
 (** ES2015:
     [startsWith substr str] returns [true] if the [str] starts with [substr], [false] otherwise.
 
-@example {[
+{[
   startsWith "ReScript" "Re" = true;;
   startsWith "ReScript" "" = true;;
   startsWith "JavaScript" "Re" = false;;
@@ -501,7 +501,7 @@ external startsWith : t -> t -> bool = "startsWith" [@@bs.send]
 (** ES2015:
     [startsWithFrom substr n str] returns [true] if the [str] starts with [substr] starting at position [n], [false] otherwise. If [n] is negative, the search starts at the beginning of [str].
 
-@example {[
+{[
   startsWithFrom "ReScript" "cri" 3 = true;;
   startsWithFrom "ReScript" "" 3 = true;;
   startsWithFrom "JavaScript" "Re" 2 = false;;
@@ -516,7 +516,7 @@ external startsWithFrom : t -> t -> int -> bool = "startsWith" [@@bs.send]
 
   If [n] is greater than or equal to the length of [str], returns the empty string.
 
-@example {[
+{[
   substr "abcdefghij" ~from: 3 = "defghij"
   substr "abcdefghij" ~from: (-3) = "hij"
   substr "abcdefghij" ~from: 12 = ""
@@ -533,7 +533,7 @@ external substr : t -> from:int -> t = "substr" [@@bs.send]
 
   If [n] is less than or equal to zero, returns the empty string.
 
-@example {[
+{[
   substrAtMost "abcdefghij" ~from: 3 ~length: 4 = "defghij"
   substrAtMost "abcdefghij" ~from: (-3) ~length: 4 = "hij"
   substrAtMost "abcdefghij" ~from: 12 ~ length: 2 = ""
@@ -550,7 +550,7 @@ external substrAtMost : t -> from:int -> length:int -> t = "substr" [@@bs.send]
 
   If [start] is greater than [finish], the start and finish points are swapped.
 
-@example {[
+{[
   substring "playground" ~from: 3 ~to_: 6 = "ygr";;
   substring "playground" ~from: 6 ~to_: 3 = "ygr";;
   substring "playground" ~from: 4 ~to_: 12 = "ground";;
@@ -565,7 +565,7 @@ external substring : t -> from:int -> to_:int ->  t = "substring" [@@bs.send]
 
   If [start] is greater than or equal to the length of [str], the empty string is returned.
 
-@example {[
+{[
   substringToEnd "playground" ~from: 4 = "ground";;
   substringToEnd "playground" ~from: (-3) = "playground";;
   substringToEnd "playground" ~from: 12 = "";
@@ -576,7 +576,7 @@ external substringToEnd : t -> from:int ->  t = "substring" [@@bs.send]
 (**
   [toLowerCase str] converts [str] to lower case using the locale-insensitive case mappings in the Unicode Character Database. Notice that the conversion can give different results depending upon context, for example with the Greek letter sigma, which has two different lower case forms when it is the last character in a string or not.
 
-@example {[
+{[
   toLowerCase "ABC" = "abc";;
   toLowerCase {js|ΣΠ|js} = {js|σπ|js};;
   toLowerCase {js|ΠΣ|js} = {js|πς|js};;
@@ -592,7 +592,7 @@ external toLocaleLowerCase : t -> t = "toLocaleLowerCase" [@@bs.send]
 (**
   [toUpperCase str] converts [str] to upper case using the locale-insensitive case mappings in the Unicode Character Database. Notice that the conversion can expand the number of letters in the result; for example the German [ß] capitalizes to two [S]es in a row.
 
-@example {[
+{[
   toUpperCase "abc" = "ABC";;
   toUpperCase {js|Straße|js} = {js|STRASSE|js};;
   toLowerCase {js|πς|js} = {js|ΠΣ|js};;
@@ -608,7 +608,7 @@ external toLocaleUpperCase : t -> t = "toLocaleUpperCase" [@@bs.send]
 (**
   [trim str] returns a string that is [str] with whitespace stripped from both ends. Internal whitespace is not removed.
 
-@example {[
+{[
   trim "   abc def   " = "abc def"
   trim "\n\r\t abc def \n\n\t\r " = "abc def"
 ]}
@@ -620,7 +620,7 @@ external trim : t -> t = "trim" [@@bs.send]
 (**
   [anchor anchorName anchorText] creates a string with an HTML [<a>] element with [name] attribute of [anchorName] and [anchorText] as its content.
 
-@example {[
+{[
   anchor "Page One" "page1" = "<a name=\"page1\">Page One</a>"
 ]}
 *)
@@ -629,7 +629,7 @@ external anchor : t -> t -> t = "anchor" [@@bs.send] (** ES2015 *)
 (**
   [link urlText linkText] creates a string withan HTML [<a>] element with [href] attribute of [urlText] and [linkText] as its content.
 
-@example {[
+{[
   link "Go to page two" "page2.html" = "<a href=\"page2.html\">Go to page two</a>"
 ]}
 *)

--- a/jscomp/others/js_types.mli
+++ b/jscomp/others/js_types.mli
@@ -53,7 +53,7 @@ type _ t =
 
 
 val test : 'a -> 'b t -> bool
-(** @example{[
+(** {[
   test "x" String = true
   ]}*)
 

--- a/jscomp/others/js_undefined.mli
+++ b/jscomp/others/js_undefined.mli
@@ -54,7 +54,7 @@ val getExn: 'a t -> 'a
 If ['a Js.undefined] contains a value, that value is unwrapped, mapped to a ['b] using
 the given function [a' -> 'b], then wrapped back up and returned as ['b Js.undefined]
 
-@example {[
+{[
 let maybeGreetWorld (maybeGreeting: string Js.undefined) =
   Js.Undefined.bind maybeGreeting (fun greeting -> greeting ^ " world!")
 ]}
@@ -66,7 +66,7 @@ val bind : 'a t -> ('a -> 'b [@bs]) -> 'b t
 If ['a Js.undefined] contains a value, that value is unwrapped and applied to
 the given function.
 
-@example {[
+{[
 let maybeSay (maybeMessage: string Js.undefined) =
   Js.Undefined.iter maybeMessage (fun message -> Js.log message)
 ]}

--- a/jscomp/others/map.cppo.mli
+++ b/jscomp/others/map.cppo.mli
@@ -28,7 +28,7 @@ val findFirstBy : 'v t -> (key -> 'v -> bool) -> (key * 'v) option
 (** [findFirstBy m p] uses funcion [f] to find the first key value pair
     to match predicate [p].
 
-    @example {[
+    {[
       let s0 = fromArray ~id:(module IntCmp) [|4,"4";1,"1";2,"2,"3""|];;
       findFirstBy s0 (fun k v -> k = 4 ) = option (4, "4");;
     ]}

--- a/jscomp/runtime/js.ml
+++ b/jscomp/runtime/js.ml
@@ -33,7 +33,7 @@
 (** This library provides bindings and necessary support for JS FFI.
     It contains all bindings into [Js] namespace.
 
-    @example {[
+    {[
       [| 1;2;3;4|]
       |. Js.Array2.map (fun x -> x + 1 )
       |. Js.Array2.reduce (+) 0


### PR DESCRIPTION
I noticed several sample snippets in code comments were using the `@example` directive, but I could not find anything about it on the [odoc documentation](https://ocaml.github.io/odoc/odoc_for_authors.html#tags). They only [mention](https://ocaml.github.io/odoc/odoc_for_authors.html#ocaml_code_blocks) regular `{[]}` blocks.

It's also rendered mostly as a string, as seen in the image below, which is weird.

This PR removes them.

<img width="852" alt="imagen" src="https://github.com/melange-re/melange/assets/220424/2c255bbf-8d00-4d4b-89ed-037459fb572a">