### PR TITLE
playground: add test for bad error msg

### DIFF
--- a/bin/jsoo_common.ml
+++ b/bin/jsoo_common.ml
@@ -78,7 +78,7 @@ module Reason = struct
   let printML = printWith ~f:ML.print_implementation_with_comments
 end
 
-let mk_js_error (error : Location.report) =
+let mk_js_error (error : Location.report) : Js.t =
   let kind, type_ =
     match error.kind with
     | Location.Report_error -> ("Error", "error")

--- a/bin/jsoo_main.ml
+++ b/bin/jsoo_main.ml
@@ -35,10 +35,29 @@ module Melange_ast = struct
     Melange_compiler_libs.Parsetree.structure = "%identity"
 end
 
-let () =
-  Bs_conditional_initial.setup_env ();
-  Clflags.binary_annotations := false;
-  Clflags.color := None
+let warnings_collected : Location.report list ref = ref []
+
+(* We need to overload the original warning printer to capture the warnings
+   and not let them go through default printer (which will end up in browser
+   console) *)
+let playground_warning_reporter (loc : Location.t) w : Location.report option =
+  let mk ~is_error id =
+    if is_error then Location.Report_warning_as_error id else Report_warning id
+  in
+  match Warnings.report w with
+  | `Inactive -> None
+  | `Active { Warnings.id; message; is_error; sub_locs } ->
+      let msg_of_str str ppf = Format.pp_print_string ppf str in
+      let kind = mk ~is_error id in
+      let main = { Location.loc; txt = msg_of_str message } in
+      let sub =
+        List.map
+          (fun (loc, sub_message) ->
+            { Location.loc; txt = msg_of_str sub_message })
+          sub_locs
+      in
+      warnings_collected := { Location.kind; main; sub } :: !warnings_collected;
+      None
 
 let error_of_exn e =
   match Location.error_of_exn e with
@@ -49,71 +68,101 @@ let error_of_exn e =
       | Some (`Ok e) -> Some e
       | Some `Already_displayed | None -> None)
 
-module From_ppxlib =
-  Ppxlib_ast.Convert (Ppxlib_ast.Selected_ast) (Ppxlib_ast__.Versions.OCaml_414)
-
-module To_ppxlib =
-  Ppxlib_ast.Convert (Ppxlib_ast__.Versions.OCaml_414) (Ppxlib_ast.Selected_ast)
-
-let compile
-    ~(impl :
-       Lexing.lexbuf -> Ppxlib_ast__.Versions.OCaml_414.Ast.Parsetree.structure)
-    str : Js.t =
-  let modulename = "Test" in
-  (* let env = !Toploop.toplevel_env in *)
-  (* Res_compmisc.init_path false; *)
-  (* let modulename = module_of_filename ppf sourcefile outputprefix in *)
-  (* Env.set_unit_name modulename; *)
-  Lam_compile_env.reset ();
-  let env = Res_compmisc.initial_env () in
-  (* Question ?? *)
-  (* let finalenv = ref Env.empty in *)
-  let types_signature = ref [] in
-  try
-    (* default *)
-    let ast = impl (Lexing.from_string str) in
-    let ast =
-      let ppxlib_ast : Ppxlib_ast.Parsetree.structure =
-        (* Copy to ppxlib version *)
-        To_ppxlib.copy_structure ast
+let compile =
+  let module From_ppxlib =
+    Ppxlib_ast.Convert
+      (Ppxlib_ast.Selected_ast)
+      (Ppxlib_ast__.Versions.OCaml_414)
+  in
+  let module To_ppxlib =
+    Ppxlib_ast.Convert
+      (Ppxlib_ast__.Versions.OCaml_414)
+      (Ppxlib_ast.Selected_ast)
+  in
+  fun ~(impl :
+         Lexing.lexbuf ->
+         Ppxlib_ast__.Versions.OCaml_414.Ast.Parsetree.structure) str : Js.t ->
+    let modulename = "Test" in
+    (* let env = !Toploop.toplevel_env in *)
+    (* Res_compmisc.init_path false; *)
+    (* let modulename = module_of_filename ppf sourcefile outputprefix in *)
+    (* Env.set_unit_name modulename; *)
+    Lam_compile_env.reset ();
+    let env = Res_compmisc.initial_env () in
+    (* Question ?? *)
+    (* let finalenv = ref Env.empty in *)
+    let types_signature = ref [] in
+    warnings_collected := [];
+    try
+      (* default *)
+      let ast = impl (Lexing.from_string str) in
+      let ast =
+        let ppxlib_ast : Ppxlib_ast.Parsetree.structure =
+          (* Copy to ppxlib version *)
+          To_ppxlib.copy_structure ast
+        in
+        let melange_converted_ast =
+          From_ppxlib.copy_structure (Ppxlib.Driver.map_structure ppxlib_ast)
+        in
+        Melange_ast.from_ppxlib melange_converted_ast
       in
