### PR TITLE
refactor: clean up legacy runtime logic

### DIFF
--- a/jscomp/core/js_name_of_module_id.ml
+++ b/jscomp/core/js_name_of_module_id.ml
@@ -56,38 +56,32 @@ let get_runtime_module_path ~package_info ~output_info
   match Js_packages_info.query_package_infos package_info module_system with
   | Package_not_found -> assert false
   | Package_script -> Ext_module_system.runtime_package_path js_file
-  | Package_found path_info -> (
-      match Js_packages_info.Legacy_runtime.is_runtime_package package_info with
-      | true ->
-          (* Runtime files end up in the same directory, `lib/js` or `lib/es6` *)
-          Ext_path.node_rebase_file ~from:path_info.rel_path
-            ~to_:path_info.rel_path js_file
-      | false -> (
-          match module_system with
-          | NodeJS | Es6 -> Ext_module_system.runtime_package_path js_file
-          (* Note we did a post-processing when working on Windows *)
-          | Es6_global ->
-              (* lib/ocaml/xx.cmj --
-                  HACKING: FIXME
-                  maybe we can caching relative package path calculation or employ package map *)
-              let dep_path =
-                Literals.lib // Ext_module_system.runtime_dir module_system
-              in
-              (* TODO: This doesn't work yet *)
-              Ext_path.rel_normalized_absolute_path
-                ~from:
-                  (Js_packages_info.get_output_dir
-                     package_info
-                     (* ~package_dir:(Lazy.force Ext_path.package_dir) *)
-                     ~package_dir:(Sys.getcwd ()) module_system)
-                (*Invariant: the package path to bs-platform, it is used to
-                  calculate relative js path
-                *)
-                (match !Js_config.customize_runtime with
-                | None ->
-                    Filename.dirname (Filename.dirname Sys.executable_name)
-                    // dep_path // js_file
-                | Some path -> path // dep_path // js_file)))
+  | Package_found _path_info -> (
+      match module_system with
+      | NodeJS | Es6 -> Ext_module_system.runtime_package_path js_file
+      (* Note we did a post-processing when working on Windows *)
+      | Es6_global ->
+          (* lib/ocaml/xx.cmj --
+              HACKING: FIXME
+              maybe we can caching relative package path calculation or employ package map *)
+          let dep_path =
+            Literals.lib // Ext_module_system.runtime_dir module_system
+          in
+          (* TODO: This doesn't work yet *)
+          Ext_path.rel_normalized_absolute_path
+            ~from:
+              (Js_packages_info.get_output_dir
+                 package_info
+                 (* ~package_dir:(Lazy.force Ext_path.package_dir) *)
+                 ~package_dir:(Sys.getcwd ()) module_system)
+            (*Invariant: the package path to bs-platform, it is used to
+              calculate relative js path
+            *)
+            (match !Js_config.customize_runtime with
+            | None ->
+                Filename.dirname (Filename.dirname Sys.executable_name)
+                // dep_path // js_file
+            | Some path -> path // dep_path // js_file))
 
 (* [output_dir] is decided by the command line argument *)
 let string_of_module_id ~package_info ~output_info
@@ -131,45 +125,27 @@ let string_of_module_id ~package_info ~output_info
               js_file_name ~case ~suffix ~path_info:dep_info dep_module_id
             in
             match
-              Js_packages_info.Legacy_runtime.is_runtime_package package_info
+              Js_packages_info.same_package_by_name package_info
+                dep_package_info
             with
             | true ->
-                (* If we're compiling the melange runtime, get a runtime module
-                   path. *)
-                get_runtime_module_path ~package_info ~output_info dep_module_id
+                (* If this is the same package, we know all imports are
+                   relative. *)
+                Ext_path.node_rebase_file ~from:cur_pkg.rel_path
+                  ~to_:dep_info.rel_path js_file
             | false -> (
-                match
-                  Js_packages_info.same_package_by_name package_info
-                    dep_package_info
-                with
-                | true ->
-                    (* If this is the same package, we know all imports are
-                       relative. *)
-                    Ext_path.node_rebase_file ~from:cur_pkg.rel_path
-                      ~to_:dep_info.rel_path js_file
-                | false -> (
-                    if
-                      (* Importing a dependency:
-                       *   - are we importing the melange runtime / stdlib? *)
-                      Js_packages_info.Legacy_runtime.is_runtime_package
-                        dep_package_info
-                    then
-                      get_runtime_module_path ~package_info ~output_info
-                        dep_module_id
-                    else
-                      (* - Are we importing another package? *)
-                      match module_system with
-                      | NodeJS | Es6 -> dep_info.pkg_rel_path // js_file
-                      (* Note we did a post-processing when working on Windows *)
-                      | Es6_global ->
-                          Ext_path.rel_normalized_absolute_path
-                            ~from:
-                              (Js_packages_info.get_output_dir
-                                 package_info
-                                 (* ~package_dir:(Lazy.force Ext_path.package_dir) *)
-                                 (* FIXME *)
-                                 ~package_dir:(Sys.getcwd ()) module_system)
-                            (package_path // dep_info.rel_path // js_file))))
+                match module_system with
+                | NodeJS | Es6 -> dep_info.pkg_rel_path // js_file
+                (* Note we did a post-processing when working on Windows *)
+                | Es6_global ->
+                    Ext_path.rel_normalized_absolute_path
+                      ~from:
+                        (Js_packages_info.get_output_dir
+                           package_info
+                           (* ~package_dir:(Lazy.force Ext_path.package_dir) *)
+                           (* FIXME *)
+                           ~package_dir:(Sys.getcwd ()) module_system)
+                      (package_path // dep_info.rel_path // js_file)))
         | Package_script, Package_script -> (
             let js_file =
               js_name_of_modulename (Ident.name dep_module_id.id) case Js

--- a/jscomp/core/js_packages_info.mli
+++ b/jscomp/core/js_packages_info.mli
@@ -29,11 +29,6 @@ type output_info = {
 
 type t
 
-module Legacy_runtime : sig
-  val for_cmj : t -> t
-  val is_runtime_package : t -> bool
-end
-
 val same_package_by_name : t -> t -> bool
 val empty : t
 val from_name : ?t:t -> string -> t

--- a/jscomp/core/js_packages_state.ml
+++ b/jscomp/core/js_packages_state.ml
@@ -46,5 +46,4 @@ let get_output_info () =
   | Some info -> [ info ]
   | None -> Js_packages_info.assemble_output_info !packages_info
 
-let get_packages_info_for_cmj () =
-  Js_packages_info.Legacy_runtime.for_cmj !packages_info
+let get_packages_info_for_cmj () = !packages_info

--- a/jscomp/ext/literals.ml
+++ b/jscomp/ext/literals.ml
@@ -42,9 +42,6 @@ let node_modules = "node_modules"
 let node_modules_length = String.length node_modules
 let package_name = "melange"
 
-(* Prefix of all melange runtime packages *)
-let mel_runtime_package_prefix = "@melange/runtime"
-
 (* Name of the library file created for each external dependency. *)
 let lib = "lib"
 let suffix_cmj = ".cmj"


### PR DESCRIPTION
melange's runtime / stdlib is now built with dune, which consolidates all the logic for finding the runtime modules too.