### PR TITLE
test: show crash with empty object key

### DIFF
--- a/test/blackbox-tests/empty-obj.t
+++ b/test/blackbox-tests/empty-obj.t
@@ -1,0 +1,11 @@
+
+  $ . ./setup.sh
+  $ cat > x.re <<EOF
+  > let obj = {"": someValue};
+  > EOF
+  $ melc -pp 'refmt --print=binary' -ppx melppx -impl x.re
+  Fatal error: exception File "jscomp/common/lam_methname.ml", line 136, characters 2-8: Assertion failed
+  melc: internal error, uncaught exception:
+        Melangelib.Cmd_ast_exception.Error(_)
+        
+  [125]


### PR DESCRIPTION
- this is related to https://github.com/reasonml/reason/issues/2387
- JS allows empty object keys, though, so I'm unsure whether we should allow this or not