### PR TITLE
chore: remove some more Ext_list functions

### DIFF
--- a/jscomp/core/js_packages_info.ml
+++ b/jscomp/core/js_packages_info.ml
@@ -123,9 +123,11 @@ let query_package_infos (t : t) (module_system : Ext_module_system.t) :
             { rel_path = module_path; pkg_rel_path = module_path; module_name })
   | Batch_compilation module_systems -> (
       match
-        Ext_list.find_first_exn module_systems (fun k ->
+        List.find
+          (fun k ->
             Ext_module_system.compatible ~dep:k.output_info.module_system
               module_system)
+          module_systems
       with
       | k ->
           let pkg_rel_path =
@@ -142,9 +144,11 @@ let query_package_infos (t : t) (module_system : Ext_module_system.t) :
 let get_js_path (module_systems : batch_info list)
     (module_system : Ext_module_system.t) : string =
   let k =
-    Ext_list.find_first_exn module_systems (fun k ->
+    List.find
+      (fun k ->
         Ext_module_system.compatible ~dep:k.output_info.module_system
           module_system)
+      module_systems
   in
   k.path
 

--- a/jscomp/core/js_pass_flatten.ml
+++ b/jscomp/core/js_pass_flatten.ml
@@ -70,9 +70,9 @@ let flatten_map =
             match block with
             | { statement_desc = Exp last_one; _ } :: rest_rev ->
                 S.block
-                  (Ext_list.rev_map_append rest_rev
-                     [ self.statement self (S.exp (E.assign a last_one)) ]
-                     (fun x -> self.statement self x))
+                  (List.rev_append
+                     (List.map (fun x -> self.statement self x) rest_rev)
+                     [ self.statement self (S.exp (E.assign a last_one)) ])
                 (* TODO: here we introduce a block, should avoid it *)
                 (* super#statement *)
                 (*   (S.block (List.rev_append rest_rev [S.exp (E.assign a  last_one)])) *)
@@ -92,9 +92,9 @@ let flatten_map =
             | { statement_desc = Exp last_one; _ } :: rest_rev ->
                 super.statement self
                   (S.block
-                     (Ext_list.rev_map_append rest_rev
-                        [ S.return_stmt last_one ]
-                        (fun x -> self.statement self x)))
+                     (List.rev_append
+                        (List.map (fun x -> self.statement self x) rest_rev)
+                        [ S.return_stmt last_one ]))
             | _ -> assert false)
         | Block [ x ] -> self.statement self x
         | _ -> super.statement self x);

--- a/jscomp/core/js_pass_flatten_and_mark_dead.ml
+++ b/jscomp/core/js_pass_flatten_and_mark_dead.ml
@@ -245,8 +245,11 @@ let subst_map (substitution : J.expression Hash_ident.t) =
             | _ ->
                 (* self#add_substitue ident e ; *)
                 S.block
-                @@ Ext_list.rev_map_append bindings [ original_statement ]
-                     (fun (id, v) -> S.define_variable ~kind:Strict id v))
+                  (List.rev_append
+                     (List.map
+                        (fun (id, v) -> S.define_variable ~kind:Strict id v)
+                        bindings)
+                     [ original_statement ]))
         | _ -> super.statement self v);
     expression =
       (fun self x ->

--- a/jscomp/core/lam_arity_analysis.ml
+++ b/jscomp/core/lam_arity_analysis.ml
@@ -122,9 +122,7 @@ let rec get_arity (meta : Lam_stats.t) (lam : Lam.t) : Lam_arity.t =
           _;
         } ) ->
       all_lambdas meta
