### PR TITLE
fix(ci): add `melange.dom` to `libraries` in the runtime tests

### DIFF
--- a/jscomp/test/dune
+++ b/jscomp/test/dune
@@ -11,7 +11,7 @@
 (library
  (name melange_runtime_tests)
  (modes melange)
- (libraries test_runner)
+ (libraries test_runner melange.dom)
  (wrapped false)
  (preprocess
   (pps melange.ppx))
@@ -29,7 +29,7 @@
  (library
   (name melange_tests_re_res)
   (modes melange)
-  (libraries test_runner)
+  (libraries test_runner melange.dom)
   (wrapped false)
   (preprocess
    (pps melange.ppx reason-react-ppx))

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -40,7 +40,7 @@ buildDunePackage {
 
   postInstall = ''
     wrapProgram "$out/bin/melc" \
-      --set MELANGELIB "$OCAMLFIND_DESTDIR/melange/melange:$OCAMLFIND_DESTDIR/melange/js/melange:$OCAMLFIND_DESTDIR/melange/belt/melange:$OCAMLFIND_DESTDIR/melange/dom/melange"
+      --set MELANGELIB "$OCAMLFIND_DESTDIR/melange/melange:$OCAMLFIND_DESTDIR/melange/js/melange:$OCAMLFIND_DESTDIR/melange/belt/melange"
   '';
 
   doCheck = true;


### PR DESCRIPTION
follow-up to https://github.com/melange-re/melange/pull/703