### PR TITLE
fix(runtime): `Js.Type.bigint_val` isn't supposed to be an alias for …

### DIFF
--- a/jscomp/runtime/js_types.ml
+++ b/jscomp/runtime/js_types.ml
@@ -27,7 +27,7 @@
 type symbol
 (**Js symbol type only available in ES6 *)
 
-type bigint_val = Js.bigint
+type bigint_val
 (** Js bigint type only available in ES2020 *)
 
 type obj_val


### PR DESCRIPTION
…bigint