### PR TITLE
chore: use default dune modes for executables

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,9 @@
+Unreleased
+---------------
+
+- melange: build executables for bytecode-only platforms too
+  ([#596](https://github.com/melange-re/melange/pull/596))
+
 1.0.0 2023-05-31
 ---------------
 

--- a/jscomp/main/dune
+++ b/jscomp/main/dune
@@ -1,7 +1,6 @@
 (executable
  (public_name melc)
  (package melange)
- (modes byte_complete native)
  (flags :standard -open Melange_compiler_libs)
  (libraries
   js_parser
@@ -19,7 +18,6 @@
 (executable
  (public_name melpp)
  (package melange)
- (modes native)
  (modules melpp)
  (flags :standard -open Melange_compiler_libs)
  (libraries common core cmdliner melange.ppxlib-ast melange_compiler_libs))
@@ -27,13 +25,11 @@
 (executable
  (public_name melppx)
  (package melange)
- (modes native)
  (modules melppx)
  (libraries melange.ppx ppxlib))
 
 (test
  (name ounit_tests_main)
  (package melange)
- (modes native)
  (modules ounit_tests_main)
  (libraries ounit2 ounit_tests))


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/23850#issuecomment-1571343049, @smorimoto mentioned some bytecode-only platforms were missing executables in the package installation.

This change allows those platforms to build too.