### PR TITLE
fix: make `Js.t` abstract (again)

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,9 @@ Unreleased
   ([#779](https://github.com/melange-re/melange/pull/779))
 - Fix `Sys.argv` runtime to match declared type
   ([#791](https://github.com/melange-re/melange/pull/791))
+- Make `'a Js.t` abstract (again), fixing a regression when bringing back
+  OCaml-style objects BuckleScript
+  ([#786](https://github.com/melange-re/melange/pull/786))
 
 2.0.0 2023-09-13
 ---------------

--- a/jscomp/runtime/js_internal.ml
+++ b/jscomp/runtime/js_internal.ml
@@ -44,7 +44,8 @@
 
 (** Types for JS objects *)
 
-type 'a t = 'a
+type 'a t
+
 (** This used to be mark a Js object type. *)
 
 (* internal types for FFI, these types are not used by normal users

--- a/jscomp/test/hash_sugar_desugar.mli
+++ b/jscomp/test/hash_sugar_desugar.mli
@@ -1,11 +1,9 @@
+val h1 : < p : 'a; .. > Js.t -> 'a
+val h2 : < m : (int -> int -> 'a [@u]); .. > Js.t -> 'a
+val h3 : < hi : int -> int -> 'a; .. > Js.t -> 'a
+val h4 : < hi : (int -> int -> 'a [@mel.meth]); .. > Js.t -> 'a
 
-
-val h1 : < p : 'a; .. > -> 'a
-val h2 : < m : (int -> int -> 'a [@u]); .. > -> 'a
-val h3 : < hi : int -> int -> 'a; .. > -> 'a
-val h4 : < hi : (int -> int -> 'a [@mel.meth]); .. > -> 'a
-
-val h5 : < hi : int [@mel.set]; .. > -> unit
+val h5 : < hi : int [@mel.set]; .. > Js.t -> unit
 (* The inferred type is
 val h5 : < hi#= : (int -> unit [@mel.meth]); .. > -> unit
 We should propose the rescript syntax:

--- a/jscomp/test/mel_267_test.ml
+++ b/jscomp/test/mel_267_test.ml
@@ -1,7 +1,7 @@
 (* https://github.com/melange-re/melange/issues/267 *)
 
-let i ~(obj : < prop : 'a -> 'b ; .. >) s = s |> obj##prop
+let i ~(obj : < prop : 'a -> 'b ; .. > Js.t) s = s |> obj##prop
 
-let f ~(obj : < prop : 'a -> 'b ; .. >) s =
+let f ~(obj : < prop : 'a -> 'b ; .. > Js.t) s =
   let p = obj##prop in
   s |> p

--- a/jscomp/test/re_or_res/reasonReactOptimizedCreateClass.re
+++ b/jscomp/test/re_or_res/reasonReactOptimizedCreateClass.re
@@ -1,6 +1,6 @@
 let _assign = Js.Obj.assign;
 
-let emptyObject = Js.Obj.empty();
+let emptyObject: Js.t({.}) = Js.Obj.empty();
 
 [%%mel.raw
   {|

--- a/jscomp/test/unsafe_this.ml
+++ b/jscomp/test/unsafe_this.ml
@@ -26,14 +26,15 @@ type (-'this, +'tuple) u
 
 type 'a fn = (< > Js.t, 'a) u
 
-
+(* doesn't typecheck: no subtype *)
+(*
 let f (x : 'a fn) =
   (x  : 'a fn :>
      (< l : int ; y :int > Js.t, 'a) u  )
-
+ *)
 let h  (u : (< l : int ; y :int > Js.t, int) u) = u
 
-let hh (x : 'a fn) = h (x : _ fn :>   (< l : int ; y :int > Js.t, int) u )
+(* let hh (x : 'a fn) = h (x : _ fn :>   (< l : int ; y :int > Js.t, int) u ) *)
 
 (* let m = [%mel.method fun o (x,y) -> o##length < x && o##length > y ] *)
 

--- a/test/blackbox-tests/builtin-ppx-cmi-consistency.t
+++ b/test/blackbox-tests/builtin-ppx-cmi-consistency.t
@@ -37,8 +37,8 @@ Test to showcase "inconsistent assumption" issues when using melange ppx
   > EOF
 
   $ cat > lib/c.ml <<EOF
-  > type t = < a : D.t >
-  > let t: < a : D.t > = [%mel.obj { a = D.t }]
+  > type t = < a : D.t > Js.t
+  > let t: < a : D.t > Js.t = [%mel.obj { a = D.t }]
   > EOF
 
   $ cat > lib/d.ml <<EOF

--- a/test/blackbox-tests/mel-unwrap-for-obj.t
+++ b/test/blackbox-tests/mel-unwrap-for-obj.t
@@ -5,14 +5,12 @@ Test `@mel.unwrap` in `@mel.obj`
   > external func :
   >   param:string ->
   >   polyParam:([ \`Str of string | \`Int of int ][@mel.unwrap]) ->
-  >   unit ->
-  >   _ Js.t = ""
+  >   unit -> _ = ""
   > [@@mel.obj]
   > external funcOpt :
   >   param:string ->
   >   ?polyParam:([ \`Str of string | \`Int of int ][@mel.unwrap]) ->
-  >   unit ->
-  >   _ Js.t = ""
+  >   unit -> _ = ""
   > [@@mel.obj]
   > let x = func ~param:"x" ~polyParam:(\`Str "hi") ()
   > let y = funcOpt ~param:"x" ~polyParam:(\`Str "hello") ()

--- a/test/blackbox-tests/melange-playground/compile-ml-obj.t
+++ b/test/blackbox-tests/melange-playground/compile-ml-obj.t
@@ -37,7 +37,7 @@
           "col": -1
         },
         "kind": "expression",
-        "hint": "< age : int; name : string > Js.t Js__.Js_internal.t ->\n< age : int; name : string > Js.t"
+        "hint": "< age : int; name : string > Js__.Js_internal.t ->\n< age : int; name : string >"
       },
       {
         "start": {
@@ -49,7 +49,7 @@
           "col": 68
         },
         "kind": "expression",
-        "hint": "< age : int; name : string > Js.t"
+        "hint": "< age : int; name : string >"
       },
       {
         "start": {


### PR DESCRIPTION
Looks like there's a missing commit from https://github.com/rescript-lang/rescript-compiler/pull/4967 that we must have forgotten to revert: https://github.com/rescript-lang/rescript-compiler/pull/4967/commits/ee283b0cb9fbea5132d8e77271f1f231d4fba4c5

I'm going to do another pass over the full PR and make sure we're not missing anything else.

fixes #758 