### PR TITLE
fix: move utf8-string interpolation empty error back 1 char

### DIFF
--- a/ppx/utf8_string.ml
+++ b/ppx/utf8_string.ml
@@ -312,14 +312,14 @@ module Interp = struct
                 {
                   cxt.segment_start with
                   offset =
-                    (match cxt.segment_start.offset with 0 -> 0 | n -> n - 2);
+                    (match cxt.segment_start.offset with 0 -> 0 | n -> n - 3);
                   byte_bol =
                     (match cxt.segment_start.byte_bol with
                     | 0 -> 0
-                    | n -> n - 2);
+                    | n -> n - 3);
                 };
-              pos_bol = cxt.pos_bol + 2;
-              byte_bol = cxt.byte_bol + 2;
+              pos_bol = cxt.pos_bol + 3;
+              byte_bol = cxt.byte_bol + 3;
             }
         | _ -> cxt
       in

--- a/test/blackbox-tests/utf8-string-interp.t
+++ b/test/blackbox-tests/utf8-string-interp.t
@@ -5,9 +5,9 @@
   > let x = {j| Hello, \$()|j}
   > EOF
   $ melc -ppx melppx x.ml
-  File "x.ml", line 1, characters 20-23:
+  File "x.ml", line 1, characters 19-22:
   1 | let x = {j| Hello, $()|j}
-                          ^^^
+                         ^^^
   Error: `' is not a valid syntax of interpolated identifer
   [2]
 
@@ -15,8 +15,8 @@
   > let x = {j| Hello, \$(   )|j}
   > EOF
   $ melc -ppx melppx x.ml
-  File "x.ml", line 1, characters 20-26:
+  File "x.ml", line 1, characters 19-25:
   1 | let x = {j| Hello, $(   )|j}
-                          ^^^^^^
+                         ^^^^^^
   Error: `   ' is not a valid syntax of interpolated identifer
   [2]

--- a/test/unit-tests/ounit_unicode_tests.ml
+++ b/test/unit-tests/ounit_unicode_tests.ml
@@ -186,7 +186,7 @@ let suites =
            | exception
                Utf8_string.Interp.Error
                  ( { lnum = 0; offset = 0; byte_bol = 0 },
-                   { lnum = 0; offset = 1; byte_bol = 2 },
+                   { lnum = 0; offset = 0; byte_bol = 3 },
                    Invalid_syntax_of_var "" ) ->
                OUnit.assert_bool __LOC__ true
            | _ -> OUnit.assert_bool __LOC__ false );


### PR DESCRIPTION
based on [feedback](https://github.com/melange-re/melange/pull/888#discussion_r1392126428) from #888