### PR TITLE
fix: print better errors for mismatched [@mel.meth] arity

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -108,6 +108,8 @@ Unreleased
 - runtime(`Js.String`): deprecate `anchor`, `link` and `substr` functions to
   match the JS standard deprecations
   [#982](https://github.com/melange-re/melange/pull/982)
+- Fix error messages related to `[@mel.meth]` arity mismatches
+  ([PR](https://github.com/melange-re/melange/pull/986))
 
 2.2.0 2023-12-05
 ---------------

--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701741565,
-        "narHash": "sha256-oJ2C+tn4ZIuo5G0AKFp3NBEodrvOXYEmypRlrL+LXB8=",
+        "lastModified": 1702477208,
+        "narHash": "sha256-ujzFs0pA1v0Fis3SqVc7FNA39jbBZASBbRay9Dednak=",
         "owner": "melange-re",
         "repo": "melange-compiler-libs",
-        "rev": "d062a28e4bd8115d3aa0a45e98b6fb387e65a486",
+        "rev": "5da5218fe400ed43b5325998b9298dbabc45b8f4",
         "type": "github"
       },
       "original": {

--- a/test/blackbox-tests/meth-arity.t
+++ b/test/blackbox-tests/meth-arity.t
@@ -30,7 +30,7 @@ Showcase how to use `[@mel.meth]`
   9 | let x = props##foo 123 "abc"
               ^^^^^^^^^^
   Error: This expression has type int -> string -> unit
-         but an expression was expected of type 'a Js__Js_OO.Meth.arity2
+         but an expression was expected of type ('a [@mel.meth])
   [1]
 
 Methods in ( < .. > Js.t) need a `[@mel.meth]` annotation


### PR DESCRIPTION
- part of #983 
- companion to https://github.com/melange-re/melange-compiler-libs/pull/34
- messages previously displayed as `'a Js__Js_OO.Meth.arityN` are now `('a [@mel.meth])`
