### PR TITLE
don't fail if not inside a git repo

### DIFF
--- a/jscomp/common/dune
+++ b/jscomp/common/dune
@@ -18,8 +18,11 @@
 (rule
  (targets git_commit.ml)
  (action
-  (with-stdout-to
-   %{targets}
-   (progn
-    (bash "echo let version = \\\"$(git rev-parse --verify HEAD)\\\"")
-    (bash "echo let short_version = \\\"$(git rev-parse --short HEAD)\\\"")))))
+  (ignore-stderr
+   (with-stdout-to
+    %{targets}
+    (progn
+     (bash
+      "echo let version = \\\"$(git rev-parse --verify HEAD || echo n/a)\\\"")
+     (bash
+      "echo let short_version = \\\"$(git rev-parse --short HEAD || echo n/a)\\\""))))))


### PR DESCRIPTION
No companion issue.

Seems that in some cases, if melange is installed from its tar file, there is no git repository available to derive the commit in `git_commit.ml`. See [example](https://toxis.caelum.ci.dev/github/ocaml/opam-repository/commit/c2b1cdf670920116d7fe42cf7295ca4425dd055c/variant/compilers,4.13,reason-react.0.11.0,lower-bounds), with error:

```
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
# (cd _build/default/jscomp/common && /bin/bash -e -u -o pipefail -c 'echo let short_version = \"$(git rev-parse --short HEAD)\"') > _build/default/jscomp/common/git_commit.ml
# fatal: not a git repository (or any parent up to mount point /)
```

This PR just falls back to `n/a` in those cases, so the command doesn't fail.