### PR TITLE
fix(playground): remove `melange.dom` dependency from `bin/jsoo_main.bc.js`

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -23,7 +23,6 @@
  (libraries
   core
   js_of_ocaml-compiler.runtime
-  melange.dom
   melange.ppx
   reason-react-ppx
   reason))


### PR DESCRIPTION
looks like it was added by mistake in https://github.com/melange-re/melange/pull/779 and I didn't catch it when reviewing, but this doesn't actually do anything, and would produce a dune error if used (it only has `modes melange`).