### PR TITLE
trailing undefined: adapt `Js.Date`

### DIFF
--- a/jscomp/runtime/js_date.ml
+++ b/jscomp/runtime/js_date.ml
@@ -30,62 +30,29 @@ external valueOf : t -> float = "valueOf"
 [@@mel.send]
 (** returns the primitive value of this date, equivalent to getTime *)
 
-external make : unit -> t = "Date"
-[@@mel.new]
-(** returns a date representing the current time *)
-
 external fromFloat : float -> t = "Date" [@@mel.new]
 external fromString : string -> t = "Date" [@@mel.new]
-external makeWithYM : year:float -> month:float -> t = "Date" [@@mel.new]
 
-external makeWithYMD : year:float -> month:float -> date:float -> t = "Date"
-[@@mel.new]
-
-external makeWithYMDH :
-  year:float -> month:float -> date:float -> hours:float -> t = "Date"
-[@@mel.new]
-
-external makeWithYMDHM :
-  year:float -> month:float -> date:float -> hours:float -> minutes:float -> t
-  = "Date"
-[@@mel.new]
-
-external makeWithYMDHMS :
-  year:float ->
-  month:float ->
-  date:float ->
-  hours:float ->
-  minutes:float ->
-  seconds:float ->
+external make :
+  ?year:float ->
+  ?month:float ->
+  ?date:float ->
+  ?hours:float ->
+  ?minutes:float ->
+  ?seconds:float ->
+  unit ->
   t = "Date"
 [@@mel.new]
+(** [make ()] returns a date representing the current time. *)
 
-external utcWithYM : year:float -> month:float -> float = "UTC"
-[@@mel.scope "Date"]
-
-external utcWithYMD : year:float -> month:float -> date:float -> float = "UTC"
-[@@mel.scope "Date"]
-
-external utcWithYMDH :
-  year:float -> month:float -> date:float -> hours:float -> float = "UTC"
-[@@mel.scope "Date"]
-
-external utcWithYMDHM :
+external utc :
   year:float ->
-  month:float ->
-  date:float ->
-  hours:float ->
-  minutes:float ->
-  float = "UTC"
-[@@mel.scope "Date"]
-
-external utcWithYMDHMS :
-  year:float ->
-  month:float ->
-  date:float ->
-  hours:float ->
-  minutes:float ->
-  seconds:float ->
+  ?month:float ->
+  ?date:float ->
+  ?hours:float ->
+  ?minutes:float ->
+  ?seconds:float ->
+  unit ->
   float = "UTC"
 [@@mel.scope "Date"]
 
@@ -144,35 +111,16 @@ external getUTCSeconds : t -> float = "getUTCSeconds" [@@mel.send]
 external setDate : date:float -> (t[@mel.this]) -> float = "setDate"
 [@@mel.send]
 
-external setFullYear : year:float -> (t[@mel.this]) -> float = "setFullYear"
-[@@mel.send]
-
-external setFullYearM : year:float -> month:float -> (t[@mel.this]) -> float
+external setFullYear :
+  year:float -> ?month:float -> ?date:float -> (t[@mel.this]) -> float
   = "setFullYear"
 [@@mel.send]
 
-external setFullYearMD :
-  year:float -> month:float -> date:float -> (t[@mel.this]) -> float
-  = "setFullYear"
-[@@mel.send]
-
-external setHours : hours:float -> (t[@mel.this]) -> float = "setHours"
-[@@mel.send]
-
-external setHoursM : hours:float -> minutes:float -> (t[@mel.this]) -> float
-  = "setHours"
-[@@mel.send]
-
-external setHoursMS :
-  hours:float -> minutes:float -> seconds:float -> (t[@mel.this]) -> float
-  = "setHours"
-[@@mel.send]
-
-external setHoursMSMs :
+external setHours :
   hours:float ->
