### PR TITLE
chore: update nix flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1685472234,
-        "narHash": "sha256-Yfkl4Hn9B6Q+CM75ywQSUut/Hm/UXRlF9TZKCaSYUjQ=",
+        "lastModified": 1685665183,
+        "narHash": "sha256-YmsFxOWhorabsNnCPzsx+WvY2VauTX6LmbAHsJ/k0+A=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "8e44447cb109db8d536b42be25dc40389eded32a",
+        "rev": "d79e9552bfdad421ee33c32e59f0e1582ddfe797",
         "type": "github"
       },
       "original": {
@@ -56,17 +56,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1685379691,
-        "narHash": "sha256-wBtVZ5Ry7CBVfdXthwMfIYMPII0/MLs1OEf9cqAp8Pk=",
+        "lastModified": 1685576448,
+        "narHash": "sha256-CaPA2UoHf4ydSZ3H3KIydVEojlb54GtrxYtPGHT5wfU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ad8dd62975cb44ed2f5d8a122f756529798bec5",
+        "rev": "a11f65c77752b5dd561e7453e1a603cf812a50b5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ad8dd62975cb44ed2f5d8a122f756529798bec5",
+        "rev": "a11f65c77752b5dd561e7453e1a603cf812a50b5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -19,11 +19,7 @@
       let
         pkgs = nixpkgs.legacyPackages."${system}".appendOverlays [
           (self: super: {
-            ocamlPackages = super.ocaml-ng.ocamlPackages_4_14.overrideScope' (oself: osuper: {
-              menhirLib = osuper.menhirLib_20230415;
-              menhirSdk = osuper.menhirSdk_20230415;
-              menhir = osuper.menhir_20230415;
-            });
+            ocamlPackages = super.ocaml-ng.ocamlPackages_4_14.overrideScope' (oself: osuper: { });
           })
         ];
       in

--- a/nix/ci/test.nix
+++ b/nix/ci/test.nix
@@ -19,9 +19,6 @@ let
     extraOverlays = [
       (self: super: {
         ocamlPackages = super.ocaml-ng."ocamlPackages_${ocamlVersion}".overrideScope' (oself: osuper: {
-          menhirLib = osuper.menhirLib_20230415;
-          menhirSdk = osuper.menhirSdk_20230415;
-          menhir = osuper.menhir_20230415;
           reactjs-jsx-ppx = osuper.reactjs-jsx-ppx.overrideAttrs (_: {
             postPatch = ''
               rm -rf test/dune


### PR DESCRIPTION
- updates flake.lock
- gets rid of the canceled menhir release for which we had to make overrides