### PR TITLE
runtime: enable more iteration functions

### DIFF
--- a/jscomp/runtime/expand_module_aliases.awk
+++ b/jscomp/runtime/expand_module_aliases.awk
@@ -12,8 +12,7 @@
 #*                                                                        *
 #**************************************************************************
 
-# This script adds the Js__ prefixes to the module aliases in
-# js.ml
+# This script adds the Js__ prefixes to the module aliases in js.ml
 BEGIN { state=0 }
 NR == 1 { printf ("# 1 \"%s\"\n", FILENAME) }
 /\(\*MODULE_ALIASES\*\)\r?/ { state=1 }

--- a/jscomp/runtime/js_array.ml
+++ b/jscomp/runtime/js_array.ml
@@ -27,10 +27,6 @@
 type 'a t = 'a array
 type 'a array_like = 'a Js.array_like
 
-(* commented out until Melange has a plan for iterators
-   type 'a array_iter = 'a array_like
-*)
-
 external from : 'a array_like -> 'a array = "from" [@@mel.scope "Array"]
 (* ES2015 *)
 
@@ -120,9 +116,7 @@ external toLocaleString : 'a t -> string = "toLocaleString" [@@mel.send]
 
 (** Iteration functions *)
 
-(* commented out until Melange has a plan for iterators
-   external entries : 'a t -> (int * 'a) array_iter = "" [@@mel.send] (* ES2015 *)
-*)
+external entries : 'a t -> (int * 'a) Js.iterator = "entries" [@@mel.send]
 
 external every : f:(('a -> bool)[@mel.uncurry]) -> bool = "every"
 [@@mel.send.pipe: 'a t]
@@ -158,9 +152,7 @@ external forEach : f:(('a -> unit)[@mel.uncurry]) -> unit = "forEach"
 external forEachi : f:(('a -> int -> unit)[@mel.uncurry]) -> unit = "forEach"
 [@@mel.send.pipe: 'a t]
 
-(* commented out until Melange has a plan for iterators
-   external keys : 'a t -> int array_iter = "" [@@mel.send] (* ES2015 *)
-*)
+external keys : 'a t -> int Js.iterator = "keys" [@@mel.send]
 
 external map : f:(('a -> 'b)[@mel.uncurry]) -> 'b t = "map"
 [@@mel.send.pipe: 'a t]
@@ -189,8 +181,6 @@ external some : f:(('a -> bool)[@mel.uncurry]) -> bool = "some"
 external somei : f:(('a -> int -> bool)[@mel.uncurry]) -> bool = "some"
 [@@mel.send.pipe: 'a t]
 
-(* commented out until Melange has a plan for iterators
-   external values : 'a t -> 'a array_iter = "" [@@mel.send] (* ES2015 *) *)
-
+external values : 'a t -> 'a Js.iterator = "values" [@@mel.send]
 external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
 external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"

--- a/jscomp/runtime/js_typed_array.cppo.ml
+++ b/jscomp/runtime/js_typed_array.cppo.ml
@@ -28,7 +28,6 @@
 *)
 
 type array_buffer
-type 'a array_like (* should be shared with js_array *)
 
 module ArrayBuffer = struct
   (** The underlying buffer that the typed arrays provide views of
@@ -105,9 +104,8 @@ end
   external toLocaleString : t -> string = "toLocaleString" [@@mel.send]\
   \
   (* Iteration functions *)\
-  (* commented out until bs has a plan for iterators
-  external entries : t -> (int * elt) array_iter = "" [@@mel.send]
-  *)\
+  external entries : t -> (int * elt) Js.iterator = "entries" [@@mel.send]\
+  \
   external every : f:(elt  -> bool [@mel.uncurry]) -> bool = "every" [@@mel.send.pipe: t]\
   external everyi : f:(elt -> int -> bool [@mel.uncurry]) -> bool = "every" [@@mel.send.pipe: t]\
   \
@@ -124,9 +122,7 @@ end
   external forEach : f:(elt -> unit [@mel.uncurry]) -> unit = "forEach" [@@mel.send.pipe: t]\
   external forEachi : f:(elt -> int -> unit [@mel.uncurry]) -> unit  = "forEach" [@@mel.send.pipe: t]\
   \
-  (* commented out until bs has a plan for iterators
-  external keys : t -> int array_iter = "" [@@mel.send]
-  *)\
+  external keys : t -> int Js.iterator = "keys" [@@mel.send]\
   \
   external map : f:(elt  -> 'b [@mel.uncurry]) -> 'b typed_array = "map" [@@mel.send.pipe: t]\
   external mapi : f:(elt -> int ->  'b [@mel.uncurry]) -> 'b typed_array = "map" [@@mel.send.pipe: t]\
@@ -148,12 +144,10 @@ end
       @param offset is in bytes, length in elements *)\
   \
   external fromLength : int -> t = STRINGIFY(moduleName) [@@mel.new]\
-  external from : elt array_like -> t = STRINGIFY(moduleName.from) \
-  (* *Array.of is redundant, use make *)
-
-  (* commented out until bs has a plan for iterators
-  external values : t -> elt array_iter = "" [@@mel.send]
-  *)
+  external from : elt Js.array_like -> t = STRINGIFY(moduleName.from) \
+  (* *Array.of is redundant, use make *)\
+  \
+  external values : t -> elt Js.iterator = "values" [@@mel.send]
 
 module Int8Array = struct
   COMMON_EXTERNALS(Int8Array,int)


### PR DESCRIPTION
now that we have `Js.iterator`, we can re-enable these functions