### PR TITLE
fix: set warnings for upstream compiler libs too

### DIFF
--- a/jscomp/core/melc_warnings.ml
+++ b/jscomp/core/melc_warnings.ml
@@ -70,11 +70,16 @@
   - 102 Mel_polymorphic_comparison
 *)
 
-open Import
-
 let defaults_w = "+a-4-29-40-41-42-44-45-48-58-59-60-61-63..70-102"
 let defaults_warn_error = "-a+5+6+101+109"
 (*TODO: add +10*)
 
 let parse_warnings ~warn_error w =
-  Option.iter Location.(prerr_alert none) (Warnings.parse_options warn_error w)
+  (* Set warnings for the OCaml lexer / parser, which also emit
+     `Illegal_backslash` (warning 14) *)
+  Option.iter Location.(prerr_alert none) (Warnings.parse_options warn_error w);
+
+  (* Now set the warnings for Melange_compiler_libs *)
+  Option.iter
+    Location.(prerr_alert none)
+    (Melange_compiler_libs.Warnings.parse_options warn_error w)

--- a/test/blackbox-tests/flags.t
+++ b/test/blackbox-tests/flags.t
@@ -43,7 +43,7 @@ Trying to build triggers both warnings
   File "main.ml", line 1, characters 9-11:
   1 | let t = "\e\n" in
                ^^
-  Warning 14 [illegal-backslash]: illegal backslash escape in string.
+  Error (warning 14 [illegal-backslash]): illegal backslash escape in string.
   Hint: Single backslashes \ are reserved for escape sequences
   (\n, \r, ...). Did you check the list of OCaml escape sequences?
   To get a backslash character, escape it with a second backslash: \\.
@@ -65,13 +65,6 @@ Let's ignore them using compile_flags
   > EOF
 
   $ dune build @mel
-  File "main.ml", line 1, characters 9-11:
-  1 | let t = "\e\n" in
-               ^^
-  Warning 14 [illegal-backslash]: illegal backslash escape in string.
-  Hint: Single backslashes \ are reserved for escape sequences
-  (\n, \r, ...). Did you check the list of OCaml escape sequences?
-  To get a backslash character, escape it with a second backslash: \\.
   $ node _build/default/output/main.js
   hello
 
@@ -89,7 +82,7 @@ Can also pass flags from the env stanza. Let's go back to failing state:
   File "main.ml", line 1, characters 9-11:
   1 | let t = "\e\n" in
                ^^
-  Warning 14 [illegal-backslash]: illegal backslash escape in string.
+  Error (warning 14 [illegal-backslash]): illegal backslash escape in string.
   Hint: Single backslashes \ are reserved for escape sequences
   (\n, \r, ...). Did you check the list of OCaml escape sequences?
   To get a backslash character, escape it with a second backslash: \\.
@@ -113,13 +106,6 @@ Adding env stanza with both warnings silenced allows the build to pass successfu
   > EOF
 
   $ dune build @mel
-  File "main.ml", line 1, characters 9-11:
-  1 | let t = "\e\n" in
-               ^^
-  Warning 14 [illegal-backslash]: illegal backslash escape in string.
-  Hint: Single backslashes \ are reserved for escape sequences
-  (\n, \r, ...). Did you check the list of OCaml escape sequences?
-  To get a backslash character, escape it with a second backslash: \\.
   $ node _build/default/output/main.js
   hello
 