-  minutes:float ->
-  seconds:float ->
-  milliseconds:float ->
+  ?minutes:float ->
+  ?seconds:float ->
+  ?milliseconds:float ->
   (t[@mel.this]) ->
   float = "setHours"
 [@@mel.send]
@@ -181,33 +129,20 @@ external setMilliseconds : milliseconds:float -> (t[@mel.this]) -> float
   = "setMilliseconds"
 [@@mel.send]
 
-external setMinutes : minutes:float -> (t[@mel.this]) -> float = "setMinutes"
-[@@mel.send]
-
-external setMinutesS : minutes:float -> seconds:float -> (t[@mel.this]) -> float
-  = "setMinutes"
-[@@mel.send]
-
-external setMinutesSMs :
+external setMinutes :
   minutes:float ->
-  seconds:float ->
-  milliseconds:float ->
+  ?seconds:float ->
+  ?milliseconds:float ->
   (t[@mel.this]) ->
   float = "setMinutes"
 [@@mel.send]
 
-external setMonth : month:float -> (t[@mel.this]) -> float = "setMonth"
-[@@mel.send]
-
-external setMonthD : month:float -> date:float -> (t[@mel.this]) -> float
+external setMonth : month:float -> ?date:float -> (t[@mel.this]) -> float
   = "setMonth"
 [@@mel.send]
 
-external setSeconds : seconds:float -> (t[@mel.this]) -> float = "setSeconds"
-[@@mel.send]
-
-external setSecondsMs :
-  seconds:float -> milliseconds:float -> (t[@mel.this]) -> float = "setSeconds"
+external setSeconds :
+  seconds:float -> ?milliseconds:float -> (t[@mel.this]) -> float = "setSeconds"
 [@@mel.send]
 
 external setTime : time:float -> (t[@mel.this]) -> float = "setTime"
@@ -216,36 +151,16 @@ external setTime : time:float -> (t[@mel.this]) -> float = "setTime"
 external setUTCDate : date:float -> (t[@mel.this]) -> float = "setUTCDate"
 [@@mel.send]
 
-external setUTCFullYear : year:float -> (t[@mel.this]) -> float
+external setUTCFullYear :
+  year:float -> ?month:float -> ?date:float -> (t[@mel.this]) -> float
   = "setUTCFullYear"
 [@@mel.send]
 
-external setUTCFullYearM : year:float -> month:float -> (t[@mel.this]) -> float
-  = "setUTCFullYear"
-[@@mel.send]
-
-external setUTCFullYearMD :
-  year:float -> month:float -> date:float -> (t[@mel.this]) -> float
-  = "setUTCFullYear"
-[@@mel.send]
-
-external setUTCHours : hours:float -> (t[@mel.this]) -> float = "setUTCHours"
-[@@mel.send]
-
-external setUTCHoursM : hours:float -> minutes:float -> (t[@mel.this]) -> float
-  = "setUTCHours"
-[@@mel.send]
-
-external setUTCHoursMS :
-  hours:float -> minutes:float -> seconds:float -> (t[@mel.this]) -> float
-  = "setUTCHours"
-[@@mel.send]
-
-external setUTCHoursMSMs :
+external setUTCHours :
   hours:float ->
-  minutes:float ->
-  seconds:float ->
-  milliseconds:float ->
+  ?minutes:float ->
+  ?seconds:float ->
+  ?milliseconds:float ->
   (t[@mel.this]) ->
   float = "setUTCHours"
 [@@mel.send]
@@ -254,35 +169,20 @@ external setUTCMilliseconds : milliseconds:float -> (t[@mel.this]) -> float
   = "setUTCMilliseconds"
 [@@mel.send]
 
-external setUTCMinutes : minutes:float -> (t[@mel.this]) -> float
-  = "setUTCMinutes"
-[@@mel.send]
-
-external setUTCMinutesS :
-  minutes:float -> seconds:float -> (t[@mel.this]) -> float = "setUTCMinutes"
-[@@mel.send]
-
-external setUTCMinutesSMs :
+external setUTCMinutes :
   minutes:float ->
