### PR TITLE
fix macos x86_64 github actions

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-13
           - macos-14
         ocaml-version:
           - 5_2


### PR DESCRIPTION
gh actions moved macos-latest to arm64