### PR TITLE
refactor: external_arg_spec

### DIFF
--- a/jscomp/common/external_arg_spec.ml
+++ b/jscomp/common/external_arg_spec.ml
@@ -29,12 +29,22 @@ type cst =
   | Arg_string_lit of string
   | Arg_js_literal of string
 
-type label_noname = Arg_label | Arg_empty | Arg_optional
+module Arg_label = struct
+  type t = Arg_label | Arg_empty | Arg_optional
+end
 
-type label =
-  | Obj_label of { name : string }
-  | Obj_empty
-  | Obj_optional of { name : string; for_sure_no_nested_option : bool }
+module Obj_label = struct
+  type t =
+    | Obj_label of { name : string }
+    | Obj_empty
+    | Obj_optional of { name : string; for_sure_no_nested_option : bool }
+
+  let empty = Obj_empty
+  let obj name = Obj_label { name }
+
+  let optional ~for_sure_no_nested_option name =
+    Obj_optional { name; for_sure_no_nested_option }
+end
 
 (* it will be ignored , side effect will be recorded *)
 
@@ -67,13 +77,8 @@ type 'a param = { arg_type : attr; arg_label : 'a }
 let cst_obj_literal s = Arg_js_literal s
 let cst_int i = Arg_int_lit i
 let cst_string s = Arg_string_lit s
-let empty_label = Obj_empty
-let obj_label name = Obj_label { name }
-
-let optional for_sure_no_nested_option name =
-  Obj_optional { name; for_sure_no_nested_option }
 
 let empty_kind obj_arg_type =
-  { arg_label = empty_label; arg_type = obj_arg_type }
+  { arg_label = Obj_label.empty; arg_type = obj_arg_type }
 
-let dummy = { arg_type = Nothing; arg_label = Arg_empty }
+let dummy = { arg_type = Nothing; arg_label = Arg_label.Arg_empty }

--- a/jscomp/common/external_arg_spec.mli
+++ b/jscomp/common/external_arg_spec.mli
@@ -27,12 +27,6 @@ type cst = private
   | Arg_string_lit of string
   | Arg_js_literal of string
 
-type label = private
-  | Obj_label of { name : string }
-  | Obj_empty
-  | Obj_optional of { name : string; for_sure_no_nested_option : bool }
-      (** it will be ignored , side effect will be recorded *)
-
 type attr =
   | Poly_var_string of { descr : (string * string) list }
   | Poly_var of { descr : (string * string) list option }
@@ -46,14 +40,26 @@ type attr =
   | Ignore
   | Unwrap
 
-type label_noname = Arg_label | Arg_empty | Arg_optional
+module Arg_label : sig
+  type t = Arg_label | Arg_empty | Arg_optional
+end
+
+module Obj_label : sig
+  type t = private
+    | Obj_label of { name : string }
+    | Obj_empty
+    | Obj_optional of { name : string; for_sure_no_nested_option : bool }
+        (** it will be ignored , side effect will be recorded *)
+
+  val empty : t
+  val obj : string -> t
+  val optional : for_sure_no_nested_option:bool -> string -> t
+end
+
 type 'a param = { arg_type : attr; arg_label : 'a }
 
 val cst_obj_literal : string -> cst
 val cst_int : int -> cst
 val cst_string : string -> cst
-val empty_label : label
-val obj_label : string -> label
-val optional : bool -> string -> label
-val empty_kind : attr -> label param
-val dummy : label_noname param
+val empty_kind : attr -> Obj_label.t param
+val dummy : Arg_label.t param

--- a/jscomp/common/external_ffi_types.ml
+++ b/jscomp/common/external_ffi_types.ml
@@ -46,7 +46,7 @@ type arg_type = External_arg_spec.attr
    design a more compact representation so that it is also easy to seralize by
    hand *)
 