-  seconds:float ->
-  milliseconds:float ->
+  ?seconds:float ->
+  ?milliseconds:float ->
   (t[@mel.this]) ->
   float = "setUTCMinutes"
 [@@mel.send]
 
-external setUTCMonth : month:float -> (t[@mel.this]) -> float = "setUTCMonth"
-[@@mel.send]
-
-external setUTCMonthD : month:float -> date:float -> (t[@mel.this]) -> float
+external setUTCMonth : month:float -> ?date:float -> (t[@mel.this]) -> float
   = "setUTCMonth"
 [@@mel.send]
 
-external setUTCSeconds : seconds:float -> (t[@mel.this]) -> float
-  = "setUTCSeconds"
-[@@mel.send]
-
-external setUTCSecondsMs :
-  seconds:float -> milliseconds:float -> (t[@mel.this]) -> float
+external setUTCSeconds :
+  seconds:float -> ?milliseconds:float -> (t[@mel.this]) -> float
   = "setUTCSeconds"
 [@@mel.send]
 

--- a/jscomp/test/js_date_test.ml
+++ b/jscomp/test/js_date_test.ml
@@ -32,14 +32,14 @@ let suites = Mt.[
           ));
 
     "makeWithYM", (fun _ ->
-      let d = N.makeWithYM ~year:1984. ~month:4. in
+      let d = N.make ~year:1984. ~month:4. () in
 
       Eq( (1984., 4.),
           (N.getFullYear d,
            N.getMonth d))
     );
     "makeWithYMD", (fun _ ->
-      let d = N.makeWithYMD ~year:1984. ~month:4. ~date:6. in
+      let d = N.make ~year:1984. ~month:4. ~date:6. () in
 
       Eq( (1984., 4., 6.),
           (N.getFullYear d,
@@ -47,7 +47,7 @@ let suites = Mt.[
            N.getDate d))
     );
     "makeWithYMDH", (fun _ ->
-      let d = N.makeWithYMDH ~year:1984. ~month:4. ~date:6. ~hours:3. in
+      let d = N.make ~year:1984. ~month:4. ~date:6. ~hours:3. () in
 
       Eq( (1984., 4., 6., 3.),
           (N.getFullYear d,
@@ -57,7 +57,7 @@ let suites = Mt.[
     );
     "makeWithYMDHM", (fun _ ->
       let d =
-        N.makeWithYMDHM ~year:1984. ~month:4. ~date:6. ~hours:3. ~minutes:59.
+        N.make ~year:1984. ~month:4. ~date:6. ~hours:3. ~minutes:59. ()
       in
 
       Eq( (1984., 4., 6., 3., 59.),
@@ -69,13 +69,14 @@ let suites = Mt.[
     );
     "makeWithYMDHMS", (fun _ ->
       let d =
-        N.makeWithYMDHMS
+        N.make
           ~year:1984.
           ~month:4.
           ~date:6.
           ~hours:3.
           ~minutes:59.
           ~seconds:27.
+          ()
       in
 
       Eq( (1984., 4., 6., 3., 59., 27.),
@@ -88,7 +89,7 @@ let suites = Mt.[
     );
 
     "utcWithYM", (fun _ ->
-      let d = N.utcWithYM ~year:1984. ~month:4. in
+      let d = N.utc ~year:1984. ~month:4. () in
       let d = N.fromFloat d in
 
       Eq( (1984., 4.),
@@ -96,7 +97,7 @@ let suites = Mt.[
            N.getUTCMonth d))
     );
     "utcWithYMD", (fun _ ->
-      let d = N.utcWithYMD ~year:1984. ~month:4. ~date:6. in
+      let d = N.utc ~year:1984. ~month:4. ~date:6. () in
       let d = N.fromFloat d in
 
       Eq( (1984., 4., 6.),
@@ -105,7 +106,7 @@ let suites = Mt.[
            N.getUTCDate d))
     );
     "utcWithYMDH", (fun _ ->
-      let d = N.utcWithYMDH ~year:1984. ~month:4. ~date:6. ~hours:3. in
+      let d = N.utc ~year:1984. ~month:4. ~date:6. ~hours:3. () in
       let d = N.fromFloat d in
 
       Eq( (1984., 4., 6., 3.),
@@ -116,7 +117,7 @@ let suites = Mt.[
     );
     "utcWithYMDHM", (fun _ ->
       let d =
-        N.utcWithYMDHM ~year:1984. ~month:4. ~date:6. ~hours:3. ~minutes:59. in
+        N.utc ~year:1984. ~month:4. ~date:6. ~hours:3. ~minutes:59. () in
       let d = N.fromFloat d in
 
       Eq( (1984., 4., 6., 3., 59.),
@@ -128,13 +129,14 @@ let suites = Mt.[
     );
     "utcWithYMDHMS", (fun _ ->
       let d =
-        N.utcWithYMDHMS
+        N.utc
           ~year:1984.
           ~month:4.
           ~date:6.
           ~hours:3.
           ~minutes:59.
           ~seconds:27.
+          ()
       in
       let d = N.fromFloat d in
 
@@ -208,14 +210,14 @@ let suites = Mt.[
     );
     "setFullYearM", (fun _ ->
       let d = date () in
-      let _ = N.setFullYearM d ~year:1986. ~month:7. in
+      let _ = N.setFullYear d ~year:1986. ~month:7. in
       Eq( (1986., 7.),
           (N.getFullYear d,
            N.getMonth d))
     );
     "setFullYearMD", (fun _ ->
       let d = date () in
-      let _ = N.setFullYearMD d ~year:1986. ~month:7. ~date:23. in
+      let _ = N.setFullYear d ~year:1986. ~month:7. ~date:23. in
       Eq( (1986., 7., 23.),
           (N.getFullYear d,
            N.getMonth d,
@@ -229,14 +231,14 @@ let suites = Mt.[
     );
     "setHoursM", (fun _ ->
       let d = date () in
-      let _ = N.setHoursM d ~hours:22. ~minutes:48. in
+      let _ = N.setHours d ~hours:22. ~minutes:48. in
       Eq( (22., 48.),
           (N.getHours d,
            N.getMinutes d))
     );
     "setHoursMS", (fun _ ->
       let d = date () in
-      let _ = N.setHoursMS d ~hours:22. ~minutes:48. ~seconds:54. in
+      let _ = N.setHours d ~hours:22. ~minutes:48. ~seconds:54. in
       Eq( (22., 48., 54.),
           (N.getHours d,
            N.getMinutes d,
@@ -256,14 +258,14 @@ let suites = Mt.[
     );
     "setMinutesS", (fun _ ->
       let d = date () in
-      let _ = N.setMinutesS d ~minutes:18. ~seconds:42. in
+      let _ = N.setMinutes d ~minutes:18. ~seconds:42. in
       Eq( (18., 42.),
          (N.getMinutes d,
           N.getSeconds d))
     );
     "setMinutesSMs", (fun _ ->
       let d = date () in
-      let _ = N.setMinutesSMs d ~minutes:18. ~seconds:42. ~milliseconds:311. in
+      let _ = N.setMinutes d ~minutes:18. ~seconds:42. ~milliseconds:311. in
       Eq( (18., 42., 311.),
           (N.getMinutes d,
            N.getSeconds d,
@@ -277,7 +279,7 @@ let suites = Mt.[
     );
     "setMonthD", (fun _ ->
       let d = date () in
-      let _ = N.setMonthD d ~month:10. ~date:14. in
+      let _ = N.setMonth d ~month:10. ~date:14. in
       Eq( (10., 14.),
           (N.getMonth d,
            N.getDate d))
@@ -290,7 +292,7 @@ let suites = Mt.[
     );
     "setSecondsMs", (fun _ ->
       let d = date () in
-      let _ = N.setSecondsMs d ~seconds:36. ~milliseconds:420. in
+      let _ = N.setSeconds d ~seconds:36. ~milliseconds:420. in
       Eq( (36., 420.),
           (N.getSeconds d,
            N.getMilliseconds d))
@@ -309,14 +311,14 @@ let suites = Mt.[
     );
     "setUTCFullYearM", (fun _ ->
       let d = date () in
-      let _ = N.setUTCFullYearM d ~year:1986. ~month:7. in
+      let _ = N.setUTCFullYear d ~year:1986. ~month:7. in
       Eq( (1986., 7.),
           (N.getUTCFullYear d,
            N.getUTCMonth d))
     );
     "setUTCFullYearMD", (fun _ ->
       let d = date () in
-      let _ = N.setUTCFullYearMD d ~year:1986. ~month:7. ~date:23. in
+      let _ = N.setUTCFullYear d ~year:1986. ~month:7. ~date:23. in
       Eq( (1986., 7., 23.),
           (N.getUTCFullYear d,
            N.getUTCMonth d,
@@ -330,14 +332,14 @@ let suites = Mt.[
     );
     "setUTCHoursM", (fun _ ->
       let d = date () in
-      let _ = N.setUTCHoursM d ~hours:22. ~minutes:48. in
+      let _ = N.setUTCHours d ~hours:22. ~minutes:48. in
       Eq( (22., 48.),
           (N.getUTCHours d,
            N.getUTCMinutes d))
     );
     "setUTCHoursMS", (fun _ ->
       let d = date () in
-      let _ = N.setUTCHoursMS d ~hours:22. ~minutes:48. ~seconds:54. in
+      let _ = N.setUTCHours d ~hours:22. ~minutes:48. ~seconds:54. in
       Eq( (22., 48., 54.),
           (N.getUTCHours d,
            N.getUTCMinutes d,
@@ -357,7 +359,7 @@ let suites = Mt.[
     );
     "setUTCMinutesS", (fun _ ->
       let d = date () in
-      let _ = N.setUTCMinutesS d ~minutes:18. ~seconds:42. in
+      let _ = N.setUTCMinutes d ~minutes:18. ~seconds:42. in
       Eq( (18., 42.),
           (N.getUTCMinutes d,
            N.getUTCSeconds d))
@@ -365,7 +367,7 @@ let suites = Mt.[
     "setUTCMinutesSMs", (fun _ ->
       let d = date () in
       let _ =
-        N.setUTCMinutesSMs d ~minutes:18. ~seconds:42. ~milliseconds:311.
+        N.setUTCMinutes d ~minutes:18. ~seconds:42. ~milliseconds:311.
       in
       Eq( (18., 42., 311.),
           (N.getUTCMinutes d,
@@ -380,7 +382,7 @@ let suites = Mt.[
     );
     "setUTCMonthD", (fun _ ->
       let d = date () in
-      let _ = N.setUTCMonthD d ~month:10. ~date:14. in
+      let _ = N.setUTCMonth d ~month:10. ~date:14. in
       Eq( (10., 14.),
           (N.getUTCMonth d,
            N.getUTCDate d))
@@ -393,7 +395,7 @@ let suites = Mt.[
     );
     "setUTCSecondsMs", (fun _ ->
       let d = date () in
-      let _ = N.setUTCSecondsMs d ~seconds:36. ~milliseconds:420. in
+      let _ = N.setUTCSeconds d ~seconds:36. ~milliseconds:420. in
       Eq( (36., 420.),
           (N.getUTCSeconds d,
            N.getUTCMilliseconds d))


### PR DESCRIPTION
adapts `Js.Date` to the trailing undefined work done in #1564, allowing a few bindings to be completely removed by virtue of having a better API to express non-existent arguments.