### PR TITLE
melange.opam: add lower bound for menhir

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -46,7 +46,8 @@
   (reason :with-test)
   (js_of_ocaml :with-test)
   ppxlib
-  menhir
+  (menhir
+   (>= 20201214))
   (reactjs-jsx-ppx :with-test)))
 
 (package

--- a/melange.opam
+++ b/melange.opam
@@ -17,7 +17,7 @@ depends: [
   "reason" {with-test}
   "js_of_ocaml" {with-test}
   "ppxlib"
-  "menhir"
+  "menhir" {>= "20201214"}
   "reactjs-jsx-ppx" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Continuation of #617 (which was not fixing anything really).

Fixes some issues in opam-repository lower bounds ci checks, by picking the `menhir` constraint that was part of `melange-compiler-libs` and bringing it over to `melange`. cc @davesnx 