### PR TITLE
Make melange.dom compatible with other modes

### DIFF
--- a/jscomp/others/dune
+++ b/jscomp/others/dune
@@ -30,7 +30,7 @@
   Js__Melange_mini_stdlib))
 
 (library
- (modes melange)
+ (modes :standard melange)
  (name dom)
  (public_name melange.dom)
  (preprocess


### PR DESCRIPTION
That's helpful for server-reason-react pointing to the same melange.dom lib as reason-react