-type arg_label = External_arg_spec.label
+type arg_label = External_arg_spec.Obj_label.t
 
 type external_spec =
   | Js_var of {
@@ -94,7 +94,7 @@ type return_wrapper =
   | Return_replaced_with_unit
 
 type params =
-  | Params of External_arg_spec.label_noname External_arg_spec.param list
+  | Params of External_arg_spec.Arg_label.t External_arg_spec.param list
   | Param_number of int
 
 type t =
@@ -102,7 +102,7 @@ type t =
       (**  [Ffi_mel(args,return,attr) ]
        [return] means return value is unit or not,
         [true] means is [unit] *)
-  | Ffi_obj_create of External_arg_spec.label External_arg_spec.param list
+  | Ffi_obj_create of External_arg_spec.Obj_label.t External_arg_spec.param list
   | Ffi_inline_const of Lam_constant.t
   | Ffi_normal
 (* When it's normal, it is handled as normal c functional ffi call *)
@@ -241,7 +241,7 @@ let inline_float_primitive (i : string) : string list =
 
 let ffi_mel =
   let rec ffi_mel_aux acc
-      (params : External_arg_spec.label_noname External_arg_spec.param list) =
+      (params : External_arg_spec.Arg_label.t External_arg_spec.param list) =
     match params with
     | { arg_type = Nothing; arg_label = Arg_empty }
         (* same as External_arg_spec.dummy*)
@@ -250,7 +250,7 @@ let ffi_mel =
     | _ :: _ -> -1
     | [] -> acc
   in
-  fun (params : External_arg_spec.label_noname External_arg_spec.param list)
+  fun (params : External_arg_spec.Arg_label.t External_arg_spec.param list)
       return attr ->
     let n = ffi_mel_aux 0 params in
     if n < 0 then Ffi_mel (Params params, return, attr)

--- a/jscomp/common/external_ffi_types.mli
+++ b/jscomp/common/external_ffi_types.mli
@@ -38,7 +38,7 @@ type external_module_name = {
 }
 
 type arg_type = External_arg_spec.attr
-type arg_label = External_arg_spec.label
+type arg_label = External_arg_spec.Obj_label.t
 
 type external_spec =
   | Js_var of {
@@ -86,17 +86,15 @@ type return_wrapper =
   | Return_replaced_with_unit
 
 type params =
-  | Params of External_arg_spec.label_noname External_arg_spec.param list
+  | Params of External_arg_spec.Arg_label.t External_arg_spec.param list
   | Param_number of int
 
 type t = private
   | Ffi_mel of params * return_wrapper * external_spec
-  | Ffi_obj_create of External_arg_spec.label External_arg_spec.param list
+  | Ffi_obj_create of External_arg_spec.Obj_label.t External_arg_spec.param list
   | Ffi_inline_const of Lam_constant.t
   | Ffi_normal
-(* When it's normal, it is handled as normal c functional ffi call *)
-
-(* val name_of_ffi : external_spec -> string *)
+(* Ffi_normal represents a C functional ffi call *)
 
 val check_ffi : loc:Location.t -> external_spec -> bool
 val to_string : t -> string
@@ -111,18 +109,19 @@ val inline_int64_primitive : int64 -> string list
 val inline_float_primitive : string -> string list
 
 val ffi_mel :
-  External_arg_spec.label_noname External_arg_spec.param list ->
+  External_arg_spec.Arg_label.t External_arg_spec.param list ->
   return_wrapper ->
   external_spec ->
   t
 
 val ffi_mel_as_prims :
-  External_arg_spec.label_noname External_arg_spec.param list ->
+  External_arg_spec.Arg_label.t External_arg_spec.param list ->
   return_wrapper ->
   external_spec ->
   string list
 
-val ffi_obj_create : External_arg_spec.label External_arg_spec.param list -> t
+val ffi_obj_create :
+  External_arg_spec.Obj_label.t External_arg_spec.param list -> t
 
 val ffi_obj_as_prims :
-  External_arg_spec.label External_arg_spec.param list -> string list
+  External_arg_spec.Obj_label.t External_arg_spec.param list -> string list

--- a/jscomp/core/js_cmj_format.ml
+++ b/jscomp/core/js_cmj_format.ml
@@ -133,8 +133,10 @@ let rec binarySearchAux arr lo hi (key : string) =
       let loVal = Array.unsafe_get arr lo in
       if loVal.name = key then get_result loVal else not_found key
     else binarySearchAux arr lo mid key
-  else if (*  a[lo] =< a[mid] < key <= a[hi] *)
-          lo = mid then
+  else if
+    (*  a[lo] =< a[mid] < key <= a[hi] *)
+    lo = mid
+  then
     let hiVal = Array.unsafe_get arr hi in
     if hiVal.name = key then get_result hiVal else not_found key
   else binarySearchAux arr mid hi key

--- a/jscomp/core/lam_analysis.ml
+++ b/jscomp/core/lam_analysis.ml
@@ -280,8 +280,7 @@ let ok_to_inline_fun_when_app (m : Lam.lfunction) (args : Lam.t list) =
           || (args_all_const args && s < 10 && no_side_effects body))
 
 (* TODO:  We can relax this a bit later,
-    but decide whether to inline it later in the call site
-*)
+    but decide whether to inline it later in the call site *)
 let safe_to_inline (lam : Lam.t) =
   match lam with
   | Lfunction _ -> true

--- a/jscomp/core/lam_compile_external_call.ml
+++ b/jscomp/core/lam_compile_external_call.ml
@@ -101,7 +101,7 @@ let append_list x xs =
 
      This would not work with [NonNullString]
 *)
-let ocaml_to_js_eff ~(arg_label : Melange_ffi.External_arg_spec.label_noname)
+let ocaml_to_js_eff ~(arg_label : Melange_ffi.External_arg_spec.Arg_label.t)
     ~(arg_type : Melange_ffi.External_arg_spec.attr) (raw_arg : E.t) :
     arg_expression * E.t list =
   let arg =
@@ -154,7 +154,7 @@ let empty_pair = ([], [])
 let add_eff eff e = match eff with None -> e | Some v -> E.seq v e
 
 type specs =
-  Melange_ffi.External_arg_spec.label_noname Melange_ffi.External_arg_spec.param
+  Melange_ffi.External_arg_spec.Arg_label.t Melange_ffi.External_arg_spec.param
   list
 
 type exprs = E.t list

--- a/jscomp/core/lam_compile_external_call.mli
+++ b/jscomp/core/lam_compile_external_call.mli
@@ -23,7 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 val ocaml_to_js_eff :
-  arg_label:Melange_ffi.External_arg_spec.label_noname ->
+  arg_label:Melange_ffi.External_arg_spec.Arg_label.t ->
   arg_type:Melange_ffi.External_arg_spec.attr ->
   J.expression ->
   Js_of_lam_variant.arg_expression * J.expression list
@@ -31,7 +31,7 @@ val ocaml_to_js_eff :
 
 val translate_ffi :
   Lam_compile_context.t ->
-  Melange_ffi.External_arg_spec.label_noname Melange_ffi.External_arg_spec.param
+  Melange_ffi.External_arg_spec.Arg_label.t Melange_ffi.External_arg_spec.param
   list ->
   Melange_ffi.External_ffi_types.external_spec ->
   J.expression list ->

--- a/jscomp/core/lam_compile_external_obj.ml
+++ b/jscomp/core/lam_compile_external_obj.ml
@@ -40,11 +40,13 @@ module S = Js_stmt_make
 (* TODO: check stackoverflow *)
 let assemble_obj_args
     (labels :
-      Melange_ffi.External_arg_spec.label Melange_ffi.External_arg_spec.param
+      Melange_ffi.External_arg_spec.Obj_label.t
+      Melange_ffi.External_arg_spec.param
       list) (args : J.expression list) : J.block * J.expression =
   let rec aux
       (labels :
-        Melange_ffi.External_arg_spec.label Melange_ffi.External_arg_spec.param
+        Melange_ffi.External_arg_spec.Obj_label.t
+        Melange_ffi.External_arg_spec.param
         list) args : (Js_op.property_name * E.t) list * J.expression list * _ =
     match (labels, args) with
     | [], [] -> ([], [], [])
@@ -109,7 +111,7 @@ let assemble_obj_args
         :: List.concat_map
              ~f:(fun
                  ( (xlabel :
-                     Melange_ffi.External_arg_spec.label
+                     Melange_ffi.External_arg_spec.Obj_label.t
                      Melange_ffi.External_arg_spec.param),
                    (arg : J.expression) )
                ->

--- a/jscomp/core/lam_compile_external_obj.mli
+++ b/jscomp/core/lam_compile_external_obj.mli
@@ -31,7 +31,8 @@
  *)
 
 val assemble_obj_args :
-  Melange_ffi.External_arg_spec.label Melange_ffi.External_arg_spec.param list ->
+  Melange_ffi.External_arg_spec.Obj_label.t Melange_ffi.External_arg_spec.param
+  list ->
   J.expression list ->
   J.block * J.expression
 (* It returns a block in cases we need set the property dynamically: we need

--- a/jscomp/core/lam_ffi.ml
+++ b/jscomp/core/lam_ffi.ml
@@ -31,7 +31,7 @@
 *)
 let rec no_auto_uncurried_arg_types
     (xs :
-      Melange_ffi.External_arg_spec.label_noname
+      Melange_ffi.External_arg_spec.Arg_label.t
       Melange_ffi.External_arg_spec.param
       list) =
   match xs with
@@ -41,7 +41,7 @@ let rec no_auto_uncurried_arg_types
 
 let rec transform_uncurried_arg_type loc
     (arg_types :
-      Melange_ffi.External_arg_spec.label_noname
+      Melange_ffi.External_arg_spec.Arg_label.t
       Melange_ffi.External_arg_spec.param
       list) (args : Lam.t list) =
   match (arg_types, args) with
@@ -74,7 +74,7 @@ let handle_mel_non_obj_ffi =
     | Return_unset | Return_identity -> result
   in
   fun (arg_types :
-        Melange_ffi.External_arg_spec.label_noname
+        Melange_ffi.External_arg_spec.Arg_label.t
         Melange_ffi.External_arg_spec.param
         list) (result_type : Melange_ffi.External_ffi_types.return_wrapper) ffi
       args loc prim_name ~dynamic_import ->

--- a/jscomp/core/lam_ffi.mli
+++ b/jscomp/core/lam_ffi.mli
@@ -23,7 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 val handle_mel_non_obj_ffi :
-  Melange_ffi.External_arg_spec.label_noname Melange_ffi.External_arg_spec.param
+  Melange_ffi.External_arg_spec.Arg_label.t Melange_ffi.External_arg_spec.param
   list ->
   Melange_ffi.External_ffi_types.return_wrapper ->
   Melange_ffi.External_ffi_types.external_spec ->

--- a/jscomp/core/lam_primitive.ml
+++ b/jscomp/core/lam_primitive.ml
@@ -54,14 +54,15 @@ type t =
   | Pjs_call of {
       prim_name : string;
       arg_types :
-        Melange_ffi.External_arg_spec.label_noname
+        Melange_ffi.External_arg_spec.Arg_label.t
         Melange_ffi.External_arg_spec.param
         list;
       ffi : Melange_ffi.External_ffi_types.external_spec;
       dynamic_import : bool;
     }
   | Pjs_object_create of
-      Melange_ffi.External_arg_spec.label Melange_ffi.External_arg_spec.param
+      Melange_ffi.External_arg_spec.Obj_label.t
+      Melange_ffi.External_arg_spec.param
       list
   (* Exceptions *)
   | Praise

--- a/jscomp/core/lam_primitive.mli
+++ b/jscomp/core/lam_primitive.mli
@@ -51,14 +51,15 @@ type t =
       (* Location.t *  [loc] is passed down *)
       prim_name : string;
       arg_types :
-        Melange_ffi.External_arg_spec.label_noname
+        Melange_ffi.External_arg_spec.Arg_label.t
         Melange_ffi.External_arg_spec.param
         list;
       ffi : Melange_ffi.External_ffi_types.external_spec;
       dynamic_import : bool;
     }
   | Pjs_object_create of
