### PR TITLE
feat(ppx): disallow attribute payload in `[@mel.new]`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -65,6 +65,9 @@ Unreleased
   ([#930](https://github.com/melange-re/melange/pull/930))
 - BREAKING(core): require OCaml 5.1.1
   ([#926](https://github.com/melange-re/melange/pull/926))
+- BREAKING(ppx): disallow attribute payload in `[@mel.new]` in favor of the
+  external primiative string
+  ([#938](https://github.com/melange-re/melange/pull/938))
 
 2.1.0 2023-10-22
 ---------------

--- a/jscomp/test/demo.ml
+++ b/jscomp/test/demo.ml
@@ -3,27 +3,27 @@ external addChild : stackPanel -> #widget -> unit = "x" [@@mel.send]
 
 
 external new_HostedWindow : unit -> hostedWindow Js.t = "HostedWindow"
-    [@@mel.new ] [@@mel.module "@blp/ui", "BUI"]
+    [@@mel.new] [@@mel.module "@blp/ui", "BUI"]
 
-external new_HostedContent : unit -> hostedContent Js.t = ""
-    [@@mel.new "HostedContent"] [@@mel.module "@blp/ui", "BUI"]
+external new_HostedContent : unit -> hostedContent Js.t = "HostedContent"
+    [@@mel.new] [@@mel.module "@blp/ui", "BUI"]
 
-external new_StackPanel : unit -> stackPanel Js.t = ""
-    [@@mel.new "StackPanel"] [@@mel.module "@ui", "UI"]
+external new_StackPanel : unit -> stackPanel Js.t = "StackPanel"
+    [@@mel.new] [@@mel.module "@ui", "UI"]
 
-external new_textArea : unit -> textArea Js.t = ""
-    [@@mel.new "TextArea"] [@@mel.module "@ui", "UI"]
+external new_textArea : unit -> textArea Js.t = "TextArea"
+    [@@mel.new] [@@mel.module "@ui", "UI"]
 
-external new_button : unit -> button Js.t = ""
-    [@@mel.new "Button"] [@@mel.module "@ui", "UI"]
+external new_button : unit -> button Js.t = "Button"
+    [@@mel.new] [@@mel.module "@ui", "UI"]
 
-external new_grid : unit -> grid Js.t = ""
-    [@@mel.new "Grid"] [@@mel.module "@ui", "UI"]
+external new_grid : unit -> grid Js.t =  "Grid"
+    [@@mel.new] [@@mel.module "@ui", "UI"]
 
 (* Note, strictly speaking, it 's not returning a primitive string, it returns
    an object string *)
-external stringify : 'a -> string = ""
-    [@@mel.new "String"]
+external stringify : 'a -> string = "String"
+    [@@mel.new]
 
 external random : unit -> float = "Math.random"
 

--- a/jscomp/test/test_array_primitive.ml
+++ b/jscomp/test/test_array_primitive.ml
@@ -1,4 +1,4 @@
-external new_uninitialized_array : int -> 'a array = "" [@@mel.new "Array"]
+external new_uninitialized_array : int -> 'a array =  "Array" [@@mel.new]
 
 let caml_array_sub (x : 'a array) (offset : int) (len : int) =
   let result = new_uninitialized_array len  in

--- a/ppx/ast_external_process.ml
+++ b/ppx/ast_external_process.ml
@@ -922,7 +922,7 @@ let external_desc_of_non_obj (loc : Location.t) (st : external_desc)
       Location.raise_errorf ~loc
         "Found an attribute that can't be used with `%@mel.send.pipe'"
   | {
-   new_name = `Nm_external (lazy name) | `Nm_payload name;
+   new_name = `Nm_external (lazy name);
    external_module_name;
    call_name = `Nm_na;
    module_as_val = None;


### PR DESCRIPTION
this change unifies the FFI language a bit more, disallowing `external` declarations with `[@@mel.new "Constructor"]`.

it plays better with the warnings that we issue when the external primitive name is `""`. In this case, the constructor must always appear in the primitive name, which makes the FFI language a bit more consistent.