### PR TITLE
Treat *.ml{i} in Linguist as OCaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 docs/Manual.html binary
 docs/Manual.pdf binary
-
+*.ml linguist-language=OCaml
+*.mli linguist-language=OCaml


### PR DESCRIPTION
[Some files](https://github.com/search?q=repo%3Amelange-re%2Fmelange++language%3A%22Standard+ML%22&type=code) are being incorrectly recognized as SML instead of OCaml by Linguist. This change explicitly marks *.ml{i} files as always OCaml for Linguist.