-      Melange_ffi.External_arg_spec.label Melange_ffi.External_arg_spec.param
+      Melange_ffi.External_arg_spec.Obj_label.t
+      Melange_ffi.External_arg_spec.param
       list
   | Praise
   | Psequand

--- a/jscomp/test/dist/jscomp/test/gpr_4442_test.js
+++ b/jscomp/test/dist/jscomp/test/gpr_4442_test.js
@@ -23,9 +23,9 @@ const u = (function fib(n){
 }
 );
 
-eq("File \"jscomp/test/gpr_4442_test.ml\", line 14, characters 6-13", u(2), 2);
+eq("File \"jscomp/test/gpr_4442_test.ml\", line 15, characters 6-13", u(2), 2);
 
-eq("File \"jscomp/test/gpr_4442_test.ml\", line 15, characters 6-13", u(3), 3);
+eq("File \"jscomp/test/gpr_4442_test.ml\", line 16, characters 6-13", u(3), 3);
 
 Mt.from_pair_suites("jscomp/test/gpr_4442_test.ml", suites.contents);
 

--- a/ppx/ast_derive/ast_derive_abstract.ml
+++ b/ppx/ast_derive/ast_derive_abstract.ml
@@ -64,8 +64,9 @@ let derive_js_constructor =
           let label_name = Melange_ffi.Lam_methname.translate p.txt in
           let obj_arg_label =
             if is_option then
