### PR TITLE
refactor: wrap `core` library, rename it to `melangelib`

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -2,7 +2,7 @@
  (public_name melc)
  (package melange)
  (flags :standard -open Melange_compiler_libs)
- (libraries js_parser ext common melange_compiler_libs core cmdliner)
+ (libraries js_parser ext common melange_compiler_libs melangelib cmdliner)
  (modules melc melc_cli)
  (preprocess
   (action
@@ -21,7 +21,7 @@
  (modules jsoo_main jsoo_common)
  (modes byte js)
  (libraries
-  core
+  melangelib
   js_of_ocaml-compiler.runtime
   melange.dom
   melange.ppx

--- a/bin/jsoo_main.ml
+++ b/bin/jsoo_main.ml
@@ -22,6 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+open Melangelib
 open Melange_compiler_libs
 module Js = Jsoo_common.Js
 

--- a/bin/melc.ml
+++ b/bin/melc.ml
@@ -41,6 +41,7 @@ let set_abs_input_name sourcefile =
 
 let process_file sourcefile
   ?(kind ) ppf =
+  let open Melangelib in
   (* This is a better default then "", it will be changed later
      The {!Location.input_name} relies on that we write the binary ast
      properly
@@ -74,6 +75,8 @@ let process_file sourcefile
 let ppf = Format.err_formatter
 
 module As_ppx = struct
+  open Melangelib
+
   let apply: 'a. kind:'a Ml_binary.kind -> 'a -> 'a = fun ~kind ast ->
     Clflags.all_ppx := [ "melppx" ];
     Cmd_ppx_apply.apply_rewriters ~tool_name:"melppx" kind ast
@@ -171,7 +174,7 @@ let clean tmpfile =
   if not !Clflags.verbose then try Sys.remove tmpfile with _ -> ()
 
 let eval (s : string) =
-  let tmpfile = Filename.temp_file "eval" Artifact_extension.ml in
+  let tmpfile = Filename.temp_file "eval" Melangelib.Artifact_extension.ml in
   let oc = (open_out_bin tmpfile) in
   Fun.protect
     ~finally:(fun () -> close_out oc)
@@ -262,6 +265,7 @@ let main: Melc_cli.t -> _ Cmdliner.Term.ret
       filenames;
       help
     } ->
+  let open Melangelib in
   if help then `Help (`Auto, None)
   else begin try
     Clflags.include_dirs :=
@@ -414,7 +418,7 @@ let file_level_flags_handler (e : Parsetree.expression option) =
     Location.raise_errorf ~loc:e.pexp_loc "string array expected"
 
 let () =
-  Initialization.Global.run ();
+  Melangelib.Initialization.Global.run ();
   let flags = "flags" in
   Ast_config.add_structure
     flags file_level_flags_handler;

--- a/bin/melc_cli.ml
+++ b/bin/melc_cli.ml
@@ -116,7 +116,7 @@ let warnings =
      <spec> can be:\n\
      <num>             a single warning number\n\
      <num1>..<num2>    a range of consecutive warning numbers\n\
-     default setting is " ^ Melc_warnings.defaults_w
+     default setting is " ^ Melangelib.Melc_warnings.defaults_w
   in
   let docv = "list" in
   Arg.(value & opt_all string [] & info [ "w" ] ~doc ~docv)
@@ -234,7 +234,7 @@ let warn_error =
   let doc =
     "Enable or disable error status for warnings according\n\
      to $(docv).  See option -w for the syntax of $(docv).\n\
-     Default setting is " ^ Melc_warnings.defaults_warn_error
+     Default setting is " ^ Melangelib.Melc_warnings.defaults_warn_error
   in
   Arg.(value & opt_all string [] & info [ "warn-error" ] ~doc)
 

--- a/jscomp/core/dune
+++ b/jscomp/core/dune
@@ -1,6 +1,5 @@
 (library
- (name core)
- (wrapped false)
+ (name melangelib)
  (flags
   (:standard -open Melange_compiler_libs))
  (libraries ext common melange_compiler_libs ppxlib.ast))


### PR DESCRIPTION
still a part of https://github.com/melange-re/melange/issues/113, perhaps the last one