### PR TITLE
feat: allow melange to work with OCaml 4.14

### DIFF
--- a/bin/melc.ml
+++ b/bin/melc.ml
@@ -84,9 +84,11 @@ module As_ppx = struct
     Cmd_ppx_apply.apply_rewriters ~tool_name:"melppx" kind ast
 
 
+module Melange_ast_version = Melangelib.Ast_io.Melange_ast_version
+
 module Convert =
   Ppxlib_ast.Convert
-    (Ppxlib_ast__.Versions.OCaml_501)
+    (Melange_ast_version)
     (Ppxlib_ast__.Versions.OCaml_current)
 
 let apply_lazy ~source ~target =
@@ -98,7 +100,7 @@ let apply_lazy ~source ~target =
   | Intf ast ->
       let ast: Ppxlib_ast__.Versions.OCaml_current.Ast.Parsetree.signature =
         let ast = apply ~kind:Ml_binary.Mli ast in
-        let ppxlib_ast: Ppxlib_ast__.Versions.OCaml_501.Ast.Parsetree.signature =
+        let ppxlib_ast: Melange_ast_version.Ast.Parsetree.signature =
           Obj.magic ast
         in
         Convert.copy_signature ppxlib_ast
@@ -112,7 +114,7 @@ let apply_lazy ~source ~target =
         let ast: Melange_compiler_libs.Parsetree.structure =
           apply ~kind:Ml_binary.Ml ast
         in
-        let ppxlib_ast: Ppxlib_ast__.Versions.OCaml_501.Ast.Parsetree.structure =
+        let ppxlib_ast: Melange_ast_version.Ast.Parsetree.structure =
           Obj.magic ast
         in
         Convert.copy_structure ppxlib_ast

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704861910,
+        "lastModified": 1705466801,
         "narHash": "sha256-1dub8rJZkAjZiKR0EopdXVP3JCbSq/8fAw2Fei0Hh+E=",
         "owner": "melange-re",
         "repo": "melange-compiler-libs",
-        "rev": "61653c60844cd04af5733512768618fa9b05ec71",
+        "rev": "87bb98024b1669766f9c8aec3bbbf73ef332dcb6",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1701697642,
-        "narHash": "sha256-L217WytWZHSY8GW9Gx1A64OnNctbuDbfslaTEofXXRw=",
+        "lastModified": 1705332318,
+        "narHash": "sha256-kcw1yFeJe9N4PjQji9ZeX47jg0p9A0DuU4djKvg1a7I=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "c843418ecfd0344ecb85844b082ff5675e02c443",
+        "rev": "3449dc925982ad46246cfc36469baf66e1b64f17",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1705277551,
-        "narHash": "sha256-T/HpuRjBj4CRGYSLvs3ezlzcp2WlRr5eBUrGfrCBGKc=",
+        "lastModified": 1705460136,
+        "narHash": "sha256-4bl+nspzOzkCt1m+jo8KkT2G+ckSUekyr8lY56oklCc=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "4798c7a11836ba876bf5e0402d4dd730139c8ebb",
+        "rev": "e44898b2f22f6cac71a8a8f687d1b2ff52d12a79",
         "type": "github"
       },
       "original": {
@@ -79,17 +79,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705069489,
-        "narHash": "sha256-kXk4DUZS5uEdowgcv5PWVJ1s37xZKPvhpD/CFNdWMbs=",
+        "lastModified": 1705293701,
+        "narHash": "sha256-yJs738MxB+RsxGETqESof15lRJ5za6s3NmhjbXt8Kt4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d",
+        "rev": "715fac4e39626ca0d24481f3d1fdd54dbeeaced8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d",
+        "rev": "715fac4e39626ca0d24481f3d1fdd54dbeeaced8",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
     } // (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages."${system}".extend (self: super: {
-          ocamlPackages = super.ocaml-ng.ocamlPackages_4_14;
+          ocamlPackages = super.ocaml-ng.ocamlPackages_5_1;
         });
 
         packages =

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
     } // (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages."${system}".extend (self: super: {
-          ocamlPackages = super.ocaml-ng.ocamlPackages_5_1;
+          ocamlPackages = super.ocaml-ng.ocamlPackages_4_14;
         });
 
         packages =

--- a/jscomp/core/ast_io.cppo.ml
+++ b/jscomp/core/ast_io.cppo.ml
@@ -23,6 +23,14 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 open Import
+
+module Melange_ast_version =
+#if OCAML_VERSION >= (5, 1, 0)
+  Ppxlib_ast__.Versions.OCaml_501
+#else
+  Ppxlib_ast__.Versions.OCaml_414
+#endif
+
 module Compiler_version = Ppxlib_ast.Compiler_version
 
 module type OCaml_version = Ppxlib_ast.OCaml_version
