### PR TITLE
gitignore vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ _opam
 *.install
 .DS_Store
 
+.vscode
+
 node_modules
 lib/melange
 lib/es6


### PR DESCRIPTION
I added some vscode config after the vendoring of compiler-libs, so that vscode only tracks the main melange repository:

```json
{
  "git.ignoredRepositories": ["vendor/melange-compiler-libs"]
}
```

As this kind of setting choice might vary between contributors, i think the best is to ignore `.vscode` folder altogether.