### PR TITLE
test: show how to use `[@mel.meth]`

### DIFF
--- a/test/blackbox-tests/meth-arity.t
+++ b/test/blackbox-tests/meth-arity.t
@@ -1,0 +1,54 @@
+Showcase how to use `[@mel.meth]`
+
+ $ . ./setup.sh
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target melange)
+  >  (alias mel)
+  >  (preprocess (pps melange.ppx))
+  >  (emit_stdlib false))
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > let props : < foo : int -> string -> unit > Js.t =
+  >   [%mel.raw
+  >     {| {
+  >     foo: function(a, b) {
+  >       console.log("a:", a);
+  >       console.log("b:", b);
+  >     } }|}]
+  > 
+  > let x = props##foo 123 "abc"
+  > EOF
+
+  $ dune build @mel
+  File "main.ml", line 9, characters 8-18:
+  9 | let x = props##foo 123 "abc"
+              ^^^^^^^^^^
+  Error: This expression has type int -> string -> unit
+         but an expression was expected of type 'a Js__Js_OO.Meth.arity2
+  [1]
+
+Methods in ( < .. > Js.t) need a `[@mel.meth]` annotation
+
+  $ cat > main.ml <<EOF
+  > let props : < foo : (int -> string -> unit [@mel.meth]) > Js.t =
+  >   [%mel.raw
+  >     {| {
+  >     foo: function(a, b) {
+  >       console.log("a:", a);
+  >       console.log("b:", b);
+  >     } }|}]
+  > 
+  > let x = props##foo 123 "abc"
+  > EOF
+
+  $ dune build @mel
+  $ node _build/default/melange/main.js
+  a: 123
+  b: abc

--- a/test/blackbox-tests/meth-arity.t
+++ b/test/blackbox-tests/meth-arity.t
@@ -10,8 +10,7 @@ Showcase how to use `[@mel.meth]`
   > (melange.emit
   >  (target melange)
   >  (alias mel)
-  >  (preprocess (pps melange.ppx))
-  >  (emit_stdlib false))
+  >  (preprocess (pps melange.ppx)))
   > EOF
 
   $ cat > main.ml <<EOF


### PR DESCRIPTION
- partly extracted from #984
- showing a bad error related to `'a Js__Js_OO.Meth.arity2` which I'll fix in a separate PR (and should change the diff)