### PR TITLE
fix `Node.Buffer.fromString` signature, add all supported encodings

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,11 @@ Unreleased
   ([#1222](https://github.com/melange-re/melange/pull/1222))
 - melange-ppx: allow `@mel.unwrap` polyvariants not to have a payload
   ([#1239](https://github.com/melange-re/melange/pull/1239))
+- `melange.node`: fix `Buffer.fromString` and add
+  `Buffer.fromStringWithEncoding`
+  ([#1246](https://github.com/melange-re/melange/pull/1246))
+- `melange.node`: bind to all supported Node.js `Buffer` encodings in
+  `Node.Buffer` ([#1246](https://github.com/melange-re/melange/pull/1246))
 
 4.0.1 2024-06-07
 ---------------

--- a/jscomp/others/node_buffer.ml
+++ b/jscomp/others/node_buffer.ml
@@ -27,11 +27,20 @@
 type t = Node.buffer
 
 type encoding =
-  [ `ascii | `utf8 | `utf16le | `usc2 | `base64 | `latin1 | `binary | `hex ]
+  [ `ascii
+  | `utf8
+  | `utf16le
+  | `ucs2
+  | `base64
+  | `base64url
+  | `latin1
+  | `binary
+  | `hex ]
 
 external isBuffer : 'a -> bool = "isBuffer" [@@mel.scope "Buffer"]
+external fromString : string -> t = "from" [@@mel.scope "Buffer"]
 
-external fromString : ?encoding:encoding -> string -> t = "from"
+external fromStringWithEncoding : string -> encoding:encoding -> t = "from"
 [@@mel.scope "Buffer"]
 
 external toString : ?encoding:encoding -> string = "toString"


### PR DESCRIPTION
fixes #1236