### PR TITLE
feat: remove `Belt` dependency from Stdlib

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+Unreleased
+---------------
+
+- Remove `Belt` as a dependency of `Stdlib`
+  ([#796](https://github.com/melange-re/melange/pull/796))
+
+
 2.1.0 2023-10-22
 ---------------
 

--- a/jscomp/others/belt_Result.ml
+++ b/jscomp/others/belt_Result.ml
@@ -22,7 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type ('a, 'b) t = Ok of 'a | Error of 'b
+type ('a, 'b) t = ('a, 'b) Stdlib.result = Ok of 'a | Error of 'b
 
 let getExn = function Ok x -> x | Error _ -> raise Not_found
 

--- a/jscomp/others/belt_Result.mli
+++ b/jscomp/others/belt_Result.mli
@@ -41,7 +41,7 @@
   ]}
 *)
 
-type ('a, 'b) t = Ok of 'a | Error of 'b
+type ('a, 'b) t = ('a, 'b) Stdlib.result = Ok of 'a | Error of 'b
 
 val getExn : ('a, 'b) t -> 'a
 (**

--- a/jscomp/others/dune
+++ b/jscomp/others/dune
@@ -4,7 +4,7 @@
  (public_name melange.belt)
  (preprocess
   (pps melange.ppx -unsafe))
- (libraries melange.js)
+ (libraries melange)
  (modules
   :standard
   \

--- a/jscomp/stdlib/dune
+++ b/jscomp/stdlib/dune
@@ -32,7 +32,7 @@
  (modes melange)
  (preprocess
   (pps melange.ppx))
- (libraries melange.js melange.belt)
+ (libraries melange.js)
  (stdlib
   (modules_before_stdlib CamlinternalFormatBasics CamlinternalAtomic)
   (internal_modules Camlinternal*))

--- a/jscomp/stdlib/stdlib.cppo.ml
+++ b/jscomp/stdlib/stdlib.cppo.ml
@@ -324,7 +324,7 @@ external decr : int ref -> unit = "%decr"
 
 (* Result type *)
 
-type ('a,'b) result = ('a, 'b) Belt.Result.t = Ok of 'a | Error of 'b
+type ('a,'b) result = Ok of 'a | Error of 'b
 
 (* String conversion functions *)
 

--- a/jscomp/stdlib/stdlib.cppo.mli
+++ b/jscomp/stdlib/stdlib.cppo.mli
@@ -1382,7 +1382,7 @@ external decr : int ref -> unit = "%decr"
 (** {1 Result type} *)
 
 (** @since 4.03 *)
-type ('a,'b) result = ('a, 'b) Belt.Result.t = Ok of 'a | Error of 'b
+type ('a,'b) result = Ok of 'a | Error of 'b
 
 (** {1 Operations on format strings} *)
 

--- a/jscomp/test/dist/jscomp/test/ocaml_re_test.js
+++ b/jscomp/test/dist/jscomp/test/ocaml_re_test.js
@@ -3373,21 +3373,39 @@ function parse(multiline, dollar_endonly, dotall, ungreedy, s) {
             };
     }
   };