-              Melange_ffi.External_arg_spec.optional false label_name
-            else Melange_ffi.External_arg_spec.obj_label label_name
+              Melange_ffi.External_arg_spec.Obj_label.optional
+                ~for_sure_no_nested_option:false label_name
+            else Melange_ffi.External_arg_spec.Obj_label.obj label_name
           in
           {
             Melange_ffi.External_arg_spec.arg_type = Nothing;

--- a/ppx/ast_external.ml
+++ b/ppx/ast_external.ml
@@ -43,7 +43,7 @@ let handleExternalInSig (self : Ast_traverse.map) (prim : value_description)
         Ast_external_process.pval_type;
         pval_prim;
         pval_attributes;
-        no_inline_cross_module;
+        dont_inline_cross_module;
       } =
         Ast_external_process.handle_attributes_as_string loc pval_type
           pval_attributes prim.pval_name.txt v
@@ -56,7 +56,7 @@ let handleExternalInSig (self : Ast_traverse.map) (prim : value_description)
             {
               prim with
               pval_type;
-              pval_prim = (if no_inline_cross_module then [] else pval_prim);
+              pval_prim = (if dont_inline_cross_module then [] else pval_prim);
               pval_attributes =
                 Ast_attributes.unboxable_type_in_prim_decl :: pval_attributes;
             };
