### PR TITLE
Playground: fix warn error prop

### DIFF
--- a/bin/jsoo_main.ml
+++ b/bin/jsoo_main.ml
@@ -259,7 +259,7 @@ let compile =
       | None -> (
           let default =
             lazy
-              (Js.obj [| ("js_error_msg", Js.string (Printexc.to_string e)) |])
+              (Js.obj [| ("js_warning_error_msg", Js.string (Printexc.to_string e)) |])
           in
           match e with
           | Warnings.Errors -> (

--- a/test/blackbox-tests/melange-playground/compile-re-error-syntax-locations.t
+++ b/test/blackbox-tests/melange-playground/compile-re-error-syntax-locations.t
@@ -3,7 +3,7 @@ Some Reason errors dont have locations
   $ cat > input.js <<EOF
   > require(process.env.DUNE_SOURCEROOT + '/_build/default/bin/jsoo_main.bc.js');
   > require(process.env.DUNE_SOURCEROOT + '/_build/default/bin/melange-cmijs.js');
-  > console.log(ocaml.compileRE("let sum = item => swiftch (item) { | Leaf => 0 };").js_error_msg.trim());
+  > console.log(ocaml.compileRE("let sum = item => swiftch (item) { | Leaf => 0 };").js_warning_error_msg.trim());
   > EOF
 
   $ node input.js


### PR DESCRIPTION
In #850 the public interface changed, from `js_error_msg` to `js_warning_error_msg`. But I forgot to update one place.