-  var regexp$p = function (_left) {
-    while(true) {
-      var left = _left;
-      if (!accept(/* '|' */124)) {
-        return left;
+  var piece = function (param) {
+    var r = atom(undefined);
+    if (accept(/* '*' */42)) {
+      return greedy_mod(repn(r, 0, undefined));
+    }
+    if (accept(/* '+' */43)) {
+      return greedy_mod(repn(r, 1, undefined));
+    }
+    if (accept(/* '?' */63)) {
+      return greedy_mod(repn(r, 0, 1));
+    }
+    if (!accept(/* '{' */123)) {
+      return r;
+    }
+    var i$1 = integer(undefined);
+    if (i$1 !== undefined) {
+      var j = accept(/* ',' */44) ? integer(undefined) : i$1;
+      if (!accept(/* '}' */125)) {
+        throw {
+              RE_EXN_ID: Parse_error,
+              Error: new Error()
+            };
       }
-      _left = alt$1({
-            hd: left,
-            tl: {
-              hd: branch$p(/* [] */0),
-              tl: /* [] */0
-            }
-          });
-      continue ;
-    };
+      if (j !== undefined && j < i$1) {
+        throw {
+              RE_EXN_ID: Parse_error,
+              Error: new Error()
+            };
+      }
+      return greedy_mod(repn(r, i$1, j));
+    }
+    i.contents = i.contents - 1 | 0;
+    return r;
   };
   var branch$p = function (_left) {
     while(true) {
@@ -3483,39 +3501,21 @@ function parse(multiline, dollar_endonly, dotall, ungreedy, s) {
       continue ;
     };
   };
-  var piece = function (param) {
-    var r = atom(undefined);
-    if (accept(/* '*' */42)) {
-      return greedy_mod(repn(r, 0, undefined));
-    }
-    if (accept(/* '+' */43)) {
-      return greedy_mod(repn(r, 1, undefined));
-    }
-    if (accept(/* '?' */63)) {
-      return greedy_mod(repn(r, 0, 1));
-    }
-    if (!accept(/* '{' */123)) {
-      return r;
-    }
-    var i$1 = integer(undefined);
-    if (i$1 !== undefined) {
-      var j = accept(/* ',' */44) ? integer(undefined) : i$1;
-      if (!accept(/* '}' */125)) {
-        throw {
-              RE_EXN_ID: Parse_error,
-              Error: new Error()
-            };
+  var regexp$p = function (_left) {
+    while(true) {
+      var left = _left;
+      if (!accept(/* '|' */124)) {
+        return left;
       }
-      if (j !== undefined && j < i$1) {
-        throw {
-              RE_EXN_ID: Parse_error,
-              Error: new Error()
-            };
-      }
-      return greedy_mod(repn(r, i$1, j));
-    }
-    i.contents = i.contents - 1 | 0;
-    return r;
+      _left = alt$1({
+            hd: left,
+            tl: {
+              hd: branch$p(/* [] */0),
+              tl: /* [] */0
+            }
+          });
+      continue ;
+    };
   };
   var $$char = function (param) {
     if (i.contents === l) {

--- a/jscomp/test/dune
+++ b/jscomp/test/dune
@@ -11,7 +11,7 @@
 (library
  (name melange_runtime_tests)
  (modes melange)
- (libraries test_runner melange.dom)
+ (libraries test_runner melange.dom melange.belt)
  (wrapped false)
  (preprocess
   (pps melange.ppx))
@@ -29,7 +29,7 @@
  (library
   (name melange_tests_re_res)
   (modes melange)
-  (libraries test_runner melange.dom)
+  (libraries test_runner melange.dom melange.belt)
   (wrapped false)
   (preprocess
    (pps melange.ppx reason-react-ppx))

--- a/test/blackbox-tests/belt-and-runtime.t
+++ b/test/blackbox-tests/belt-and-runtime.t
@@ -49,9 +49,6 @@ Now es6
   $ cat > ./_build/default/melange/node_modules/melange.js/package.json <<EOF
   > { "type": "module" }
   > EOF
-  $ cat > ./_build/default/melange/node_modules/melange.belt/package.json <<EOF
-  > { "type": "module" }
-  > EOF
 
   $ cd _build/default
   $ node ./melange/x.js

--- a/test/blackbox-tests/belt-and-runtime.t
+++ b/test/blackbox-tests/belt-and-runtime.t
@@ -17,7 +17,7 @@ Try commonjs first
   > (melange.emit
   >  (target melange)
   >  (alias melange)
-  >  (libraries melange)
+  >  (libraries melange melange.belt)
   >  (emit_stdlib false)
   >  (module_systems commonjs))
   > EOF
@@ -35,7 +35,7 @@ Now es6
   > (melange.emit
   >  (target melange)
   >  (alias melange)
-  >  (libraries melange)
+  >  (libraries melange melange.belt)
   >  (emit_stdlib false)
   >  (module_systems es6))
   > EOF
@@ -47,6 +47,9 @@ Now es6
   > EOF
 
   $ cat > ./_build/default/melange/node_modules/melange.js/package.json <<EOF
+  > { "type": "module" }
+  > EOF
+  $ cat > ./_build/default/melange/node_modules/melange.belt/package.json <<EOF
   > { "type": "module" }
   > EOF
 


### PR DESCRIPTION
- removes `melange.belt` as a dependency for the melange stdlib
- uses OCaml maps in the stdlib again
- a future PR will stop adding `melange.belt` to the libraries that melange auto-includes by default