### PR TITLE
Fix let rec with lazy bindings generating forward JS references

### DIFF
--- a/jscomp/core/lam_compile.ml
+++ b/jscomp/core/lam_compile.ml
@@ -313,7 +313,11 @@ and compile_recursive_let :
             ~no_effects:(lazy (Lam_analysis.no_side_effects arg)),
           [] )
     | Lprim { primitive = Pmakeblock (_, _, _); args; _ }
-      when args_either_function_or_const args ->
+      when args_either_function_or_const args
+           && not
+                (List.exists all_bindings ~f:(fun (other_id, other_arg) ->
+                     (not (Ident.same other_id id))
+                     && Lam_hit.hit_variable id other_arg)) ->
         (compile_lambda { cxt with continuation = Declare (Alias, id) } arg, [])
         (* case of lazy blocks, treat it as usual *)
     | Lprim

--- a/test/blackbox-tests/let-rec-lazy.t
+++ b/test/blackbox-tests/let-rec-lazy.t
@@ -42,12 +42,14 @@ Melange build and run
   
   let a = {};
   
+  let b = {};
+  
   Caml_obj.update_dummy(a, {
     value: 1,
     next: b
   });
   
-  const b = {
+  Caml_obj.update_dummy(b, {
     LAZY_DONE: false,
     VAL: (function () {
       return {
@@ -58,7 +60,7 @@ Melange build and run
         }
       };
     })
-  };
+  });
   
   Stdlib.print_int(1);
   
@@ -73,5 +75,5 @@ Melange build and run
     b,
   }
   /*  Not a pure module */
-  $ node _build/default/out/rec_value.js 2>&1 | grep -i error
-  ReferenceError: Cannot access 'b' before initialization
+  $ node _build/default/out/rec_value.js
+  1 2


### PR DESCRIPTION
When a `let rec` group contains a lazy binding (Case B: Pmakeblock with all-function-or-const args) that is referenced by a sibling binding using `update_dummy`, the lazy binding was emitted as a `const` declaration after the `update_dummy` call that references it, causing a temporal dead zone ReferenceError at runtime.

Strengthen the Case B guard in `compile_recursive_let` to check whether any other binding in the same recursive group references this identifier. When it does, fall through to Case D (dummy + update_dummy) so the declaration is hoisted before any eager references.

P.S. Link to the original offending code https://github.com/dbuenzli/jsont/blob/v0.2.0/src/jsont.ml#L1726