-        (let rest =
-           Ext_list.map_append sw_consts (List.map snd sw_blocks) snd
-         in
+        (let rest = List.map snd sw_consts @ List.map snd sw_blocks in
          match sw_failaction with None -> rest | Some x -> x :: rest)
   | Lstringswitch (_, sw, d) -> (
       match d with

--- a/jscomp/core/lam_compile.ml
+++ b/jscomp/core/lam_compile.ml
@@ -777,7 +777,7 @@ and compile_staticcatch (lam : Lam.t) (lambda_cxt : Lam_compile_context.t) =
   match (lambda_cxt.continuation, code_table) with
   | ( EffectCall
         (Maybe_tail_is_return (Tail_with_name { in_staticcatch = false; _ }) as
-        tail_type),
+         tail_type),
       [ code_table ] )
   (* tail position and only one exit code *)
     when Lam_compile_context.no_static_raise_in_handler code_table ->
@@ -1451,8 +1451,8 @@ and compile_apply (appinfo : Lam.apply) (lambda_cxt : Lam_compile_context.t) =
             Map_ident.disjoint_merge_exn new_params ret.new_params (fun _ _ _ ->
                 assert false);
           let block =
-            Ext_list.map_append assigned_params [ S.continue_ ]
-              (fun (param, arg) -> S.assign param arg)
+            List.map (fun (param, arg) -> S.assign param arg) assigned_params
+            @ [ S.continue_ ]
           in
           (* Note true and continue needed to be handled together*)
           Js_output.make ~output_finished:True (List.append args_code block)

--- a/jscomp/core/lam_eta_conversion.ml
+++ b/jscomp/core/lam_eta_conversion.ml
@@ -253,9 +253,8 @@ let unsafe_adjust_to_arity loc ~(to_ : int) ?(from : int option) (fn : Lam.t) :
                      ~attr:Lambda.default_function_attribute
                      ~body:
                        (Lam.apply new_fn
-                          (Ext_list.map_append extra_outer_args
-                             (List.map Lam.var extra_inner_args)
-                             Lam.var)
+                          (List.map Lam.var extra_outer_args
+                          @ List.map Lam.var extra_inner_args)
                           { ap_info with ap_status = App_infer_full }))
             in
             match wrapper with

--- a/jscomp/core/lam_print.ml
+++ b/jscomp/core/lam_print.ml
@@ -225,9 +225,7 @@ let rec aux (acc : (print_kind * Ident.t * Lam.t) list) (lam : Lam.t) =
   | Llet (str3, id3, arg3, body3) ->
       aux ((to_print_kind str3, id3, arg3) :: acc) body3
   | Lletrec (bind_args, body) ->
