### PR TITLE
nested mel uncurry experiment

### DIFF
--- a/jscomp/common/external_arg_spec.ml
+++ b/jscomp/common/external_arg_spec.ml
@@ -61,6 +61,7 @@ type attr =
   | Nothing
   | Ignore
   | Unwrap
+  | Nested_callback of { this : attr; args : attr list }
 
 type param = { arg_type : attr; arg_label : label_noname }
 type obj_param = { obj_arg_type : attr; obj_arg_label : label }

--- a/jscomp/common/external_arg_spec.mli
+++ b/jscomp/common/external_arg_spec.mli
@@ -45,6 +45,7 @@ type attr =
   | Nothing
   | Ignore
   | Unwrap
+  | Nested_callback of { this : attr; args : attr list }
 
 type label_noname = Arg_label | Arg_empty | Arg_optional
 type obj_param = { obj_arg_type : attr; obj_arg_label : label }
@@ -56,8 +57,6 @@ val cst_obj_literal : string -> cst
 val cst_int : int -> cst
 val cst_string : string -> cst
 val empty_label : label
-
-(* val empty_lit : cst -> label  *)
 val obj_label : string -> label
 val optional : bool -> string -> label
 val empty_kind : attr -> obj_param

--- a/jscomp/core/lam_compile_external_call.ml
+++ b/jscomp/core/lam_compile_external_call.ml
@@ -106,8 +106,8 @@ let ocaml_to_js_eff ~(arg_label : Melange_ffi.External_arg_spec.label_noname)
   in
   match arg_type with
   | Arg_cst _ -> assert false
-  | Fn_uncurry_arity _ -> assert false
-  (* has to be preprocessed by {!Lam} module first *)
+  | Nested_callback { this = Fn_uncurry_arity _; _ } | Fn_uncurry_arity _ ->
+      assert false (* has to be preprocessed by {!Lam} module first *)
   | Extern_unit ->
       ( (if arg_label = Arg_empty then Splice0 else Splice1 E.unit),
         if Js_analyzer.no_side_effect_expression arg then [] else [ arg ] )
@@ -142,7 +142,8 @@ let ocaml_to_js_eff ~(arg_label : Melange_ffi.External_arg_spec.label_noname)
         | _ -> Js_of_lam_variant.eval_as_unwrap raw_arg
       in
       (Splice1 single_arg, [])
-  | Nothing -> (Splice1 arg, [])
+  | Nothing | Nested_callback { this = Nothing; args = [] } -> (Splice1 arg, [])
+  | Nested_callback _ -> assert false
 
 let empty_pair = ([], [])
 let add_eff eff e = match eff with None -> e | Some v -> E.seq v e


### PR DESCRIPTION
putting this up to show how it can't really work at the melange level because nested `mel.uncurry` callbacks aren't arguments that we pass, but rather passed from the JS side. 