### PR TITLE
flow_ast_utils: return parse result and error

### DIFF
--- a/jscomp/common/flow_ast_utils.mli
+++ b/jscomp/common/flow_ast_utils.mli
@@ -22,28 +22,18 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-(* val check_flow_errors :
-  loc:Location.t ->
-  offset:int ->
-  (Js_parser.Loc.t * Js_parser.Parse_error.t) list ->
-  Js_parser.Parse_error.t option *)
-
 type check_errors = Dont_check | Check of { delimiter : string option }
-type 'a error = { prog : 'a; error : Js_parser.Parse_error.t }
+type 'a parse_result = { prog : 'a; error : Js_parser.Parse_error.t option }
 
 val parse_expression :
   loc:Location.t ->
   check_errors:check_errors ->
   string ->
-  ( (Js_parser.Loc.t, Js_parser.Loc.t) Js_parser.Flow_ast.Expression.t',
-    (Js_parser.Loc.t, Js_parser.Loc.t) Js_parser.Flow_ast.Expression.t' error
-  )
-  result
+  (Js_parser.Loc.t, Js_parser.Loc.t) Js_parser.Flow_ast.Expression.t'
+  parse_result
 
 val parse_program :
   loc:Location.t ->
   check_errors:check_errors ->
   string ->
-  ( (Js_parser.Loc.t, Js_parser.Loc.t) Js_parser.Flow_ast.Program.t',
-    (Js_parser.Loc.t, Js_parser.Loc.t) Js_parser.Flow_ast.Program.t' error )
-  result
+  (Js_parser.Loc.t, Js_parser.Loc.t) Js_parser.Flow_ast.Program.t' parse_result

--- a/ppx/ast_extensions.ml
+++ b/ppx/ast_extensions.ml
@@ -111,13 +111,8 @@ let raw_as_string_exp_exn ~(kind : Melange_ffi.Js_raw_info.raw_kind)
         let check_errors = Melange_ffi.Flow_ast_utils.Check { delimiter } in
         match kind with
         | Raw_re | Raw_exp ->
-            let prog =
-              match
-                Melange_ffi.Flow_ast_utils.parse_expression ~loc ~check_errors
-                  str
-              with
-              | Ok prog -> prog
-              | Error { prog; error = _ } -> prog
+            let { Melange_ffi.Flow_ast_utils.prog; error = _ } =
+              Melange_ffi.Flow_ast_utils.parse_expression ~loc ~check_errors str
             in
             (match (kind, prog) with
             | Raw_re, RegExpLiteral _ -> ()
@@ -133,7 +128,7 @@ let raw_as_string_exp_exn ~(kind : Melange_ffi.Js_raw_info.raw_kind)
                 | _ -> ())
               is_function
         | Raw_program ->
-            let _ : _ result =
+            let { Melange_ffi.Flow_ast_utils.prog = _; error = _ } =
               Melange_ffi.Flow_ast_utils.parse_program ~loc ~check_errors str
             in
             ()


### PR DESCRIPTION
we always use `prog` regardless, so there's no point of using the result type