### PR TITLE
`Js.Re`: add labeled argument

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -93,7 +93,8 @@ Unreleased
 - BREAKING(runtime): Improve `Js.Date` and change some of its functions to
   pipe-last ([#967](https://github.com/melange-re/melange/pull/967))
 - BREAKING(runtime): Improve `Js.Re` and change some of its functions to
-  pipe-last ([#969](https://github.com/melange-re/melange/pull/969))
+  pipe-last ([#969](https://github.com/melange-re/melange/pull/969),
+  [#989](https://github.com/melange-re/melange/pull/989))
 - BREAKING(runtime): Improve docstrings in the `Node` library and change some
   of its functions to pipe-last
   ([#970](https://github.com/melange-re/melange/pull/970))

--- a/jscomp/runtime/js_re.ml
+++ b/jscomp/runtime/js_re.ml
@@ -70,7 +70,7 @@ Regex literals ([\[%re "/.../"\]]) should generally be preferred, but
 
 let contentOf tag xmlString =
   Js.Re.fromString ("<" ^ tag ^ ">(.*?)<\\/" ^ tag ^">")
-    |> Js.Re.exec xmlString
+    |> Js.Re.exec ~str:xmlString
     |> function
       | Some result -> Js.Nullable.toOption (Js.Re.captures result).(1)
       | None -> None
@@ -122,7 +122,7 @@ let str = "abbcdefabh" in
 
 let break = ref false in
 while not !break do
-  match re |> Js.Re.exec str with
+  match re |> Js.Re.exec ~str with
   | None -> break := true
   | Some result ->
     Js.Nullable.iter (Js.Re.captures result).(0) ((fun match_ ->
@@ -154,7 +154,7 @@ external unicode : t -> bool = "unicode"
 [@@mel.get]
 (** returns a bool indicating whether the [unicode] flag is set *)
 
-external exec : string -> result option = "exec"
+external exec : str:string -> result option = "exec"
 [@@mel.send.pipe: t] [@@mel.return null_to_opt]
 (** executes a search on a given string using the given RegExp object
 
@@ -167,13 +167,13 @@ external exec : string -> result option = "exec"
  *)
 
 let re = [%re "/quick\s(brown).+?(jumps)/ig"] in
-let result = re |. Js.Re.exec_ "The Quick Brown Fox Jumps Over The Lazy Dog"
+let result = re |. Js.Re.exec ~str:"The Quick Brown Fox Jumps Over The Lazy Dog"
 ]}
 
 @see <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec> MDN
 *)
 
-external test : string -> bool = "test"
+external test : str:string -> bool = "test"
 [@@mel.send.pipe: t]
 (** tests whether the given RegExp object will match a given string
 
@@ -186,7 +186,7 @@ let str = "hello world!"
 
 let startsWith target substring =
   Js.Re.fromString ("^" ^ substring)
-    |. Js.Re.test_ target
+    |. Js.Re.test ~str:target
 
 let () = Js.log (str |. startsWith "hello") (* prints "true" *)
 ]}

--- a/jscomp/test/gpr_1501_test.ml
+++ b/jscomp/test/gpr_1501_test.ml
@@ -13,10 +13,10 @@ let () =
 
     eq __LOC__ "Not_found" (Printexc.to_string Not_found);
     eq __LOC__
-      (Js.Re.test (Printexc.to_string A) [%re{|/Gpr_1501_test.A\/[0-9]+/|}])
+      (Js.Re.test ~str:(Printexc.to_string A) [%re{|/Gpr_1501_test.A\/[0-9]+/|}])
       true;
     eq __LOC__
-    (Js.Re.test (Printexc.to_string (B 1)) [%re{|/Gpr_1501_test.B\/[0-9]+\(1\)/|}]) true
+    (Js.Re.test ~str:(Printexc.to_string (B 1)) [%re{|/Gpr_1501_test.B\/[0-9]+\(1\)/|}]) true
 
 let () =
     Mt.from_pair_suites __MODULE__ !suites

--- a/jscomp/test/gpr_3895_test.ml
+++ b/jscomp/test/gpr_3895_test.ml
@@ -1,3 +1,3 @@
 let f re =
-  let _ = re |> Js.Re.exec "banana" in
+  let _ = re |> Js.Re.exec ~str:"banana" in
   3

--- a/jscomp/test/js_re_test.ml
+++ b/jscomp/test/js_re_test.ml
@@ -2,7 +2,7 @@ let suites = Mt.[
   "captures", (fun _ ->
     let re = [%re "/(\\d+)-(?:(\\d+))?/g"] in
     let str = "3-" in
-    match re |> Js.Re.exec str with
+    match re |> Js.Re.exec ~str with
       | Some result ->
         let defined = (Js.Re.captures result).(1) in
         let undefined = (Js.Re.captures result).(2) in
@@ -14,7 +14,7 @@ let suites = Mt.[
     (* From the example in js_re.mli *)
     let contentOf tag xmlString =
       Js.Re.fromString ("<" ^ tag ^ ">(.*?)<\\/" ^ tag ^">")
-        |> Js.Re.exec xmlString
+        |> Js.Re.exec ~str:xmlString
         |. function
           | Some result -> Js.Nullable.toOption (Js.Re.captures result).(1)
           | None -> None in
@@ -22,7 +22,7 @@ let suites = Mt.[
   );
 
   "exec_literal", (fun _ ->
-    match [%re "/[^.]+/"] |> Js.Re.exec "http://xxx.domain.com" with
+    match [%re "/[^.]+/"] |> Js.Re.exec ~str:"http://xxx.domain.com" with
     | Some res ->
       Eq(Js.Nullable.return "http://xxx", (Js.Re.captures res).(0))
     | None ->
@@ -30,7 +30,7 @@ let suites = Mt.[
   );
 
   "exec_no_match", (fun _ ->
-    match [%re "/https:\\/\\/(.*)/"] |> Js.Re.exec "http://xxx.domain.com" with
+    match [%re "/https:\\/\\/(.*)/"] |> Js.Re.exec ~str:"http://xxx.domain.com" with
     | Some _ ->  FailWith "regex should not match"
     | None -> Ok true
   );
@@ -38,7 +38,7 @@ let suites = Mt.[
   "test_str", (fun _ ->
     let res = "foo"
       |. Js.Re.fromString
-      |> Js.Re.test "#foo#" in
+      |> Js.Re.test ~str:"#foo#" in
 
     Eq(true, res)
   );
@@ -49,7 +49,7 @@ let suites = Mt.[
     Eq(true, res |. Js.Re.global)
   );
   "result_index", (fun _ ->
-    match "zbar" |. Js.Re.fromString |> Js.Re.exec "foobarbazbar" with
+    match "zbar" |. Js.Re.fromString |> Js.Re.exec ~str:"foobarbazbar" with
     | Some res ->
       Eq(8, res |> Js.Re.index)
     | None ->
@@ -58,7 +58,7 @@ let suites = Mt.[
   "result_input", (fun _ ->
     let input = "foobar" in
 
-    match [%re "/foo/g"] |> Js.Re.exec input with
+    match [%re "/foo/g"] |> Js.Re.exec ~str:input with
     | Some res ->
       Eq(input,  res |> Js.Re.input)
     | None ->
@@ -78,7 +78,7 @@ let suites = Mt.[
   );
   "t_lastIndex", (fun _ ->
     let re = [%re "/na/g"] in
-    let _ = re |> Js.Re.exec "banana" in     (* Caml_option.null_to_opt post operation is not dropped in 4.06 which seems to be reduandant *)
+    let _ = re |> Js.Re.exec ~str:"banana" in     (* Caml_option.null_to_opt post operation is not dropped in 4.06 which seems to be reduandant *)
     Eq(4,  re |. Js.Re.lastIndex)
   );
   "t_setLastIndex", (fun _ ->


### PR DESCRIPTION
Maybe it makes sense to add labeled args to `Js.Re` for consistency with `Js.String`, `Js.Array`...

cc @davesnx 