@@ -35,7 +43,7 @@ module Intf_or_impl = struct
   module Convert =
     Ppxlib_ast.Convert
       (Ppxlib_ast.Selected_ast)
-      (Ppxlib_ast__.Versions.OCaml_501)
+      (Melange_ast_version)
 
   let ppxlib_impl : Ppxlib_ast.Ast.structure -> t =
    fun stru ->

--- a/jscomp/core/ast_io.mli
+++ b/jscomp/core/ast_io.mli
@@ -23,6 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, US. *)
 
 open Import
+module Melange_ast_version : Ppxlib_ast.OCaml_version
 module Compiler_version = Ppxlib_ast.Compiler_version
 
 module type OCaml_version = Ppxlib_ast.OCaml_version

--- a/jscomp/core/dune
+++ b/jscomp/core/dune
@@ -9,6 +9,45 @@
   dune-build-info))
 
 (rule
+ (targets lam_convert.ml)
+ (deps lam_convert.cppo.ml)
+ (action
+  (run
+   cppo
+   -V
+   OCAML:%{ocaml_version}
+   %{env:CPPO_FLAGS=}
+   %{deps}
+   -o
+   %{targets})))
+
+(rule
+ (targets polyvar_pattern_match.ml)
+ (deps polyvar_pattern_match.cppo.ml)
+ (action
+  (run
+   cppo
+   -V
+   OCAML:%{ocaml_version}
+   %{env:CPPO_FLAGS=}
+   %{deps}
+   -o
+   %{targets})))
+
+(rule
+ (targets initialization.ml)
+ (deps initialization.cppo.ml)
+ (action
+  (run
+   cppo
+   -V
+   OCAML:%{ocaml_version}
+   %{env:CPPO_FLAGS=}
+   %{deps}
+   -o
+   %{targets})))
+
+(rule
  (target include_dirs.ml)
  (deps include_dirs.dev.ml include_dirs.release.ml)
  (action

--- a/jscomp/core/dune
+++ b/jscomp/core/dune
@@ -48,6 +48,19 @@
    %{targets})))
 
 (rule
+ (targets ast_io.ml)
+ (deps ast_io.cppo.ml)
+ (action
+  (run
+   cppo
+   -V
+   OCAML:%{ocaml_version}
+   %{env:CPPO_FLAGS=}
+   %{deps}
+   -o
+   %{targets})))
+
+(rule
  (target include_dirs.ml)
  (deps include_dirs.dev.ml include_dirs.release.ml)
  (action

--- a/jscomp/core/gen/record_fold.ml
+++ b/jscomp/core/gen/record_fold.ml
@@ -202,7 +202,7 @@ let make type_declaration =
                     [
                       Typ.var "state"; Typ.constr { txt = Lident name; loc } [];
                     ])))
-           (StringSet.to_list customNames))
+           (StringSet.to_seq customNames |> List.of_seq))
     in
     let iter =
       Ast_helper.Type.mk
@@ -228,7 +228,7 @@ let make type_declaration =
            ~f:(fun s ->
              let lid = { Asttypes.txt = Longident.Lident s; loc } in
              (lid, Ast_helper.Exp.ident lid))
-           (StringSet.to_list customNames))
+           (StringSet.to_seq customNames |> List.of_seq))
         None
     in
     [%stri let super : 'state iter = [%e super]]

--- a/jscomp/core/gen/record_iter.ml
+++ b/jscomp/core/gen/record_iter.ml
@@ -189,7 +189,7 @@ let make type_declaration =
                Type.field { txt = name; loc }
                  (Typ.constr { txt = Lident "fn"; loc }
                     [ Typ.constr { txt = Lident name; loc } [] ])))
-           (StringSet.to_list customNames))
+           (StringSet.to_seq customNames |> List.of_seq))
     in
     let iter = Ast_helper.Type.mk ~kind:record { txt = "iter"; loc } in
     let fn =
@@ -206,7 +206,7 @@ let make type_declaration =
            ~f:(fun s ->
              let lid = { Asttypes.txt = Longident.Lident s; loc } in
              (lid, Ast_helper.Exp.ident lid))
-           (StringSet.to_list customNames))
+           (StringSet.to_seq customNames |> List.of_seq))
         None
     in
     [%stri let super : iter = [%e super]]