-      let melange_converted_ast =
-        From_ppxlib.copy_structure (Ppxlib.Driver.map_structure ppxlib_ast)
+      let typed_tree =
+        let { Typedtree.structure; coercion; shape = _; signature }, _finalenv =
+          Typemod.type_implementation_more modulename modulename modulename env
+            ast
+        in
+        (* finalenv := c ; *)
+        types_signature := signature;
+        (structure, coercion)
       in
-      Melange_ast.from_ppxlib melange_converted_ast
-    in
-    let typed_tree =
-      let { Typedtree.structure; coercion; shape = _; signature }, _finalenv =
-        Typemod.type_implementation_more modulename modulename modulename env
-          ast
+      typed_tree |> Translmod.transl_implementation modulename
+      |> (* Printlambda.lambda ppf *) fun { Lambda.code = lam; _ } ->
+      let buffer = Buffer.create 1000 in
+      let () =
+        Js_dump_program.pp_deps_program ~output_prefix:""
+          ~package_info:Js_packages_info.empty
+          ~output_info:{ Js_packages_info.module_system = Es6; suffix = Js }
+          (Ext_pp.from_buffer buffer)
+          (Lam_compile_main.compile "" lam)
       in
-      (* finalenv := c ; *)
-      types_signature := signature;
-      (structure, coercion)
-    in
-    typed_tree |> Translmod.transl_implementation modulename
-    |> (* Printlambda.lambda ppf *) fun { Lambda.code = lam; _ } ->
-    let buffer = Buffer.create 1000 in
-    let () =
-      Js_dump_program.pp_deps_program ~output_prefix:""
-        ~package_info:Js_packages_info.empty
-        ~output_info:{ Js_packages_info.module_system = Es6; suffix = Js }
-        (Ext_pp.from_buffer buffer)
-        (Lam_compile_main.compile "" lam)
-    in
-    let v = Buffer.contents buffer in
-    Js.(obj [| ("js_code", Js.string v) |])
-    (* Format.fprintf output_ppf {| { "js_code" : %S }|} v ) *)
-  with e -> (
-    match error_of_exn e with
-    | Some error -> Jsoo_common.mk_js_error error
-    | None -> Js.(obj [| ("js_error_msg", Js.string (Printexc.to_string e)) |]))
+      let v = Buffer.contents buffer in
+      Js.(obj [| ("js_code", Js.string v) |])
+      (* Format.fprintf output_ppf {| { "js_code" : %S }|} v ) *)
+    with e -> (
+      match error_of_exn e with
+      | Some error -> Jsoo_common.mk_js_error error
+      | None -> (
+          let default =
+            lazy
+              (Js.obj [| ("js_error_msg", Js.string (Printexc.to_string e)) |])
+          in
+          match e with
+          | Warnings.Errors -> (
+              let warnings = !warnings_collected in
+              match warnings with
+              | [] -> Lazy.force default
+              | warnings ->
+                  let type_ = "warning_errors" in
+                  let jsErrors =
+                    List.rev_map Jsoo_common.mk_js_error warnings
+                    |> Array.of_list
+                  in
+                  Js.obj
+                    [|
+                      ("warning_errors", Js.array jsErrors);
+                      ("type", Js.string type_);
+                    |])
+          | _ -> Lazy.force default))
 
 let export (field : Js.t) v = Js.set (Js.pure_js_expr "globalThis") field v
 
