### PR TITLE
fix: use `Lambda.lfunction'` with kind `Curried`

### DIFF
--- a/jscomp/core/compile_letrec.520.ml
+++ b/jscomp/core/compile_letrec.520.ml
@@ -35,7 +35,7 @@ let compile_letrec :
         | Lambda.Lfunction def -> { Lambda.id; def }
         | _ ->
             let def =
-              Lambda.lfunction' ~kind:Tupled ~params:[] ~return:Pgenval
+              Lambda.lfunction' ~kind:Curried ~params:[] ~return:Pgenval
                 ~body:lambda
                 ~attr:
                   {

--- a/jscomp/core/compile_rec_module.cppo.ml
+++ b/jscomp/core/compile_rec_module.cppo.ml
@@ -147,7 +147,7 @@ let eval_rec_bindings (bindings : binding list) cont =
             | Id id, _, rhs ->
               let def =
                 Lambda.lfunction'
-                  ~kind:Tupled ~params:[] ~return:Pgenval
+                  ~kind:Curried ~params:[] ~return:Pgenval
                   ~body:rhs
                   ~attr:{ Lambda.default_function_attribute with smuggled_lambda = true }
                   ~loc:Loc_unknown


### PR DESCRIPTION
Melange doesn't support the `Tupled` calling convention.