### PR TITLE
melange ppx: fatal error when parsing %raw with callback

### DIFF
--- a/jscomp/frontend/melange_ppx.ml
+++ b/jscomp/frontend/melange_ppx.ml
@@ -323,6 +323,13 @@ module Obj = struct
 end
 
 let () =
+  let module Location = Ocaml_common.Location in
+  Location.register_error_of_exn (fun exn ->
+      match Melange_compiler_libs.Location.error_of_exn exn with
+      | Some (`Ok report) -> Some report
+      | None | Some `Already_displayed -> None)
+
+let () =
   Driver.add_arg "-unsafe"
     (Unit (fun () -> Ocaml_common.Clflags.unsafe := true))
     ~doc:"Do not compile bounds checking on array and string access";

--- a/test/melange-ppx-raw.t
+++ b/test/melange-ppx-raw.t
@@ -1,0 +1,33 @@
+Test to showcase fatal error when parsing a `raw` attribute that includes a function callback
+
+  $ . ./setup.sh
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (alias mel)
+  >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx)))
+  > EOF
+
+Simple %raw expressions work
+
+  $ cat > main.ml <<EOF
+  > let unsafeDeleteKey = [%raw "2"]
+  > EOF
+  $ dune build @mel
+
+Adding a callback breaks
+
+  $ cat > main.ml <<EOF
+  > let unsafeDeleteKey = [%raw fun _foo -> "2"]
+  > EOF
+  $ dune build @mel
+  File "dune", line 5, characters 13-30:
+  5 |  (preprocess (pps melange.ppx)))
+                   ^^^^^^^^^^^^^^^^^
+  Fatal error: exception Parsing0.Location.Error(_)
+  [1]

--- a/test/melange-ppx-raw.t
+++ b/test/melange-ppx-raw.t
@@ -26,8 +26,8 @@ Adding a callback breaks
   > let unsafeDeleteKey = [%raw fun _foo -> "2"]
   > EOF
   $ dune build @mel
-  File "dune", line 5, characters 13-30:
-  5 |  (preprocess (pps melange.ppx)))
-                   ^^^^^^^^^^^^^^^^^
-  Fatal error: exception Parsing0.Location.Error(_)
+  File "main.ml", line 1, characters 22-44:
+  1 | let unsafeDeleteKey = [%raw fun _foo -> "2"]
+                            ^^^^^^^^^^^^^^^^^^^^^^
+  Error: bs.raw can only be applied to a string
   [1]


### PR DESCRIPTION
Melange ppx throws when passing a function callback as payload of the `%raw` attribute.