### PR TITLE
chore(build): fix makefile for OCaml 5.1.1-trunk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 
 .PHONY: opam-create-switch
 opam-create-switch: ## Create opam switch
-	opam switch create . 5.1.0 -y --no-install
+	opam switch create . ocaml-variants.5.1.1+trunk -y --no-install
 
 .PHONY: opam-install-test
 opam-install-test: ## Install test dependencies


### PR DESCRIPTION
after #926, we need to set up a switch with ocaml-variants.5.1.1-trunk.

@jchavarri could you try setting up an opam switch for this new change and check if it works?
