### PR TITLE
ci: upgrade macos-13, now retired

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -19,8 +19,8 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - macos-13
           - macos-14
+          - macos-15-intel
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/