### PR TITLE
runtime(js.array): port most `@mel.send.pipe` functions to `@mel.send`

### DIFF
--- a/jscomp/runtime/js_array.ml
+++ b/jscomp/runtime/js_array.ml
@@ -43,22 +43,23 @@ external length : 'a array -> int = "length" [@@mel.get]
 
 (** Mutating functions *)
 
-external copyWithin : to_:int -> ?start:int -> ?end_:int -> 'a t = "copyWithin"
-[@@mel.send.pipe: 'a t]
+external copyWithin : to_:int -> ?start:int -> ?end_:int -> 'a t -> 'a t
+  = "copyWithin"
+[@@mel.send]
 (* ES2015 *)
 
-external fill : value:'a -> ?start:int -> ?end_:int -> 'a t = "fill"
-[@@mel.send.pipe: 'a t]
+external fill : value:'a -> ?start:int -> ?end_:int -> 'a t -> 'a t = "fill"
+[@@mel.send]
 (* ES2015 *)
 
 external pop : 'a t -> 'a option = "pop"
 [@@mel.send] [@@mel.return undefined_to_opt]
 (** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push *)
 
-external push : value:'a -> int = "push" [@@mel.send.pipe: 'a t]
+external push : value:'a -> 'a t -> int = "push" [@@mel.send]
 
-external pushMany : values:'a array -> int = "push"
-[@@mel.send.pipe: 'a t] [@@mel.variadic]
+external pushMany : 'a t -> values:'a array -> int = "push"
+[@@mel.send] [@@mel.variadic]
 
 external reverseInPlace : 'a t -> 'a t = "reverse" [@@mel.send]
 
@@ -67,50 +68,47 @@ external shift : 'a t -> 'a option = "shift"
 
 external sortInPlace : 'a t -> 'a t = "sort" [@@mel.send]
 
-external sortInPlaceWith : f:(('a -> 'a -> int)[@mel.uncurry]) -> 'a t = "sort"
-[@@mel.send.pipe: 'a t]
+external sortInPlaceWith : f:(('a -> 'a -> int)[@mel.uncurry]) -> 'a t -> 'a t
+  = "sort"
+[@@mel.send]
 
 external spliceInPlace : start:int -> remove:int -> add:'a array -> 'a t
   = "splice"
 [@@mel.send.pipe: 'a t] [@@mel.variadic]
 
-external removeFromInPlace : start:int -> 'a t = "splice"
-[@@mel.send.pipe: 'a t]
+external removeFromInPlace : start:int -> 'a t -> 'a t = "splice" [@@mel.send]
 
-external removeCountInPlace : start:int -> count:int -> 'a t = "splice"
-[@@mel.send.pipe: 'a t]
+external removeCountInPlace : start:int -> count:int -> 'a t -> 'a t = "splice"
+[@@mel.send]
 
-external unshift : value:'a -> int = "unshift" [@@mel.send.pipe: 'a t]
+external unshift : value:'a -> 'a t -> int = "unshift" [@@mel.send]
 
 external unshiftMany : values:'a array -> int = "unshift"
 [@@mel.send.pipe: 'a t] [@@mel.variadic]
 
-external concat : other:'a t -> 'a t = "concat" [@@mel.send.pipe: 'a t]
+external concat : other:'a t -> 'a t -> 'a t = "concat" [@@mel.send]
 
 external concatMany : arrays:'a t array -> 'a t = "concat"
 [@@mel.send.pipe: 'a t] [@@mel.variadic]
 
-external includes : value:'a -> bool = "includes"
-[@@mel.send.pipe: 'a t]
+external includes : value:'a -> 'a t -> bool = "includes"
+[@@mel.send]
 (** ES2015 *)
 
-external join : ?sep:string -> string = "join" [@@mel.send.pipe: 'a t]
+external join : ?sep:string -> 'a t -> string = "join" [@@mel.send]
 
 (** Accessor functions *)
 
-external indexOf : value:'a -> ?start:int -> int = "indexOf"
-[@@mel.send.pipe: 'a t]
+external indexOf : value:'a -> ?start:int -> 'a t -> int = "indexOf"
+[@@mel.send]
 
-external lastIndexOf : value:'a -> int = "lastIndexOf" [@@mel.send.pipe: 'a t]
+external lastIndexOf : value:'a -> 'a t -> int = "lastIndexOf" [@@mel.send]
 
-external lastIndexOfFrom : value:'a -> start:int -> int = "lastIndexOf"
-[@@mel.send.pipe: 'a t]
+external lastIndexOfFrom : value:'a -> start:int -> 'a t -> int = "lastIndexOf"
+[@@mel.send]
 
 external copy : 'a t -> 'a t = "slice" [@@mel.send]
-
-external slice : ?start:int -> ?end_:int -> 'a t = "slice"
-[@@mel.send.pipe: 'a t]
-
+external slice : ?start:int -> ?end_:int -> 'a t -> 'a t = "slice" [@@mel.send]
 external toString : 'a t -> string = "toString" [@@mel.send]
 external toLocaleString : 'a t -> string = "toLocaleString" [@@mel.send]
 
@@ -118,68 +116,73 @@ external toLocaleString : 'a t -> string = "toLocaleString" [@@mel.send]
 
 external entries : 'a t -> (int * 'a) Js.iterator = "entries" [@@mel.send]
 
-external every : f:(('a -> bool)[@mel.uncurry]) -> bool = "every"
-[@@mel.send.pipe: 'a t]
+external every : f:(('a -> bool)[@mel.uncurry]) -> 'a t -> bool = "every"
+[@@mel.send]
 
-external everyi : f:(('a -> int -> bool)[@mel.uncurry]) -> bool = "every"
-[@@mel.send.pipe: 'a t]
+external everyi : f:(('a -> int -> bool)[@mel.uncurry]) -> 'a t -> bool
+  = "every"
+[@@mel.send]
 
-external filter : f:(('a -> bool)[@mel.uncurry]) -> 'a t = "filter"
-[@@mel.send.pipe: 'a t]
+external filter : f:(('a -> bool)[@mel.uncurry]) -> 'a t -> 'a t = "filter"
+[@@mel.send]
 
-external filteri : f:(('a -> int -> bool)[@mel.uncurry]) -> 'a t = "filter"
-[@@mel.send.pipe: 'a t]
+external filteri : f:(('a -> int -> bool)[@mel.uncurry]) -> 'a t -> 'a t
+  = "filter"
+[@@mel.send]
 
-external find : f:(('a -> bool)[@mel.uncurry]) -> 'a option = "find"
-[@@mel.send.pipe: 'a t] [@@mel.return { undefined_to_opt }]
+external find : f:(('a -> bool)[@mel.uncurry]) -> 'a t -> 'a option = "find"
+[@@mel.send] [@@mel.return { undefined_to_opt }]
 (* ES2015 *)
 
-external findi : f:(('a -> int -> bool)[@mel.uncurry]) -> 'a option = "find"
-[@@mel.send.pipe: 'a t] [@@mel.return { undefined_to_opt }]
+external findi : f:(('a -> int -> bool)[@mel.uncurry]) -> 'a t -> 'a option
+  = "find"
+[@@mel.send] [@@mel.return { undefined_to_opt }]
 (* ES2015 *)
 
-external findIndex : f:(('a -> bool)[@mel.uncurry]) -> int = "findIndex"
-[@@mel.send.pipe: 'a t]
+external findIndex : f:(('a -> bool)[@mel.uncurry]) -> 'a t -> int = "findIndex"
+[@@mel.send]
 (* ES2015 *)
 
-external findIndexi : f:(('a -> int -> bool)[@mel.uncurry]) -> int = "findIndex"
-[@@mel.send.pipe: 'a t]
+external findIndexi : f:(('a -> int -> bool)[@mel.uncurry]) -> 'a t -> int
+  = "findIndex"
+[@@mel.send]
 (* ES2015 *)
 
-external forEach : f:(('a -> unit)[@mel.uncurry]) -> unit = "forEach"
-[@@mel.send.pipe: 'a t]
+external forEach : f:(('a -> unit)[@mel.uncurry]) -> 'a t -> unit = "forEach"
+[@@mel.send]
 
-external forEachi : f:(('a -> int -> unit)[@mel.uncurry]) -> unit = "forEach"
-[@@mel.send.pipe: 'a t]
+external forEachi : f:(('a -> int -> unit)[@mel.uncurry]) -> 'a t -> unit
+  = "forEach"
+[@@mel.send]
 
 external keys : 'a t -> int Js.iterator = "keys" [@@mel.send]
+external map : f:(('a -> 'b)[@mel.uncurry]) -> 'a t -> 'b t = "map" [@@mel.send]
 
-external map : f:(('a -> 'b)[@mel.uncurry]) -> 'b t = "map"
-[@@mel.send.pipe: 'a t]
+external mapi : f:(('a -> int -> 'b)[@mel.uncurry]) -> 'a t -> 'b t = "map"
+[@@mel.send]
 
-external mapi : f:(('a -> int -> 'b)[@mel.uncurry]) -> 'b t = "map"
-[@@mel.send.pipe: 'a t]
-
-external reduce : f:(('b -> 'a -> 'b)[@mel.uncurry]) -> init:'b -> 'b = "reduce"
-[@@mel.send.pipe: 'a t]
-
-external reducei : f:(('b -> 'a -> int -> 'b)[@mel.uncurry]) -> init:'b -> 'b
+external reduce : f:(('b -> 'a -> 'b)[@mel.uncurry]) -> init:'b -> 'a t -> 'b
   = "reduce"
-[@@mel.send.pipe: 'a t]
+[@@mel.send]
 
-external reduceRight : f:(('b -> 'a -> 'b)[@mel.uncurry]) -> init:'b -> 'b
-  = "reduceRight"
-[@@mel.send.pipe: 'a t]
+external reducei :
+  f:(('b -> 'a -> int -> 'b)[@mel.uncurry]) -> init:'b -> 'a t -> 'b = "reduce"
+[@@mel.send]
+
+external reduceRight :
+  f:(('b -> 'a -> 'b)[@mel.uncurry]) -> init:'b -> 'a t -> 'b = "reduceRight"
+[@@mel.send]
 
 external reduceRighti :
-  f:(('b -> 'a -> int -> 'b)[@mel.uncurry]) -> init:'b -> 'b = "reduceRight"
-[@@mel.send.pipe: 'a t]
+  f:(('b -> 'a -> int -> 'b)[@mel.uncurry]) -> init:'b -> 'a t -> 'b
+  = "reduceRight"
+[@@mel.send]
 
-external some : f:(('a -> bool)[@mel.uncurry]) -> bool = "some"
-[@@mel.send.pipe: 'a t]
+external some : f:(('a -> bool)[@mel.uncurry]) -> 'a t -> bool = "some"
+[@@mel.send]
 
-external somei : f:(('a -> int -> bool)[@mel.uncurry]) -> bool = "some"
-[@@mel.send.pipe: 'a t]
+external somei : f:(('a -> int -> bool)[@mel.uncurry]) -> 'a t -> bool = "some"
+[@@mel.send]
 
 external values : 'a t -> 'a Js.iterator = "values" [@@mel.send]
 external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"


### PR DESCRIPTION
this is an example of `external` declaration that becomes way more readable after #1252