### PR TITLE
Fix #658: handle case cmj not available

### DIFF
--- a/jscomp/core/lam_arity_analysis.ml
+++ b/jscomp/core/lam_arity_analysis.ml
@@ -48,9 +48,9 @@ let rec get_arity (meta : Lam_stats.t) (lam : Lam.t) : Lam_arity.t =
         args = [ Lglobal_module id ];
         _;
       } -> (
-      match (Lam_compile_env.query_external_id_info id name).arity with
-      | Single x -> x
-      | Submodule _ -> Lam_arity.na)
+      match Lam_compile_env.query_external_id_info id name with
+      | Some { arity = Single x; _ } -> x
+      | Some { arity = Submodule _; _ } | None -> Lam_arity.na)
   | Lprim
       {
         primitive = Pfield (m, _);
@@ -65,9 +65,10 @@ let rec get_arity (meta : Lam_stats.t) (lam : Lam.t) : Lam_arity.t =
           ];
         _;
       } -> (
-      match (Lam_compile_env.query_external_id_info id name).arity with
-      | Submodule subs -> subs.(m) (* TODO: shall we store it as array?*)
-      | Single _ -> Lam_arity.na)
+      match Lam_compile_env.query_external_id_info id name with
+      | Some { arity = Submodule subs; _ } ->
+          subs.(m) (* TODO: shall we store it as array?*)
+      | Some { arity = Single _; _ } | None -> Lam_arity.na)
   (* TODO: all information except Pccall is complete, we could
      get more arity information
   *)

--- a/jscomp/core/lam_compile_env.mli
+++ b/jscomp/core/lam_compile_env.mli
@@ -59,7 +59,7 @@ val add_js_module :
    pay attention to for those modules are actually used or not
 *)
 
-val query_external_id_info : Ident.t -> string -> Js_cmj_format.keyed_cmj_value
+val query_external_id_info : Ident.t -> string -> Js_cmj_format.keyed_cmj_value option
 (**
   [query_external_id_info id pos env found]
   will raise if not found

--- a/jscomp/core/lam_pass_remove_alias.ml
+++ b/jscomp/core/lam_pass_remove_alias.ml
@@ -133,7 +133,7 @@ let simplify_alias (meta : Lam_stats.t) (lam : Lam.t) : Lam.t =
           ap_info;
         } -> (
         match Lam_compile_env.query_external_id_info ident fld_name with
-        | { persistent_closed_lambda = Some (Lfunction { params; body; _ }); _ }
+        | Some { persistent_closed_lambda = Some (Lfunction { params; body; _ }); _ }
         (* be more cautious when do cross module inlining *)
           when List.same_length params args
                && List.for_all

--- a/jscomp/core/mel_exception.mli
+++ b/jscomp/core/mel_exception.mli
@@ -33,7 +33,7 @@ TODO: In the futrue, we should refine dependency [bsb]
 should not rely on such exception, it should have its own exception handling
 *)
 
-(* exception Error of error *)
+exception Error of error
 
 (* val report_error : Format.formatter -> error -> unit *)
 


### PR DESCRIPTION
Fix #658 
Not perfect solution, but considered more acceptable than break the virtual library function.
Idea: fallback to `Curry._N` while cmj not available