--- a/test/blackbox-tests/flags.t
+++ b/test/blackbox-tests/flags.t
@@ -1,0 +1,154 @@
+Test flags and compile_flags fields on melange.emit stanza
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+Using flags field in melange.emit stanzas is not supported
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (modules main)
+  >  (flags -w -14-26))
+  > EOF
+
+  $ dune build @mel
+  File "dune", line 5, characters 2-7:
+  5 |  (flags -w -14-26))
+        ^^^^^
+  Error: Unknown field flags
+  [1]
+
+Adds a module that contains unused var (warning 26) and illegal backlash (warning 14)
+
+  $ cat > main.ml <<EOF
+  > let t = "\e\n" in
+  > print_endline "hello"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (modules main)
+  >  (alias mel))
+  > EOF
+
+Trying to build triggers both warnings
+
+  $ dune build @mel
+  File "main.ml", line 1, characters 9-11:
+  1 | let t = "\e\n" in
+               ^^
+  Warning 14 [illegal-backslash]: illegal backslash escape in string.
+  Hint: Single backslashes \ are reserved for escape sequences
+  (\n, \r, ...). Did you check the list of OCaml escape sequences?
+  To get a backslash character, escape it with a second backslash: \\.
+  File "main.ml", line 1, characters 4-5:
+  1 | let t = "\e\n" in
+          ^
+  Error (warning 26 [unused-var]): unused variable t.
+  [1]
+
+Let's ignore them using compile_flags
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (modules main)
+  >  (emit_stdlib false)
+  >  (alias mel)
+  >  (compile_flags -w -14-26))
+  > EOF
+
+  $ dune build @mel
+  File "main.ml", line 1, characters 9-11:
+  1 | let t = "\e\n" in
+               ^^
+  Warning 14 [illegal-backslash]: illegal backslash escape in string.
+  Hint: Single backslashes \ are reserved for escape sequences
+  (\n, \r, ...). Did you check the list of OCaml escape sequences?
+  To get a backslash character, escape it with a second backslash: \\.
+  $ node _build/default/output/main.js
+  hello
+
+Can also pass flags from the env stanza. Let's go back to failing state:
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (modules main)
+  >  (alias mel))
+  > EOF
+
+  $ dune build @mel
+  File "main.ml", line 1, characters 9-11:
+  1 | let t = "\e\n" in
+               ^^
+  Warning 14 [illegal-backslash]: illegal backslash escape in string.
+  Hint: Single backslashes \ are reserved for escape sequences
+  (\n, \r, ...). Did you check the list of OCaml escape sequences?
+  To get a backslash character, escape it with a second backslash: \\.
+  File "main.ml", line 1, characters 4-5:
+  1 | let t = "\e\n" in
+          ^
+  Error (warning 26 [unused-var]): unused variable t.
+  [1]
+
+Adding env stanza with both warnings silenced allows the build to pass successfully
+
+  $ cat > dune <<EOF
+  > (env
+  >  (_
+  >   (melange.compile_flags -w -14-26)))
+  > (melange.emit
+  >  (alias mel)
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (modules main))
+  > EOF
+
+  $ dune build @mel
+  File "main.ml", line 1, characters 9-11:
+  1 | let t = "\e\n" in
+               ^^
+  Warning 14 [illegal-backslash]: illegal backslash escape in string.
+  Hint: Single backslashes \ are reserved for escape sequences
+  (\n, \r, ...). Did you check the list of OCaml escape sequences?
+  To get a backslash character, escape it with a second backslash: \\.
+  $ node _build/default/output/main.js
+  hello
+
+Warning 102 (Melange only) is available if explicitly set
+
+  $ cat > main.ml <<EOF
+  > let compare a b = compare a b
+  > EOF
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (modules main)
+  >  (compile_flags -w +a-70))
+  > EOF
+
+  $ dune build output/main.js
+  File "main.ml", line 1, characters 18-29:
+  1 | let compare a b = compare a b
+                        ^^^^^^^^^^^
+  Warning 102 [polymorphic-comparison-introduced]: Polymorphic comparison introduced (maybe unsafe)
+
+But it is disabled by default
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (modules main))
+  > EOF
+
+  $ dune build output/main.js

--- a/test/blackbox-tests/flags.t
+++ b/test/blackbox-tests/flags.t
@@ -1,5 +1,6 @@
 Test flags and compile_flags fields on melange.emit stanza
 
+  $ . ./setup.sh
   $ cat > dune-project <<EOF
   > (lang dune 3.8)
   > (using melange 0.1)


### PR DESCRIPTION
this fixes a bug that was found when trying to update the melange version in the dune test suite

the root cause is that we slimmed down `melange-compiler-libs` quite a bit in https://github.com/melange-re/melange-compiler-libs/pull/40 because we're releasing melange versions specific to each compiler version.

As part of the above, we stopped tracking the OCaml parser and lexer, which also emit warnings. Therefore, we must set their warnings appropriately, too.