@@ -75,7 +75,7 @@ let handleExternalInStru (self : Ast_traverse.map) (prim : value_description)
         Ast_external_process.pval_type;
         pval_prim;
         pval_attributes;
-        no_inline_cross_module;
+        dont_inline_cross_module;
       } =
         Ast_external_process.handle_attributes_as_string loc pval_type
           pval_attributes prim.pval_name.txt v
@@ -94,7 +94,7 @@ let handleExternalInStru (self : Ast_traverse.map) (prim : value_description)
               };
         }
       in
-      if not no_inline_cross_module then external_result
+      if not dont_inline_cross_module then external_result
       else
         let open Ast_helper in
         Str.include_ ~loc

--- a/ppx/ast_external_process.mli
+++ b/ppx/ast_external_process.mli
@@ -28,7 +28,7 @@ type response = {
   pval_type : core_type;
   pval_prim : string list;
   pval_attributes : attributes;
-  no_inline_cross_module : bool;
+  dont_inline_cross_module : bool;
 }
 
 val handle_attributes_as_string :

--- a/ppx/ast_object.ml
+++ b/ppx/ast_object.ml
@@ -30,7 +30,7 @@ let pval_prim_of_labels (labels : string Asttypes.loc list) =
     List.fold_right
       ~f:(fun p arg_kinds ->
         let obj_arg_label =
-          Melange_ffi.External_arg_spec.obj_label
+          Melange_ffi.External_arg_spec.Obj_label.obj
             (Melange_ffi.Lam_methname.translate p.txt)
         in
         {


### PR DESCRIPTION
part of a wider refactor to make the `external` FFI PPX code a bit easier to maintain