-(* To add a directory to the load path *)
-
-let () = Load_path.add_dir "/static"
+let () =
+  Bs_conditional_initial.setup_env ();
+  Clflags.binary_annotations := false;
+  Clflags.color := None;
+  Location.warning_reporter := playground_warning_reporter;
+  (* To add a directory to the load path *)
+  Load_path.add_dir "/static"
 
 let () =
   export (Js.string "ocaml")

--- a/test/blackbox-tests/playground.t
+++ b/test/blackbox-tests/playground.t
@@ -140,8 +140,28 @@ Prepare an input file to test some snippets to exercise common functionality
     text: 'Unbound value swiftch',
     type: 'error'
   }
-  File "_none_", line 1, characters 12-13:
-  Error (warning 109 [bucklescript-toplevel-expr-unit]): Toplevel expression is expected to have unit type.
-  File "_none_", line 1, characters 16-17:
-  Error (warning 109 [bucklescript-toplevel-expr-unit]): Toplevel expression is expected to have unit type.
-  { js_error_msg: 'Melange_compiler_libs__Warnings.Errors' }
+  {
+    warning_errors: [
+      {
+        js_error_msg: 'Line 1, 12:\n' +
+          '  Error: (warning 109 [bucklescript-toplevel-expr-unit]) Toplevel expression is expected to have unit type.',
+        row: 0,
+        column: 12,
+        endRow: 0,
+        endColumn: 13,
+        text: 'Toplevel expression is expected to have unit type.',
+        type: 'warning_as_error'
+      },
+      {
+        js_error_msg: 'Line 1, 16:\n' +
+          '  Error: (warning 109 [bucklescript-toplevel-expr-unit]) Toplevel expression is expected to have unit type.',
+        row: 0,
+        column: 16,
+        endRow: 0,
+        endColumn: 17,
+        text: 'Toplevel expression is expected to have unit type.',
+        type: 'warning_as_error'
+      }
+    ],
+    type: 'warning_errors'
+  }

--- a/test/blackbox-tests/playground.t
+++ b/test/blackbox-tests/playground.t
@@ -21,6 +21,7 @@ Prepare an input file to test some snippets to exercise common functionality
   > console.log(ocaml.compileRE("let t = 1;"));
   > console.log(ocaml.compileRE("let sum = item => swiftch (item) { | Leaf => 0 };").js_error_msg.trim()); // Some Reason errors dont have locations
   > console.log(ocaml.compileRE("let sum = item => swiftch (item) { 2 };")); // but some do
+  > console.log(ocaml.compileML("let t = 2;; 3;; 5"));
   > EOF
 
   $ node input.js
@@ -139,3 +140,8 @@ Prepare an input file to test some snippets to exercise common functionality
     text: 'Unbound value swiftch',
     type: 'error'
   }
+  File "_none_", line 1, characters 12-13:
+  Error (warning 109 [bucklescript-toplevel-expr-unit]): Toplevel expression is expected to have unit type.
+  File "_none_", line 1, characters 16-17:
+  Error (warning 109 [bucklescript-toplevel-expr-unit]): Toplevel expression is expected to have unit type.
+  { js_error_msg: 'Melange_compiler_libs__Warnings.Errors' }


### PR DESCRIPTION
Showcases that when warnings are found, the error message passed in the json by the playground app is not good.