### PR TITLE
nix: add missing dependency, don't run tests in the overlay

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,6 +8,7 @@
 , nix-filter
 , nodejs
 , melange-compiler-libs-vendor-dir
+, doCheck ? true
 }:
 
 with ocamlPackages;
@@ -44,7 +45,7 @@ buildDunePackage {
       --set MELANGELIB "$OCAMLFIND_DESTDIR/melange/melange:$OCAMLFIND_DESTDIR/melange/js/melange"
   '';
 
-  doCheck = true;
+  inherit doCheck;
   nativeCheckInputs = [ tree nodejs reason jq merlin ];
   checkInputs = [ ounit2 ];
 
@@ -54,6 +55,7 @@ buildDunePackage {
     cmdliner
     ppxlib
     menhirLib
+    pp
   ];
   meta.mainProgram = "melc";
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -10,6 +10,7 @@ final: prev:
     {
       melange = prev.callPackage ./. {
         inherit nix-filter melange-compiler-libs-vendor-dir;
+        doCheck = false;
       };
       melange-playground = prev.lib.callPackageWith oself ./melange-playground.nix {
         inherit nix-filter melange-compiler-libs-vendor-dir;


### PR DESCRIPTION
since we started supporting multiple versions of OCaml in v3, some cram test output looks different between 4.14 and 5.1. It's not convenient to have them run by default in the overlay we distribute.