### PR TITLE
opam: fix ocaml-lsp installation

### DIFF
--- a/melange.opam
+++ b/melange.opam
@@ -39,6 +39,6 @@ dev-repo: "git+https://github.com/melange-re/melange.git"
 pin-depends: [
   [ "js_of_ocaml-compiler.dev" "https://github.com/ocsigen/js_of_ocaml/archive/31e5d22f96435e511c8bd6e2a6d43f7c5fb13dec.tar.gz" ]
   [ "js_of_ocaml.dev" "https://github.com/ocsigen/js_of_ocaml/archive/31e5d22f96435e511c8bd6e2a6d43f7c5fb13dec.tar.gz" ]
-  [ "merlin-lib.dev" "https://github.com/voodoos/merlin/archive/15491d05db13ec6beaf3c84632914c29b674270d.tar.gz" ]
-  [ "merlin.dev" "https://github.com/voodoos/merlin/archive/15491d05db13ec6beaf3c84632914c29b674270d.tar.gz" ]
+  [ "merlin-lib.4.13.1-501" "https://github.com/voodoos/merlin/archive/15491d05db13ec6beaf3c84632914c29b674270d.tar.gz" ]
+  [ "merlin.4.13.1-501" "https://github.com/voodoos/merlin/archive/15491d05db13ec6beaf3c84632914c29b674270d.tar.gz" ]
 ]

--- a/melange.opam.template
+++ b/melange.opam.template
@@ -1,6 +1,6 @@
 pin-depends: [
   [ "js_of_ocaml-compiler.dev" "https://github.com/ocsigen/js_of_ocaml/archive/31e5d22f96435e511c8bd6e2a6d43f7c5fb13dec.tar.gz" ]
   [ "js_of_ocaml.dev" "https://github.com/ocsigen/js_of_ocaml/archive/31e5d22f96435e511c8bd6e2a6d43f7c5fb13dec.tar.gz" ]
-  [ "merlin-lib.dev" "https://github.com/voodoos/merlin/archive/15491d05db13ec6beaf3c84632914c29b674270d.tar.gz" ]
-  [ "merlin.dev" "https://github.com/voodoos/merlin/archive/15491d05db13ec6beaf3c84632914c29b674270d.tar.gz" ]
+  [ "merlin-lib.4.13.1-501" "https://github.com/voodoos/merlin/archive/15491d05db13ec6beaf3c84632914c29b674270d.tar.gz" ]
+  [ "merlin.4.13.1-501" "https://github.com/voodoos/merlin/archive/15491d05db13ec6beaf3c84632914c29b674270d.tar.gz" ]
 ]


### PR DESCRIPTION
a small follow up to #962. there's a constraint on lsp server: `ocaml-lsp-server → merlin-lib < 5.0`. the changes in this pr work around it by replacing `dev` with `4.13.1-501` for merlin pkgs. for some reason these packages [have been already published](https://github.com/ocaml/opam-repository/pull/24882/), but they don't appear in the opam main mirror.