--- a/jscomp/core/gen/record_map.ml
+++ b/jscomp/core/gen/record_map.ml
@@ -219,7 +219,7 @@ let make type_declaration =
                Type.field { txt = name; loc }
                  (Typ.constr { txt = Lident "fn"; loc }
                     [ Typ.constr { txt = Lident name; loc } [] ])))
-           (StringSet.to_list customNames))
+           (StringSet.to_seq customNames |> List.of_seq))
     in
     let iter = Ast_helper.Type.mk ~kind:record { txt = "iter"; loc } in
     let fn =
@@ -236,7 +236,7 @@ let make type_declaration =
            ~f:(fun s ->
              let lid = { Asttypes.txt = Longident.Lident s; loc } in
              (lid, Ast_helper.Exp.ident lid))
-           (StringSet.to_list customNames))
+           (StringSet.to_seq customNames |> List.of_seq))
         None
     in
     [%stri let super : iter = [%e super]]

--- a/jscomp/core/initialization.cppo.ml
+++ b/jscomp/core/initialization.cppo.ml
@@ -105,6 +105,9 @@ module Perfile = struct
     Typemod.initial_env
       ~loc:(Location.in_file "command line")
       ~initially_opened_module
+#if OCAML_VERSION < (5,0,0)
+      ~safe_string:true
+#endif
       ~open_implicit_modules:(List.rev !Clflags.open_modules)
 end
 

--- a/jscomp/core/lam_convert.cppo.ml
+++ b/jscomp/core/lam_convert.cppo.ml
@@ -274,7 +274,11 @@ let lam_prim ~primitive:(p : Lambda.primitive) ~args loc : Lam.t =
       | Blk_na s ->
           let info : Lam.Tag_info.t = Blk_na s in
           prim ~primitive:(Pmakeblock (tag, info, mutable_flag)) ~args loc)
+#if OCAML_VERSION >= (5, 1, 0)
   | Pfield (id, _ptr, _mut, info) ->
+#else
+  | Pfield (id, info) ->
+#endif
       prim ~primitive:(Pfield (id, info)) ~args loc
   | Psetfield (id, _, _initialization_or_assignment, info) ->
       prim ~primitive:(Psetfield (id, info)) ~args loc
@@ -428,11 +432,13 @@ let lam_prim ~primitive:(p : Lambda.primitive) ~args loc : Lam.t =
   | Pbbswap i -> prim ~primitive:(Pbbswap i) ~args loc
   | Pbswap16 -> prim ~primitive:Pbswap16 ~args loc
   | Pduparray _ -> assert false
+#if OCAML_VERSION >= (5, 1, 0)
   | Prunstack | Pperform | Presume | Preperform | Patomic_exchange | Patomic_cas
   | Patomic_fetch_add | Pdls_get | Patomic_load _ ->
       Location.raise_errorf ~loc
         "OCaml 5 multicore primitives (Effect, Condition, Semaphore) are not \
          currently supported in Melange"
+#endif
 
 (* Does not exist since we compile array in js backend unlike native backend *)
 

--- a/jscomp/core/polyvar_pattern_match.cppo.ml
+++ b/jscomp/core/polyvar_pattern_match.cppo.ml
@@ -125,5 +125,9 @@ let call_switcher_variant_constr (loc : Lambda.scoped_location)
     ( Alias,
       Pgenval,
       v,
+#if OCAML_VERSION >= (5, 1, 0)
       Lprim (Pfield (0, Pointer, Immutable, Fld_poly_var_tag), [ arg ], loc),
+#else
+      Lprim (Pfield (0, Fld_poly_var_tag), [ arg ], loc),
+#endif
       call_switcher_variant_constant loc fail (Lvar v) int_lambda_list names )

--- a/playground/mel_playground.ml
+++ b/playground/mel_playground.ml
@@ -26,7 +26,7 @@ open Melstd
 open Melangelib
 open Melange_compiler_libs
 module Js = Jsoo_runtime.Js
-module Melange_OCaml_version = Ppxlib_ast__.Versions.OCaml_501
+module Melange_OCaml_version = Ast_io.Melange_ast_version
 
 module Melange_ast = struct
   external to_ppxlib :


### PR DESCRIPTION
This change adapts Melange to work with both the `master` and [`anmonteiro/414`](https://github.com/melange-re/melange-compiler-libs/tree/anmonteiro/414) branches over on [melange-compiler-libs](https://github.com/melange-re/melange-compiler-libs/).

The bulk of the work is done in `melange-compiler-libs`, which now has 2 typechecker versions.