-      aux
-        (Ext_list.map_append bind_args acc (fun (id, l) -> (Recursive, id, l)))
-        body
+      aux (List.map (fun (id, l) -> (Recursive, id, l)) bind_args @ acc) body
   | e -> (acc, e)
 
 (* type left_var =

--- a/jscomp/ext/ext_list.ml
+++ b/jscomp/ext/ext_list.ml
@@ -104,15 +104,6 @@ let rec map_last l f =
       let y4 = f false x4 in
       y1 :: y2 :: y3 :: y4 :: map_last tail f
 
-let rec mapi_aux lst i f tail =
-  match lst with
-  | [] -> tail
-  | a :: l ->
-      let r = f i a in
-      r :: mapi_aux l (i + 1) f tail
-
-let mapi_append lst f tail = mapi_aux lst 0 f tail
-
 let rec append_aux l1 l2 =
   match l1 with
   | [] -> l2
@@ -126,40 +117,6 @@ let rec append_aux l1 l2 =
 
 let append l1 l2 = match l2 with [] -> l1 | _ -> append_aux l1 l2
 let append_one l1 x = append_aux l1 [ x ]
-
-let rec map_append l1 l2 f =
-  match l1 with
-  | [] -> l2
-  | [ a0 ] -> f a0 :: l2
-  | [ a0; a1 ] ->
-      let b0 = f a0 in
-      let b1 = f a1 in
-      b0 :: b1 :: l2
-  | [ a0; a1; a2 ] ->
-      let b0 = f a0 in
-      let b1 = f a1 in
-      let b2 = f a2 in
-      b0 :: b1 :: b2 :: l2
-  | [ a0; a1; a2; a3 ] ->
-      let b0 = f a0 in
-      let b1 = f a1 in
-      let b2 = f a2 in
-      let b3 = f a3 in
-      b0 :: b1 :: b2 :: b3 :: l2
-  | [ a0; a1; a2; a3; a4 ] ->
-      let b0 = f a0 in
-      let b1 = f a1 in
-      let b2 = f a2 in
-      let b3 = f a3 in
-      let b4 = f a4 in
-      b0 :: b1 :: b2 :: b3 :: b4 :: l2
-  | a0 :: a1 :: a2 :: a3 :: a4 :: rest ->
-      let b0 = f a0 in
-      let b1 = f a1 in
-      let b2 = f a2 in
-      let b3 = f a3 in
-      let b4 = f a4 in
-      b0 :: b1 :: b2 :: b3 :: b4 :: map_append rest l2 f
 
 let rec fold_right3 l r last acc f =
   match (l, r, last) with
@@ -212,17 +169,8 @@ let rec same_length xs ys =
   | _ :: xs, _ :: ys -> same_length xs ys
   | _, _ -> false
 
-let rec rev_append l1 l2 =
-  match l1 with
-  | [] -> l2
-  | [ a0 ] -> a0 :: l2 (* single element is common *)
-  | [ a0; a1 ] -> a1 :: a0 :: l2
-  | a0 :: a1 :: a2 :: rest -> rev_append rest (a2 :: a1 :: a0 :: l2)
-
-let rev l = rev_append l []
-
 let rec small_split_at n acc l =
-  if n <= 0 then (rev acc, l)
+  if n <= 0 then (List.rev acc, l)
   else
     match l with
     | x :: xs -> small_split_at (n - 1) (x :: acc) xs
@@ -233,7 +181,7 @@ let split_at l n = small_split_at n [] l
 let rec split_at_last_aux acc x =
   match x with
   | [] -> invalid_arg "Ext_list.split_at_last"
-  | [ x ] -> (rev acc, x)
+  | [ x ] -> (List.rev acc, x)
   | y0 :: ys -> split_at_last_aux (y0 :: acc) ys
 
 let split_at_last (x : 'a list) =
@@ -261,9 +209,6 @@ let filter_mapi xs f =
         | Some z -> z :: aux (i + 1) ys)
   in
   aux 0 xs
-
-let rec rev_map_append l1 l2 f =
-  match l1 with [] -> l2 | a :: l -> rev_map_append l (f a :: l2) f
 
 let rec length_compare l n =
   if n < 0 then `Gt
@@ -296,15 +241,7 @@ and aux eq (x : 'a) (xss : 'a list list) : 'a list list =
       if eq x y0 then (x :: y) :: ys else y :: aux eq x ys
   | _ :: _ -> assert false
 
-let stable_group lst eq = group eq lst |> rev
-
-let rec find_first x p =
-  match x with [] -> None | x :: l -> if p x then Some x else find_first l p
-
-let rec find_first_exn x p =
-  match x with
-  | [] -> raise Not_found
-  | x :: l -> if p x then x else find_first_exn l p
+let stable_group lst eq = group eq lst |> List.rev
 
 let rec find_first_not xs p =
   match xs with

--- a/jscomp/ext/ext_list.mli
+++ b/jscomp/ext/ext_list.mli
@@ -28,7 +28,6 @@ val combine_array : 'a array -> 'b list -> ('a -> 'c) -> ('c * 'b) list
 val combine_array_append :
   'a array -> 'b list -> ('c * 'b) list -> ('a -> 'c) -> ('c * 'b) list
 
-val mapi_append : 'a list -> (int -> 'a -> 'b) -> 'b list -> 'b list
 val map_snd : ('a * 'b) list -> ('b -> 'c) -> ('a * 'c) list
 
 val map_last : 'a list -> (bool -> 'a -> 'b) -> 'b list
@@ -39,7 +38,6 @@ val map_last : 'a list -> (bool -> 'a -> 'b) -> 'b list
 *)
 
 val append_one : 'a list -> 'a -> 'a list
-val map_append : 'b list -> 'a list -> ('b -> 'a) -> 'a list
 
 val fold_right3 :
   'a list -> 'b list -> 'c list -> 'd -> ('a -> 'b -> 'c -> 'd -> 'd) -> 'd
@@ -80,14 +78,6 @@ val length_ge : 'a list -> int -> bool
 
 val length_larger_than_n : 'a list -> 'a list -> int -> bool
 
-val rev_map_append : 'a list -> 'b list -> ('a -> 'b) -> 'b list
-(**
-   [rev_map_append f l1 l2]
-   [map f l1] and reverse it to append [l2]
-   This weird semantics is due to it is the most efficient operation
-   we can do
-*)
-
 val stable_group : 'a list -> ('a -> 'a -> bool) -> 'a list list
 (**
     [stable_group eq lst]
@@ -103,9 +93,6 @@ val stable_group : 'a list -> ('a -> 'a -> bool) -> 'a list list
     TODO: this is O(n^2) behavior
     which could be improved later
 *)
-
-val find_first : 'a list -> ('a -> bool) -> 'a option
-val find_first_exn : 'a list -> ('a -> bool) -> 'a
 
 val find_first_not : 'a list -> ('a -> bool) -> 'a option
 (** [find_first_not p lst ]

--- a/jscomp/ext/ext_path.ml
+++ b/jscomp/ext/ext_path.ml
@@ -73,7 +73,7 @@ let node_relative_path ~from:(file_or_dir_2 : t) (file_or_dir_1 : t) =
     | "." :: xs, ys -> go xs ys
     | xs, "." :: ys -> go xs ys
     | x :: xs, y :: ys when x = y -> go xs ys
-    | _, _ -> Ext_list.map_append dir2 dir1 (fun _ -> Literals.node_parent)
+    | _, _ -> List.map (fun _ -> Literals.node_parent) dir2 @ dir1
   in
   match go dir1 dir2 with
   | x :: _ as ys when x = Literals.node_parent ->

--- a/ppx/ast_attributes.ml
+++ b/ppx/ast_attributes.ml
@@ -416,7 +416,7 @@ let is_inline : attr -> bool =
   warn_if_bs ~loc txt;
   txt = "mel.inline" || txt = "bs.inline" || txt = "inline"
 
-let has_inline_payload (attrs : t) = Ext_list.find_first attrs is_inline
+let has_inline_payload (attrs : t) = List.find_opt is_inline attrs
 
 (* We disable warning 61 in Melange externals since they're substantially
    different from OCaml externals. This warning doesn't make sense for a JS

--- a/ppx/ast_bs_open.ml
+++ b/ppx/ast_bs_open.ml
@@ -60,8 +60,7 @@ let convertBsErrorFunction loc (self : Ast_traverse.map) attrs
           (Exp.constraint_ ~loc
              [%expr [%e Exp.ident ~loc { txt = obj_magic; loc }] [%e txt_expr]]
              [%type: exn])
-          (Ext_list.map_append cases
-             [ Exp.case (Pat.any ~loc ()) none ]
+          (List.map
              (fun x ->
                let pc_rhs = x.pc_rhs in
                let loc = pc_rhs.pexp_loc in
@@ -71,5 +70,7 @@ let convertBsErrorFunction loc (self : Ast_traverse.map) attrs
                    Exp.construct ~loc
                      { txt = Ast_literal.predef_some; loc }
                      (Some pc_rhs);
-               })))
+               })
+             cases
+          @ [ Exp.case (Pat.any ~loc ()) none ]))
        (Some none))

--- a/ppx/ast_derive/ast_derive_abstract.ml
+++ b/ppx/ast_derive/ast_derive_abstract.ml
@@ -157,8 +157,7 @@ let handleTdclsInStr ~light _rf tdcls =
       (fun tdcl (tdcls, sts) ->
         match handleTdcl light tdcl with
         | ntdcl, value_descriptions ->
-            ( ntdcl :: tdcls,
-              Ext_list.map_append value_descriptions sts Str.primitive ))
+            (ntdcl :: tdcls, List.map Str.primitive value_descriptions @ sts))
       tdcls ([], [])
   in
   (* Str.include_ (Incl.mk (Mod.structure [ Str.type_ rf tdcls ])) ::  *)
@@ -170,8 +169,7 @@ let handleTdclsInSig ~light _rf tdcls =
       (fun tdcl (tdcls, sts) ->
         match handleTdcl light tdcl with
         | ntdcl, value_descriptions ->
-            ( ntdcl :: tdcls,
-              Ext_list.map_append value_descriptions sts Sig.value ))
+            (ntdcl :: tdcls, List.map Sig.value value_descriptions @ sts))
       tdcls ([], [])
   in
   (*   Sig.type_ rf tdcls ::  *) code

--- a/ppx/ast_tuple_pattern_flatten.ml
+++ b/ppx/ast_tuple_pattern_flatten.ml
@@ -74,7 +74,8 @@ let flattern_tuple_pattern_vb (self : Ast_traverse.map)
             xs es acc
       | _ -> { pvb_pat; pvb_expr; pvb_loc = vb.pvb_loc; pvb_attributes } :: acc)
   | Ppat_record (lid_pats, _), Pexp_pack { pmod_desc = Pmod_ident id; _ } ->
-      Ext_list.map_append lid_pats acc (fun (lid, pat) ->
+      List.map
+        (fun (lid, pat) ->
           match lid.txt with
           | Lident s ->
               {
@@ -88,6 +89,8 @@ let flattern_tuple_pattern_vb (self : Ast_traverse.map)
           | _ ->
               Location.raise_errorf ~loc:lid.loc
                 "Not supported pattern match on modules")
+        lid_pats
+      @ acc
   | _ -> { pvb_pat; pvb_expr; pvb_loc = vb.pvb_loc; pvb_attributes } :: acc
 
 (* XXX(anmonteiro): this one is a little brittle. Because it might introduce

--- a/ppx/utf8_string.ml
+++ b/ppx/utf8_string.ml
@@ -371,7 +371,6 @@ module Interp = struct
   *)
   and expect_simple_var loc s offset ({ buf; s_len; _ } as cxt) =
     let v = ref offset in
-    (* prerr_endline @@ Ext_pervasives.dump (s, has_paren, (is_space s.[!v]), !v); *)
     if not (offset < s_len && valid_lead_identifier_char s.[offset]) then
       pos_error cxt ~loc (Invalid_syntax_of_var String.empty)
     else (
@@ -388,7 +387,6 @@ module Interp = struct
 
   and expect_var_paren loc s offset ({ buf; s_len; _ } as cxt) =
     let v = ref offset in
-    (* prerr_endline @@ Ext_pervasives.dump (s, has_paren, (is_space s.[!v]), !v); *)
     while !v < s_len && s.[!v] <> ')' do
       let cur_char = s.[!v] in
       Buffer.add_char buf cur_char;

--- a/test/unit-tests/ounit_list_test.ml
+++ b/test/unit-tests/ounit_list_test.ml
@@ -65,7 +65,7 @@ let suites =
              "z" );
          ( __LOC__ >:: fun _ ->
            OUnit.assert_raises
-             (Assert_failure ("jscomp/ext/ext_list.ml", 362, 35))
+             (Assert_failure ("jscomp/ext/ext_list.ml", 341, 35))
              (fun _ ->
                ignore
                @@ Ext_list.assoc_by_int [ (2, "x"); (3, "y"); (1, "z") ] 11 None)

--- a/test/unit-tests/ounit_list_test.ml
+++ b/test/unit-tests/ounit_list_test.ml
@@ -38,8 +38,8 @@ let suites =
            =~ [ 0; 0; 0; 0; 0; 0; 1 ] );
          ( __LOC__ >:: fun _ ->
            OUnit.assert_equal
-             (Ext_list.map_append [ 0; 1; 2 ] [ "1"; "2"; "3" ] (fun x ->
-                  string_of_int x))
+             (List.map (fun x -> string_of_int x) [ 0; 1; 2 ]
+             @ [ "1"; "2"; "3" ])
              [ "0"; "1"; "2"; "1"; "2"; "3" ] );
          ( __LOC__ >:: fun _ ->
            let a, b = Ext_list.split_at [ 1; 2; 3; 4; 5; 6 ] 3 in
@@ -65,7 +65,7 @@ let suites =
              "z" );
          ( __LOC__ >:: fun _ ->
            OUnit.assert_raises
-             (Assert_failure ("jscomp/ext/ext_list.ml", 404, 35))
+             (Assert_failure ("jscomp/ext/ext_list.ml", 362, 35))
              (fun _ ->
                ignore
                @@ Ext_list.assoc_by_int [ (2, "x"); (3, "y"); (1, "z") ] 11 None)


### PR DESCRIPTION
this gets us a bit closer to removing `ext` from the melange-ppx, and making `ext` a private library again