### PR TITLE
fix(utf8): emit `Js.String` instead of `Js.String2`

### DIFF
--- a/jscomp/core/js_dump_string.ml
+++ b/jscomp/core/js_dump_string.ml
@@ -28,7 +28,6 @@ module P = Js_pp
 (** Avoid to allocate single char string too many times*)
 let array_str1 = Array.init 256 ~f:(fun i -> String.make 1 (Char.chr i))
 
-(* For converting *)
 let array_conv =
   [|
     "0";

--- a/jscomp/core/js_dump_string.mli
+++ b/jscomp/core/js_dump_string.mli
@@ -25,7 +25,6 @@
 open Import
 
 (* Make sure the escaped string conforms to
-   JS lexing convention
-*)
+   JS lexing convention *)
 val escape_to_string : string -> string
 val pp_string : Js_pp.t -> string -> unit


### PR DESCRIPTION
This change is best viewed without whitespace https://github.com/melange-re/melange/pull/994/files?w=1