### PR TITLE
Add Js.Fetch.{request,response,body,headers} as abstract

### DIFF
--- a/jscomp/runtime/js.pre.ml
+++ b/jscomp/runtime/js.pre.ml
@@ -162,4 +162,5 @@ module Iterator = Js_iterator
 module Blob = Js_blob
 module File = Js_file
 module FormData = Js_formData
+module Fetch = Js_fetch
 module OO = Js_OO

--- a/jscomp/runtime/js.pre.mli
+++ b/jscomp/runtime/js.pre.mli
@@ -261,6 +261,9 @@ module File = Js_file
 module FormData = Js_formData
 (** Bindings to FormData *)
 
+module Fetch = Js_fetch
+(** Abstract types for Fetch *)
+
 (**/**)
 
 module OO = Js_OO

--- a/jscomp/runtime/js_fetch.ml
+++ b/jscomp/runtime/js_fetch.ml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2022- Authors of Melange
+(* Copyright (C) 2025- Authors of Melange
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/runtime/js_fetch.ml
+++ b/jscomp/runtime/js_fetch.ml
@@ -1,0 +1,30 @@
+(* Copyright (C) 2022- Authors of Melange
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+(** Abstract types for Fetch, see [https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API] *)
+
+type response
+type request
+type body
+type headers


### PR DESCRIPTION
The minimum required to share types from reason-react and melange-fetch