### PR TITLE
stdlib paths: don't include `dom` by default

### DIFF
--- a/jscomp/common/js_config.cppo.ml
+++ b/jscomp/common/js_config.cppo.ml
@@ -61,13 +61,11 @@ let stdlib_paths =
 #ifndef BS_RELEASE_BUILD
       [ root // "jscomp" // "stdlib" // ".stdlib.objs" // Literals.package_name
       ; root // "jscomp" // "runtime" // ".js.objs" // Literals.package_name
-      ; root // "jscomp" // "others" // ".belt.objs" // Literals.package_name
-      ; root // "jscomp" // "others" // ".dom.objs" // Literals.package_name ]
+      ; root // "jscomp" // "others" // ".belt.objs" // Literals.package_name ]
 #else
       [ root // Literals.lib // Literals.package_name // Literals.package_name
       ; root // Literals.lib // Literals.package_name // "js" // Literals.package_name
-      ; root // Literals.lib // Literals.package_name // "belt" // Literals.package_name
-      ; root // Literals.lib // Literals.package_name // "dom" // Literals.package_name ]
+      ; root // Literals.lib // Literals.package_name // "belt" // Literals.package_name ]
 #endif
   end)
 


### PR DESCRIPTION
Fixes #695.

I spent some time trying to write a test that would show the change, but I ended up realizing that `setup.sh` was ignoring `dom` already:

https://github.com/melange-re/melange/blob/539bfc00870c1d90150d6ffe7968c45b173943d6/test/blackbox-tests/setup.sh#L3