### PR TITLE
test sys.argv

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,9 +2,11 @@ Unreleased
 ---------------
 
 - Add TRMC (Tail Recursion Modulo Cons) support
-  ([#743](https://github.com/melange-re/melange/pull/743)).
+  ([#743](https://github.com/melange-re/melange/pull/743))
 - [playground]: Add `melange.dom` to bundle
-  ([#779](https://github.com/melange-re/melange/pull/779)).
+  ([#779](https://github.com/melange-re/melange/pull/779))
+- Fix `Sys.argv` runtime to match declared type
+  ([#791](https://github.com/melange-re/melange/pull/791))
 
 2.0.0 2023-09-13
 ---------------

--- a/jscomp/runtime/caml_sys.ml
+++ b/jscomp/runtime/caml_sys.ml
@@ -101,13 +101,12 @@ let caml_sys_executable_name () : string =
     if Js.testAny argv then "" else Caml_array_extern.unsafe_get argv 0
 
 (* Called by {!Sys} in the toplevel, should never fail*)
-let caml_sys_argv () : string * string array =
+let caml_sys_argv () : string array =
   let module Js = Js_internal in
-  if Js.typeof [%raw {|process|}] = "undefined" then ("", [| "" |])
+  if Js.typeof [%raw {|process|}] = "undefined" then [| "" |]
   else
     let argv = [%raw {|process.argv|}] in
-    if Js.testAny argv then ("", [| "" |])
-    else (Caml_array_extern.unsafe_get argv 0, argv)
+    if Js.testAny argv then [| "" |] else argv
 
 (** {!Pervasives.sys_exit} *)
 let caml_sys_exit : int -> 'a =

--- a/jscomp/runtime/caml_sys.mli
+++ b/jscomp/runtime/caml_sys.mli
@@ -28,7 +28,7 @@ val os_type : unit -> string
 val caml_sys_system_command : string -> int
 val caml_sys_getcwd : unit -> string
 val caml_sys_executable_name : unit -> string
-val caml_sys_argv : unit -> string * string array
+val caml_sys_argv : unit -> string array
 val caml_sys_exit : int -> unit
 val caml_sys_is_directory : string -> bool
 val caml_sys_file_exists : string -> bool

--- a/test/blackbox-tests/sys-argv.t
+++ b/test/blackbox-tests/sys-argv.t
@@ -1,0 +1,50 @@
+Test case for Sys.argv
+
+  $ . ./setup.sh
+
+  $ export BUILD_PATH_PREFIX_MAP="/NODE_BIN_PATH=$(command -v node):$BUILD_PATH_PREFIX_MAP"
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (libraries melange.node)
+  >  (target js-out))
+  > EOF
+
+  $ cat > x.ml <<EOF
+  > let () = Js.log Sys.argv
+  > EOF
+
+  $ dune build @melange
+
+  $ node _build/default/js-out/x.js a b c
+  [
+    '/NODE_BIN_PATH',
+    [
+      '/NODE_BIN_PATH',
+      '$TESTCASE_ROOT/_build/default/js-out/x.js',
+      'a',
+      'b',
+      'c'
+    ]
+  ]
+
+Compare with Node.Process.argv
+
+  $ cat > x.ml <<EOF
+  > let () = Js.log Node.Process.argv
+  > EOF
+
+  $ dune build @melange
+
+  $ node _build/default/js-out/x.js a b c
+  [
+    '/NODE_BIN_PATH',
+    '$TESTCASE_ROOT/_build/default/js-out/x.js',
+    'a',
+    'b',
+    'c'
+  ]

--- a/test/blackbox-tests/sys-argv.t
+++ b/test/blackbox-tests/sys-argv.t
@@ -15,21 +15,20 @@ Test case for Sys.argv
   > EOF
 
   $ cat > x.ml <<EOF
+  > let () = Js.log Sys.executable_name
   > let () = Js.log Sys.argv
   > EOF
 
   $ dune build @melange
 
   $ node _build/default/js-out/x.js a b c
+  /NODE_BIN_PATH
   [
     '/NODE_BIN_PATH',
-    [
-      '/NODE_BIN_PATH',
-      '$TESTCASE_ROOT/_build/default/js-out/x.js',
-      'a',
-      'b',
-      'c'
-    ]
+    '$TESTCASE_ROOT/_build/default/js-out/x.js',
+    'a',
+    'b',
+    'c'
   ]
 
 Compare with Node.Process.argv


### PR DESCRIPTION
It seems `Sys.argv` is behaving in a strange way, where the first value in the array is the command, and the second is another array with the actual args.

This is different to what `Node.Process.argv` is doing (which behaves in the expected way).