### PR TITLE
Track direct imported call summaries

### DIFF
--- a/jscomp/core/lam_call_summary.ml
+++ b/jscomp/core/lam_call_summary.ml
@@ -3,13 +3,25 @@ open Import
 type t =
   | Unknown
   | Direct_primitive of Lam_primitive.t
+  | Direct_external of {
+      dynamic_import : bool;
+      id : Ident.t;
+      name : string;
+      arity : Lam_arity.t;
+    }
 
 let print fmt = function
   | Unknown -> Format.fprintf fmt "Unknown"
   | Direct_primitive primitive ->
       Format.fprintf fmt "Direct(%a)" Lam_print.primitive primitive
+  | Direct_external { dynamic_import; id; name; arity = _ } ->
+      Format.fprintf fmt "Direct(%s%s.%s)"
+        (if dynamic_import then "import " else "")
+        (Ident.name id) name
 
-let is_unknown = function Unknown -> true | Direct_primitive _ -> false
+let is_unknown = function
+  | Unknown -> true
+  | Direct_primitive _ | Direct_external _ -> false
 
 let params_match_args (params : Ident.t list) (args : Lam.t list) =
   List.same_length params args
@@ -39,6 +51,6 @@ and of_eta_wrapper ~find_ident ~find_external params body =
   | Lam.Lapply { ap_func; ap_args; _ }
     when params_match_args params ap_args -> (
       match of_lambda ~find_ident ~find_external ap_func with
-      | Direct_primitive _ as summary -> summary
+      | (Direct_primitive _ | Direct_external _) as summary -> summary
       | Unknown -> Unknown)
   | _ -> Unknown

--- a/jscomp/core/lam_call_summary.mli
+++ b/jscomp/core/lam_call_summary.mli
@@ -1,6 +1,12 @@
 type t =
   | Unknown
   | Direct_primitive of Lam_primitive.t
+  | Direct_external of {
+      dynamic_import : bool;
+      id : Ident.t;
+      name : string;
+      arity : Lam_arity.t;
+    }
 
 val print : Format.formatter -> t -> unit
 val is_unknown : t -> bool

--- a/jscomp/core/lam_pass_collect.ml
+++ b/jscomp/core/lam_pass_collect.ml
@@ -60,7 +60,14 @@ let annotate (meta : Lam_stats.t) rec_flag (k : Ident.t) (arity : Lam_arity.t)
 let collect_info =
   let find_external ~dynamic_import ident name =
     match Lam_compile_env.query_external_id_info ~dynamic_import ident name with
-    | Some { call_summary; _ } -> call_summary
+    | Some ({ arity; call_summary; _ } as _info) ->
+        if not (Lam_call_summary.is_unknown call_summary) then call_summary
+        else (
+          match arity with
+          | Single arity when not (Lam_arity.first_arity_na arity) ->
+              Lam_call_summary.Direct_external
+                { dynamic_import; id = ident; name; arity }
+          | Single _ | Submodule _ -> Lam_call_summary.Unknown)
     | None -> Lam_call_summary.Unknown
   in
   let find_ident (meta : Lam_stats.t) ident =

--- a/jscomp/core/lam_pass_remove_alias.ml
+++ b/jscomp/core/lam_pass_remove_alias.ml
@@ -140,12 +140,12 @@ let simplify_alias =
     | (exception Not_found) ->
         Eval_unknown
   in
-  let parameter_arg_id (tbl : Lam_id_kind.t Ident.Hashtbl.t) = function
+  let arg_is_parameter (tbl : Lam_id_kind.t Ident.Hashtbl.t) = function
     | Lam.Lvar p | Lam.Lmutvar p -> (
         match Ident.Hashtbl.find tbl p with
-        | Parameter -> Some p
-        | _ | exception Not_found -> None)
-    | _ -> None
+        | Parameter -> true
+        | _ | exception Not_found -> false)
+    | _ -> false
   in
   let rec contains_global_module (lam : Lam.t) =
     match lam with
@@ -330,15 +330,12 @@ let simplify_alias =
             let reduced =
               Lam_beta_reduce.propagate_beta_reduce meta params body args
             in
-            let parameter_args =
-              List.filter_map args ~f:(parameter_arg_id meta.ident_tbl)
+            let has_parameter_arg =
+              List.exists args ~f:(arg_is_parameter meta.ident_tbl)
             in
             if
-              List.is_empty parameter_args
-              || (cross_module_parameter_result_is_safe reduced
-                 && not
-                      (List.exists parameter_args ~f:(fun param ->
-                           Lam_hit.hit_variable param reduced)))
+              (not has_parameter_arg)
+              || cross_module_parameter_result_is_safe reduced
             then simpl meta reduced
             else Lam.apply (simpl meta l1) (List.map ~f:(simpl meta) args) ap_info
         | Some _ | None ->

--- a/jscomp/core/lam_pass_remove_alias.ml
+++ b/jscomp/core/lam_pass_remove_alias.ml
@@ -73,10 +73,20 @@ let simplify_alias =
     | Some n -> n = List.length args
     | None -> false
   in
+  let direct_apply_info (ap_info : Lam.ap_info) =
+    match ap_info.ap_status with
+    | Lam.App_na -> { ap_info with ap_status = Lam.App_infer_full }
+    | Lam.App_infer_full | Lam.App_uncurry -> ap_info
+  in
   let fully_applied_external arity args =
     match arity with
     | Js_cmj_format.Single arity -> fully_applied arity args
     | Js_cmj_format.Submodule _ -> false
+  in
+  let direct_external_field ~dynamic_import ident name ~loc =
+    Lam.prim ~primitive:(Pfield (0, Fld_module { name }))
+      ~args:[ Lam.global_module ~dynamic_import ident ]
+      ~loc
   in
   let direct_primitive_of_value value args =
     match value with
@@ -88,6 +98,18 @@ let simplify_alias =
         }
       when fully_applied arity args ->
         Some primitive
+    | _ -> None
+  in
+  let direct_external_of_value value args =
+    match value with
+    | Lam_id_kind.FunctionId
+        {
+          call_summary =
+            Lam_call_summary.Direct_external { dynamic_import; id; name; arity };
+          _;
+        }
+      when fully_applied arity args ->
+        Some (dynamic_import, id, name)
     | _ -> None
   in
   let rec id_is_for_sure_true_in_boolean (tbl : Lam_id_kind.t Ident.Hashtbl.t)
@@ -279,6 +301,28 @@ let simplify_alias =
               ~loc:ap_info.ap_loc
         | Some
             {
+              call_summary =
+                Lam_call_summary.Direct_external
+                  {
+                    dynamic_import = dynamic_import';
+                    id;
+                    name;
+                    arity = direct_arity;
+                  };
+              _;
+            }
+          when
+            fully_applied direct_arity args
+            && not
+                 (dynamic_import = dynamic_import' && Ident.same ident id
+                 && String.equal fld_name name) ->
+            simpl meta
+              (Lam.apply
+                 (direct_external_field ~dynamic_import:dynamic_import' id name
+                    ~loc:ap_info.ap_loc)
+                 args (direct_apply_info ap_info))
+        | Some
+            {
               persistent_closed_lambda = Some (Lfunction { params; body; _ }, _);
               _;
             }
@@ -317,7 +361,15 @@ let simplify_alias =
             | Some primitive ->
                 Lam.prim ~primitive ~args:ap_args ~loc:ap_info.ap_loc
             | None -> (
-                match value with
+                match direct_external_of_value value ap_args with
+                | Some (dynamic_import, id, name) ->
+                    simpl meta
+                      (Lam.apply
+                         (direct_external_field ~dynamic_import id name
+                            ~loc:ap_info.ap_loc)
+                         ap_args (direct_apply_info ap_info))
+                | None -> (
+                    match value with
                 | FunctionId
                     {
                       lambda =
@@ -384,7 +436,7 @@ let simplify_alias =
                         | _ -> normal ()
                       else normal ()
                     else normal ()
-                | _ -> normal ()))
+                | _ -> normal ())))
         | exception Not_found -> normal ())
     | Lapply { ap_func = Lfunction { params; body; _ }; ap_args = args; _ }
       when List.same_length params args ->

--- a/jscomp/core/lam_pass_remove_alias.ml
+++ b/jscomp/core/lam_pass_remove_alias.ml
@@ -140,12 +140,12 @@ let simplify_alias =
     | (exception Not_found) ->
         Eval_unknown
   in
-  let arg_is_parameter (tbl : Lam_id_kind.t Ident.Hashtbl.t) = function
+  let parameter_arg_id (tbl : Lam_id_kind.t Ident.Hashtbl.t) = function
     | Lam.Lvar p | Lam.Lmutvar p -> (
         match Ident.Hashtbl.find tbl p with
-        | Parameter -> true
-        | _ | exception Not_found -> false)
-    | _ -> false
+        | Parameter -> Some p
+        | _ | exception Not_found -> None)
+    | _ -> None
   in
   let rec contains_global_module (lam : Lam.t) =
     match lam with
@@ -330,12 +330,15 @@ let simplify_alias =
             let reduced =
               Lam_beta_reduce.propagate_beta_reduce meta params body args
             in
-            let has_parameter_arg =
-              List.exists args ~f:(arg_is_parameter meta.ident_tbl)
+            let parameter_args =
+              List.filter_map args ~f:(parameter_arg_id meta.ident_tbl)
             in
             if
-              (not has_parameter_arg)
-              || cross_module_parameter_result_is_safe reduced
+              List.is_empty parameter_args
+              || (cross_module_parameter_result_is_safe reduced
+                 && not
+                      (List.exists parameter_args ~f:(fun param ->
+                           Lam_hit.hit_variable param reduced)))
             then simpl meta reduced
             else Lam.apply (simpl meta l1) (List.map ~f:(simpl meta) args) ap_info
         | Some _ | None ->

--- a/jscomp/core/lam_stats_export.ml
+++ b/jscomp/core/lam_stats_export.ml
@@ -107,18 +107,29 @@ let values_of_export =
         let call_summary =
           match Ident.Map.find x export_map with
           | lambda ->
+              let find_external ~dynamic_import ident name =
+                match
+                  Lam_compile_env.query_external_id_info ~dynamic_import ident
+                    name
+                with
+                | Some { arity; call_summary; _ } ->
+                    if not (Lam_call_summary.is_unknown call_summary) then
+                      call_summary
+                    else (
+                      match arity with
+                      | Single arity when not (Lam_arity.first_arity_na arity)
+                        ->
+                          Lam_call_summary.Direct_external
+                            { dynamic_import; id = ident; name; arity }
+                      | Single _ | Submodule _ -> Lam_call_summary.Unknown)
+                | None -> Lam_call_summary.Unknown
+              in
               Lam_call_summary.of_lambda lambda
                 ~find_ident:(fun ident ->
                   match Ident.Hashtbl.find meta.ident_tbl ident with
                   | FunctionId { call_summary; _ } -> call_summary
                   | _ | exception Not_found -> Lam_call_summary.Unknown)
-                ~find_external:(fun ~dynamic_import ident name ->
-                  match
-                    Lam_compile_env.query_external_id_info ~dynamic_import ident
-                      name
-                  with
-                  | Some { call_summary; _ } -> call_summary
-                  | None -> Lam_call_summary.Unknown)
+                ~find_external
           | exception Not_found -> Lam_call_summary.Unknown
         in
         match (arity, persistent_closed_lambda, call_summary) with

--- a/jscomp/test/dist/bs_MapInt_test.js
+++ b/jscomp/test/dist/bs_MapInt_test.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const Belt__Belt_MapInt = require("melange.belt/belt_MapInt.js");
+const Belt__Belt_internalAVLtree = require("melange.belt/belt_internalAVLtree.js");
+const Belt__Belt_internalMapInt = require("melange.belt/belt_internalMapInt.js");
 const Js__Js_exn = require("melange.js/js_exn.js");
 
 function should(b) {
@@ -17,12 +19,12 @@ function test(param) {
     m = Belt__Belt_MapInt.set(m, i, i);
   }
   for (let i$1 = 0; i$1 <= 999999; ++i$1) {
-    should(Belt__Belt_MapInt.get(m, i$1) !== undefined);
+    should(Belt__Belt_internalMapInt.get(m, i$1) !== undefined);
   }
   for (let i$2 = 0; i$2 <= 999999; ++i$2) {
     m = Belt__Belt_MapInt.remove(m, i$2);
   }
-  should(Belt__Belt_MapInt.isEmpty(m));
+  should(Belt__Belt_internalAVLtree.isEmpty(m));
 }
 
 test();

--- a/jscomp/test/dist/bs_hashmap_test.js
+++ b/jscomp/test/dist/bs_hashmap_test.js
@@ -6,6 +6,7 @@ const Belt__Belt_Array = require("melange.belt/belt_Array.js");
 const Belt__Belt_HashMap = require("melange.belt/belt_HashMap.js");
 const Belt__Belt_Id = require("melange.belt/belt_Id.js");
 const Belt__Belt_SortArray = require("melange.belt/belt_SortArray.js");
+const Belt__Belt_internalBuckets = require("melange.belt/belt_internalBuckets.js");
 const Belt__Belt_internalBucketsType = require("melange.belt/belt_internalBucketsType.js");
 const Caml = require("melange.js/caml.js");
 const Mt = require("./mt.js");
@@ -74,7 +75,7 @@ const xx = Belt__Belt_HashMap.fromArray(v, Y);
 
 eqx("File \"jscomp/test/bs_hashmap_test.ml\", line 41, characters 6-13", xx.size, 91);
 
-eqx("File \"jscomp/test/bs_hashmap_test.ml\", line 42, characters 6-13", Belt__Belt_SortArray.stableSortBy(Belt__Belt_HashMap.keysToArray(xx), cmp), Array_data_util.range(30, 120));
+eqx("File \"jscomp/test/bs_hashmap_test.ml\", line 42, characters 6-13", Belt__Belt_SortArray.stableSortBy(Belt__Belt_internalBuckets.keysToArray(xx), cmp), Array_data_util.range(30, 120));
 
 const u$1 = Belt__Belt_Array.concat(Array_data_util.randomRange(0, 100000), Array_data_util.randomRange(0, 100));
 

--- a/jscomp/test/dist/bs_hashset_int_test.js
+++ b/jscomp/test/dist/bs_hashset_int_test.js
@@ -4,9 +4,11 @@
 const Array_data_util = require("./array_data_util.js");
 const Belt__Belt_Array = require("melange.belt/belt_Array.js");
 const Belt__Belt_HashSetInt = require("melange.belt/belt_HashSetInt.js");
-const Belt__Belt_SetInt = require("melange.belt/belt_SetInt.js");
 const Belt__Belt_SortArrayInt = require("melange.belt/belt_SortArrayInt.js");
+const Belt__Belt_internalAVLset = require("melange.belt/belt_internalAVLset.js");
 const Belt__Belt_internalBucketsType = require("melange.belt/belt_internalBucketsType.js");
+const Belt__Belt_internalSetBuckets = require("melange.belt/belt_internalSetBuckets.js");
+const Belt__Belt_internalSetInt = require("melange.belt/belt_internalSetInt.js");
 const Mt = require("./mt.js");
 
 const suites = {
@@ -33,7 +35,7 @@ function sum2(h) {
   const v = {
     contents: 0
   };
-  Belt__Belt_HashSetInt.forEach(h, (function (x) {
+  Belt__Belt_internalSetBuckets.forEach(h, (function (x) {
     v.contents = v.contents + x | 0;
   }));
   return v.contents;
@@ -45,11 +47,11 @@ const v = Belt__Belt_HashSetInt.fromArray(u);
 
 eq("File \"jscomp/test/bs_hashset_int_test.ml\", line 19, characters 5-12", v.size, 91);
 
-const xs = Belt__Belt_SetInt.toArray(Belt__Belt_SetInt.fromArray(Belt__Belt_HashSetInt.toArray(v)));
+const xs = Belt__Belt_internalAVLset.toArray(Belt__Belt_internalSetInt.fromArray(Belt__Belt_internalSetBuckets.toArray(v)));
 
 eq("File \"jscomp/test/bs_hashset_int_test.ml\", line 21, characters 5-12", xs, Array_data_util.range(30, 120));
 
-eq("File \"jscomp/test/bs_hashset_int_test.ml\", line 23, characters 5-12", Belt__Belt_HashSetInt.reduce(v, 0, add), 6825);
+eq("File \"jscomp/test/bs_hashset_int_test.ml\", line 23, characters 5-12", Belt__Belt_internalSetBuckets.reduce(v, 0, add), 6825);
 
 eq("File \"jscomp/test/bs_hashset_int_test.ml\", line 24, characters 5-12", sum2(v), 6825);
 
@@ -75,9 +77,9 @@ eq("File \"jscomp/test/bs_hashset_int_test.ml\", line 38, characters 5-12", v$1.
 
 const u0 = Belt__Belt_HashSetInt.fromArray(Array_data_util.randomRange(0, 100000));
 
-const u1 = Belt__Belt_HashSetInt.copy(u0);
+const u1 = Belt__Belt_internalSetBuckets.copy(u0);
 
-eq("File \"jscomp/test/bs_hashset_int_test.ml\", line 46, characters 5-12", Belt__Belt_HashSetInt.toArray(u0), Belt__Belt_HashSetInt.toArray(u1));
+eq("File \"jscomp/test/bs_hashset_int_test.ml\", line 46, characters 5-12", Belt__Belt_internalSetBuckets.toArray(u0), Belt__Belt_internalSetBuckets.toArray(u1));
 
 for (let i$2 = 0; i$2 <= 2000; ++i$2) {
   Belt__Belt_HashSetInt.remove(u1, i$2);
@@ -87,9 +89,9 @@ for (let i$3 = 0; i$3 <= 1000; ++i$3) {
   Belt__Belt_HashSetInt.remove(u0, i$3);
 }
 
-const v0 = Belt__Belt_Array.concat(Array_data_util.range(0, 1000), Belt__Belt_HashSetInt.toArray(u0));
+const v0 = Belt__Belt_Array.concat(Array_data_util.range(0, 1000), Belt__Belt_internalSetBuckets.toArray(u0));
 
-const v1 = Belt__Belt_Array.concat(Array_data_util.range(0, 2000), Belt__Belt_HashSetInt.toArray(u1));
+const v1 = Belt__Belt_Array.concat(Array_data_util.range(0, 2000), Belt__Belt_internalSetBuckets.toArray(u1));
 
 Belt__Belt_SortArrayInt.stableSortInPlace(v0);
 
@@ -99,7 +101,7 @@ eq("File \"jscomp/test/bs_hashset_int_test.ml\", line 57, characters 5-12", v0, 
 
 const h = Belt__Belt_HashSetInt.fromArray(Array_data_util.randomRange(0, 1000000));
 
-const histo = Belt__Belt_HashSetInt.getBucketHistogram(h);
+const histo = Belt__Belt_internalSetBuckets.getBucketHistogram(h);
 
 b("File \"jscomp/test/bs_hashset_int_test.ml\", line 62, characters 4-11", histo.length <= 10);
 

--- a/jscomp/test/dist/bs_hashtbl_string_test.js
+++ b/jscomp/test/dist/bs_hashtbl_string_test.js
@@ -6,7 +6,10 @@ const Belt__Belt_HashMapInt = require("melange.belt/belt_HashMapInt.js");
 const Belt__Belt_HashMapString = require("melange.belt/belt_HashMapString.js");
 const Belt__Belt_HashSetInt = require("melange.belt/belt_HashSetInt.js");
 const Belt__Belt_Id = require("melange.belt/belt_Id.js");
+const Belt__Belt_Map = require("melange.belt/belt_Map.js");
 const Belt__Belt_MapDict = require("melange.belt/belt_MapDict.js");
+const Belt__Belt_internalAVLtree = require("melange.belt/belt_internalAVLtree.js");
+const Belt__Belt_internalBuckets = require("melange.belt/belt_internalBuckets.js");
 const Belt__Belt_internalBucketsType = require("melange.belt/belt_internalBucketsType.js");
 const Caml = require("melange.js/caml.js");
 const Caml_hash_primitive = require("melange.js/caml_hash_primitive.js");
@@ -64,7 +67,7 @@ function bench(param) {
     }
     
   }
-  Belt__Belt_HashMap.logStats(empty);
+  Belt__Belt_internalBuckets.logStats(empty);
 }
 
 function bench2(m) {
@@ -109,7 +112,7 @@ function bench3(m) {
     table = Belt__Belt_MapDict.set(table, String(i), i, cmp);
   }
   for (let i$1 = 0; i$1 <= 1000000; ++i$1) {
-    if (!Belt__Belt_MapDict.has(table, String(i$1), cmp)) {
+    if (!Belt__Belt_internalAVLtree.has(table, String(i$1), cmp)) {
       throw new Caml_js_exceptions.MelangeError("Assert_failure", {
           MEL_EXN_ID: "Assert_failure",
           _1: [
@@ -124,7 +127,7 @@ function bench3(m) {
   for (let i$2 = 0; i$2 <= 1000000; ++i$2) {
     table = Belt__Belt_MapDict.remove(table, String(i$2), cmp);
   }
-  if (Belt__Belt_MapDict.size(table) === 0) {
+  if (Belt__Belt_internalAVLtree.size(table) === 0) {
     return;
   }
   throw new Caml_js_exceptions.MelangeError("Assert_failure", {
@@ -160,7 +163,7 @@ function bench4(param) {
   for (let i$2 = 0; i$2 <= 1000000; ++i$2) {
     Belt__Belt_HashMapString.remove(table, String(i$2));
   }
-  if (Belt__Belt_HashMapString.isEmpty(table)) {
+  if (table.size === 0) {
     return;
   }
   throw new Caml_js_exceptions.MelangeError("Assert_failure", {
@@ -200,7 +203,7 @@ function bench5(param) {
     Belt__Belt_HashMap.remove(table, i$2);
   }
   console.timeEnd("bs_hashtbl_string_test.ml 141");
-  if (Belt__Belt_HashMap.isEmpty(table)) {
+  if (table.size === 0) {
     return;
   }
   throw new Caml_js_exceptions.MelangeError("Assert_failure", {

--- a/jscomp/test/dist/bs_map_set_dict_test.js
+++ b/jscomp/test/dist/bs_map_set_dict_test.js
@@ -7,7 +7,9 @@ const Belt__Belt_Id = require("melange.belt/belt_Id.js");
 const Belt__Belt_List = require("melange.belt/belt_List.js");
 const Belt__Belt_Map = require("melange.belt/belt_Map.js");
 const Belt__Belt_MapDict = require("melange.belt/belt_MapDict.js");
+const Belt__Belt_Set = require("melange.belt/belt_Set.js");
 const Belt__Belt_SetDict = require("melange.belt/belt_SetDict.js");
+const Belt__Belt_internalAVLtree = require("melange.belt/belt_internalAVLtree.js");
 const Caml = require("melange.js/caml.js");
 const Mt = require("./mt.js");
 
@@ -112,16 +114,16 @@ function $eq$tilde(a, b) {
   };
 }
 
-const u0 = f(Belt__Belt_Array.map(Array_data_util.randomRange(0, 39), (function (x) {
+const u0 = Belt__Belt_Map.fromArray(Belt__Belt_Array.map(Array_data_util.randomRange(0, 39), (function (x) {
   return [
     x,
     x
   ];
-})));
+})), Icmp);
 
 const u1 = Belt__Belt_Map.set(u0, 39, 120);
 
-b("File \"jscomp/test/bs_map_set_dict_test.ml\", line 80, characters 4-11", Belt__Belt_Array.every2(Belt__Belt_MapDict.toArray(u0.data), Belt__Belt_Array.map(Array_data_util.range(0, 39), (function (x) {
+b("File \"jscomp/test/bs_map_set_dict_test.ml\", line 80, characters 4-11", Belt__Belt_Array.every2(Belt__Belt_internalAVLtree.toArray(u0.data), Belt__Belt_Array.map(Array_data_util.range(0, 39), (function (x) {
   return [
     x,
     x
@@ -134,7 +136,7 @@ b("File \"jscomp/test/bs_map_set_dict_test.ml\", line 80, characters 4-11", Belt
   }
 })));
 
-b("File \"jscomp/test/bs_map_set_dict_test.ml\", line 85, characters 4-11", Belt__Belt_List.every2(Belt__Belt_MapDict.toList(u0.data), Belt__Belt_List.fromArray(Belt__Belt_Array.map(Array_data_util.range(0, 39), (function (x) {
+b("File \"jscomp/test/bs_map_set_dict_test.ml\", line 85, characters 4-11", Belt__Belt_List.every2(Belt__Belt_internalAVLtree.toList(u0.data), Belt__Belt_List.fromArray(Belt__Belt_Array.map(Array_data_util.range(0, 39), (function (x) {
   return [
     x,
     x
@@ -151,19 +153,19 @@ eq("File \"jscomp/test/bs_map_set_dict_test.ml\", line 90, characters 5-12", Bel
 
 eq("File \"jscomp/test/bs_map_set_dict_test.ml\", line 91, characters 5-12", Belt__Belt_Map.get(u1, 39), 120);
 
-const u = f(Belt__Belt_Array.makeByAndShuffle(10000, (function (x) {
+const u = Belt__Belt_Map.fromArray(Belt__Belt_Array.makeByAndShuffle(10000, (function (x) {
   return [
     x,
     x
   ];
-})));
+})), Icmp);
 
 eq("File \"jscomp/test/bs_map_set_dict_test.ml\", line 97, characters 4-11", Belt__Belt_Array.makeBy(10000, (function (x) {
   return [
     x,
     x
   ];
-})), Belt__Belt_MapDict.toArray(u.data));
+})), Belt__Belt_internalAVLtree.toArray(u.data));
 
 Mt.from_pair_suites("Bs_map_set_dict_test", suites.contents);
 

--- a/jscomp/test/dist/bs_map_test.js
+++ b/jscomp/test/dist/bs_map_test.js
@@ -3,7 +3,9 @@
 
 const Belt__Belt_Array = require("melange.belt/belt_Array.js");
 const Belt__Belt_MapInt = require("melange.belt/belt_MapInt.js");
-const Belt__Belt_SetInt = require("melange.belt/belt_SetInt.js");
+const Belt__Belt_internalAVLtree = require("melange.belt/belt_internalAVLtree.js");
+const Belt__Belt_internalMapInt = require("melange.belt/belt_internalMapInt.js");
+const Belt__Belt_internalSetInt = require("melange.belt/belt_internalSetInt.js");
 const Mt = require("./mt.js");
 
 const suites = {
@@ -47,9 +49,9 @@ function b(loc, v) {
   };
 }
 
-const mapOfArray = Belt__Belt_MapInt.fromArray;
+const mapOfArray = Belt__Belt_internalMapInt.fromArray;
 
-const setOfArray = Belt__Belt_SetInt.fromArray;
+const setOfArray = Belt__Belt_internalSetInt.fromArray;
 
 function emptyMap(param) {
   
@@ -62,9 +64,9 @@ const v = Belt__Belt_Array.makeByAndShuffle(1000000, (function (i) {
   ];
 }));
 
-const u = Belt__Belt_MapInt.fromArray(v);
+const u = Belt__Belt_internalMapInt.fromArray(v);
 
-Belt__Belt_MapInt.checkInvariantInternal(u);
+Belt__Belt_internalAVLtree.checkInvariantInternal(u);
 
 const firstHalf = Belt__Belt_Array.slice(v, 0, 2000);
 
@@ -72,9 +74,9 @@ const xx = Belt__Belt_Array.reduce(firstHalf, u, (function (acc, param) {
   return Belt__Belt_MapInt.remove(acc, param[0]);
 }));
 
-Belt__Belt_MapInt.checkInvariantInternal(u);
+Belt__Belt_internalAVLtree.checkInvariantInternal(u);
 
-Belt__Belt_MapInt.checkInvariantInternal(xx);
+Belt__Belt_internalAVLtree.checkInvariantInternal(xx);
 
 Mt.from_pair_suites("Bs_map_test", suites.contents);
 

--- a/jscomp/test/dist/bs_mutable_set_test.js
+++ b/jscomp/test/dist/bs_mutable_set_test.js
@@ -293,64 +293,56 @@ b("File \"jscomp/test/bs_mutable_set_test.ml\", line 120, characters 4-11", Belt
   data: undefined
 }));
 
+const xs$13 = [
+  1,
+  3,
+  4,
+  5,
+  7,
+  9
+];
+
+const xs$14 = [
+  2,
+  4,
+  5,
+  6,
+  8,
+  10
+];
+
+const xs$15 = [
+  4,
+  5
+];
+
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 126, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.intersect({
-  data: Belt__Belt_internalSetInt.fromArray([
-    1,
-    3,
-    4,
-    5,
-    7,
-    9
-  ])
+  data: Belt__Belt_internalSetInt.fromArray(xs$13)
 }, {
-  data: Belt__Belt_internalSetInt.fromArray([
-    2,
-    4,
-    5,
-    6,
-    8,
-    10
-  ])
+  data: Belt__Belt_internalSetInt.fromArray(xs$14)
 }), {
-  data: Belt__Belt_internalSetInt.fromArray([
-    4,
-    5
-  ])
+  data: Belt__Belt_internalSetInt.fromArray(xs$15)
 }));
 
-const xs$13 = Array_data_util.randomRange(0, 39);
+const xs$16 = Array_data_util.randomRange(0, 39);
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 132, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff(aa$2, bb$2), {
-  data: Belt__Belt_internalSetInt.fromArray(xs$13)
+  data: Belt__Belt_internalSetInt.fromArray(xs$16)
 }));
 
-const xs$14 = Array_data_util.randomRange(101, 120);
+const xs$17 = Array_data_util.randomRange(101, 120);
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 134, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff(bb$2, aa$2), {
-  data: Belt__Belt_internalSetInt.fromArray(xs$14)
-}));
-
-const xs$15 = Array_data_util.randomRange(21, 40);
-
-const xs$16 = Array_data_util.randomRange(0, 20);
-
-const xs$17 = Array_data_util.randomRange(21, 40);
-
-b("File \"jscomp/test/bs_mutable_set_test.ml\", line 136, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
-  data: Belt__Belt_internalSetInt.fromArray(xs$15)
-}, {
-  data: Belt__Belt_internalSetInt.fromArray(xs$16)
-}), {
   data: Belt__Belt_internalSetInt.fromArray(xs$17)
 }));
 
-const xs$18 = Array_data_util.randomRange(0, 20);
+const xs$18 = Array_data_util.randomRange(21, 40);
 
-const xs$19 = Array_data_util.randomRange(21, 40);
+const xs$19 = Array_data_util.randomRange(0, 20);
 
-const xs$20 = Array_data_util.randomRange(0, 20);
+const xs$20 = Array_data_util.randomRange(21, 40);
 
-b("File \"jscomp/test/bs_mutable_set_test.ml\", line 142, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
+b("File \"jscomp/test/bs_mutable_set_test.ml\", line 136, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
   data: Belt__Belt_internalSetInt.fromArray(xs$18)
 }, {
   data: Belt__Belt_internalSetInt.fromArray(xs$19)
@@ -360,11 +352,11 @@ b("File \"jscomp/test/bs_mutable_set_test.ml\", line 142, characters 4-11", Belt
 
 const xs$21 = Array_data_util.randomRange(0, 20);
 
-const xs$22 = Array_data_util.randomRange(0, 40);
+const xs$22 = Array_data_util.randomRange(21, 40);
 
-const xs$23 = Array_data_util.randomRange(0, -1);
+const xs$23 = Array_data_util.randomRange(0, 20);
 
-b("File \"jscomp/test/bs_mutable_set_test.ml\", line 149, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
+b("File \"jscomp/test/bs_mutable_set_test.ml\", line 142, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
   data: Belt__Belt_internalSetInt.fromArray(xs$21)
 }, {
   data: Belt__Belt_internalSetInt.fromArray(xs$22)
@@ -372,10 +364,24 @@ b("File \"jscomp/test/bs_mutable_set_test.ml\", line 149, characters 4-11", Belt
   data: Belt__Belt_internalSetInt.fromArray(xs$23)
 }));
 
-const xs$24 = Array_data_util.randomRange(0, 1000);
+const xs$24 = Array_data_util.randomRange(0, 20);
+
+const xs$25 = Array_data_util.randomRange(0, 40);
+
+const xs$26 = Array_data_util.randomRange(0, -1);
+
+b("File \"jscomp/test/bs_mutable_set_test.ml\", line 149, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
+  data: Belt__Belt_internalSetInt.fromArray(xs$24)
+}, {
+  data: Belt__Belt_internalSetInt.fromArray(xs$25)
+}), {
+  data: Belt__Belt_internalSetInt.fromArray(xs$26)
+}));
+
+const xs$27 = Array_data_util.randomRange(0, 1000);
 
 const a0 = {
-  data: Belt__Belt_internalSetInt.fromArray(xs$24)
+  data: Belt__Belt_internalSetInt.fromArray(xs$27)
 };
 
 const a1 = Belt__Belt_MutableSetInt.keep(a0, (function (x) {
@@ -471,12 +477,12 @@ eq("File \"jscomp/test/bs_mutable_set_test.ml\", line 206, characters 5-12", Bel
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 207, characters 4-11", Belt__Belt_MutableSetInt.isEmpty(v$3));
 
-const xs$25 = Belt__Belt_Array.makeBy(30, (function (i) {
+const xs$28 = Belt__Belt_Array.makeBy(30, (function (i) {
   return i;
 }));
 
 const v$4 = {
-  data: Belt__Belt_internalSetInt.fromArray(xs$25)
+  data: Belt__Belt_internalSetInt.fromArray(xs$28)
 };
 
 Belt__Belt_MutableSetInt.remove(v$4, 30);
@@ -592,10 +598,10 @@ id("File \"jscomp/test/bs_mutable_set_test.ml\", line 239, characters 5-12", [
 
 id("File \"jscomp/test/bs_mutable_set_test.ml\", line 240, characters 5-12", Array_data_util.range(0, 1000));
 
-const xs$26 = Array_data_util.randomRange(0, 1000);
+const xs$29 = Array_data_util.randomRange(0, 1000);
 
 const v$5 = {
-  data: Belt__Belt_internalSetInt.fromArray(xs$26)
+  data: Belt__Belt_internalSetInt.fromArray(xs$29)
 };
 
 const copyV = Belt__Belt_MutableSetInt.keep(v$5, (function (x) {
@@ -626,199 +632,205 @@ b("File \"jscomp/test/bs_mutable_set_test.ml\", line 253, characters 4-11", Belt
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 254, characters 4-11", Belt__Belt_MutableSetInt.eq(cc$1, match$5[1]));
 
-const xs$27 = Array_data_util.randomRange(0, 1000);
+const xs$30 = Array_data_util.randomRange(0, 1000);
 
 const v$6 = {
-  data: Belt__Belt_internalSetInt.fromArray(xs$27)
+  data: Belt__Belt_internalSetInt.fromArray(xs$30)
 };
 
 const match$6 = Belt__Belt_MutableSetInt.split(v$6, 400);
 
 const match$7 = match$6[0];
 
-const xs$28 = Array_data_util.randomRange(0, 399);
+const xs$31 = Array_data_util.randomRange(0, 399);
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 259, characters 4-11", Belt__Belt_MutableSetInt.eq(match$7[0], {
-  data: Belt__Belt_internalSetInt.fromArray(xs$28)
+  data: Belt__Belt_internalSetInt.fromArray(xs$31)
 }));
 
-const xs$29 = Array_data_util.randomRange(401, 1000);
+const xs$32 = Array_data_util.randomRange(401, 1000);
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 260, characters 4-11", Belt__Belt_MutableSetInt.eq(match$7[1], {
-  data: Belt__Belt_internalSetInt.fromArray(xs$29)
+  data: Belt__Belt_internalSetInt.fromArray(xs$32)
 }));
 
-const xs$30 = Belt__Belt_Array.map(Array_data_util.randomRange(0, 1000), (function (x) {
+const xs$33 = Belt__Belt_Array.map(Array_data_util.randomRange(0, 1000), (function (x) {
   return (x << 1);
 }));
 
 const d = {
-  data: Belt__Belt_internalSetInt.fromArray(xs$30)
+  data: Belt__Belt_internalSetInt.fromArray(xs$33)
 };
 
 const match$8 = Belt__Belt_MutableSetInt.split(d, 1001);
 
 const match$9 = match$8[0];
 
-const xs$31 = Belt__Belt_Array.makeBy(501, (function (x) {
+const xs$34 = Belt__Belt_Array.makeBy(501, (function (x) {
   return (x << 1);
 }));
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 263, characters 4-11", Belt__Belt_MutableSetInt.eq(match$9[0], {
-  data: Belt__Belt_internalSetInt.fromArray(xs$31)
+  data: Belt__Belt_internalSetInt.fromArray(xs$34)
 }));
 
-const xs$32 = Belt__Belt_Array.makeBy(500, (function (x) {
+const xs$35 = Belt__Belt_Array.makeBy(500, (function (x) {
   return 1002 + (x << 1) | 0;
 }));
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 264, characters 4-11", Belt__Belt_MutableSetInt.eq(match$9[1], {
-  data: Belt__Belt_internalSetInt.fromArray(xs$32)
+  data: Belt__Belt_internalSetInt.fromArray(xs$35)
 }));
 
-const xs$33 = Array_data_util.randomRange(0, 100);
+const xs$36 = Array_data_util.randomRange(0, 100);
 
 const aa$3 = {
-  data: Belt__Belt_internalSetInt.fromArray(xs$33)
+  data: Belt__Belt_internalSetInt.fromArray(xs$36)
 };
 
-const xs$34 = Array_data_util.randomRange(40, 120);
+const xs$37 = Array_data_util.randomRange(40, 120);
 
 const bb$3 = {
-  data: Belt__Belt_internalSetInt.fromArray(xs$34)
+  data: Belt__Belt_internalSetInt.fromArray(xs$37)
 };
 
 const cc$2 = Belt__Belt_MutableSetInt.union(aa$3, bb$3);
 
-const xs$35 = Array_data_util.randomRange(0, 120);
+const xs$38 = Array_data_util.randomRange(0, 120);
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 274, characters 4-11", Belt__Belt_MutableSetInt.eq(cc$2, {
-  data: Belt__Belt_internalSetInt.fromArray(xs$35)
+  data: Belt__Belt_internalSetInt.fromArray(xs$38)
 }));
 
-const xs$36 = Array_data_util.randomRange(0, 20);
+const xs$39 = Array_data_util.randomRange(0, 20);
 
-const xs$37 = Array_data_util.randomRange(21, 40);
+const xs$40 = Array_data_util.randomRange(21, 40);
 
-const xs$38 = Array_data_util.randomRange(0, 40);
+const xs$41 = Array_data_util.randomRange(0, 40);
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 276, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.union({
-  data: Belt__Belt_internalSetInt.fromArray(xs$36)
+  data: Belt__Belt_internalSetInt.fromArray(xs$39)
 }, {
-  data: Belt__Belt_internalSetInt.fromArray(xs$37)
+  data: Belt__Belt_internalSetInt.fromArray(xs$40)
 }), {
-  data: Belt__Belt_internalSetInt.fromArray(xs$38)
+  data: Belt__Belt_internalSetInt.fromArray(xs$41)
 }));
 
 const dd$1 = Belt__Belt_MutableSetInt.intersect(aa$3, bb$3);
 
-const xs$39 = Array_data_util.randomRange(40, 100);
+const xs$42 = Array_data_util.randomRange(40, 100);
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 281, characters 4-11", Belt__Belt_MutableSetInt.eq(dd$1, {
-  data: Belt__Belt_internalSetInt.fromArray(xs$39)
+  data: Belt__Belt_internalSetInt.fromArray(xs$42)
 }));
-
-const xs$40 = Array_data_util.randomRange(0, 20);
-
-const xs$41 = Array_data_util.randomRange(21, 40);
-
-b("File \"jscomp/test/bs_mutable_set_test.ml\", line 282, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.intersect({
-  data: Belt__Belt_internalSetInt.fromArray(xs$40)
-}, {
-  data: Belt__Belt_internalSetInt.fromArray(xs$41)
-}), {
-  data: undefined
-}));
-
-const xs$42 = Array_data_util.randomRange(21, 40);
 
 const xs$43 = Array_data_util.randomRange(0, 20);
 
-b("File \"jscomp/test/bs_mutable_set_test.ml\", line 288, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.intersect({
-  data: Belt__Belt_internalSetInt.fromArray(xs$42)
-}, {
+const xs$44 = Array_data_util.randomRange(21, 40);
+
+b("File \"jscomp/test/bs_mutable_set_test.ml\", line 282, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.intersect({
   data: Belt__Belt_internalSetInt.fromArray(xs$43)
+}, {
+  data: Belt__Belt_internalSetInt.fromArray(xs$44)
 }), {
   data: undefined
 }));
 
-b("File \"jscomp/test/bs_mutable_set_test.ml\", line 294, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.intersect({
-  data: Belt__Belt_internalSetInt.fromArray([
-    1,
-    3,
-    4,
-    5,
-    7,
-    9
-  ])
+const xs$45 = Array_data_util.randomRange(21, 40);
+
+const xs$46 = Array_data_util.randomRange(0, 20);
+
+b("File \"jscomp/test/bs_mutable_set_test.ml\", line 288, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.intersect({
+  data: Belt__Belt_internalSetInt.fromArray(xs$45)
 }, {
-  data: Belt__Belt_internalSetInt.fromArray([
-    2,
-    4,
-    5,
-    6,
-    8,
-    10
-  ])
+  data: Belt__Belt_internalSetInt.fromArray(xs$46)
 }), {
-  data: Belt__Belt_internalSetInt.fromArray([
-    4,
-    5
-  ])
+  data: undefined
 }));
 
-const xs$44 = Array_data_util.randomRange(0, 39);
+const xs$47 = [
+  1,
+  3,
+  4,
+  5,
+  7,
+  9
+];
+
+const xs$48 = [
+  2,
+  4,
+  5,
+  6,
+  8,
+  10
+];
+
+const xs$49 = [
+  4,
+  5
+];
+
+b("File \"jscomp/test/bs_mutable_set_test.ml\", line 294, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.intersect({
+  data: Belt__Belt_internalSetInt.fromArray(xs$47)
+}, {
+  data: Belt__Belt_internalSetInt.fromArray(xs$48)
+}), {
+  data: Belt__Belt_internalSetInt.fromArray(xs$49)
+}));
+
+const xs$50 = Array_data_util.randomRange(0, 39);
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 300, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff(aa$3, bb$3), {
-  data: Belt__Belt_internalSetInt.fromArray(xs$44)
+  data: Belt__Belt_internalSetInt.fromArray(xs$50)
 }));
 
-const xs$45 = Array_data_util.randomRange(101, 120);
+const xs$51 = Array_data_util.randomRange(101, 120);
 
 b("File \"jscomp/test/bs_mutable_set_test.ml\", line 302, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff(bb$3, aa$3), {
-  data: Belt__Belt_internalSetInt.fromArray(xs$45)
-}));
-
-const xs$46 = Array_data_util.randomRange(21, 40);
-
-const xs$47 = Array_data_util.randomRange(0, 20);
-
-const xs$48 = Array_data_util.randomRange(21, 40);
-
-b("File \"jscomp/test/bs_mutable_set_test.ml\", line 304, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
-  data: Belt__Belt_internalSetInt.fromArray(xs$46)
-}, {
-  data: Belt__Belt_internalSetInt.fromArray(xs$47)
-}), {
-  data: Belt__Belt_internalSetInt.fromArray(xs$48)
-}));
-
-const xs$49 = Array_data_util.randomRange(0, 20);
-
-const xs$50 = Array_data_util.randomRange(21, 40);
-
-const xs$51 = Array_data_util.randomRange(0, 20);
-
-b("File \"jscomp/test/bs_mutable_set_test.ml\", line 310, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
-  data: Belt__Belt_internalSetInt.fromArray(xs$49)
-}, {
-  data: Belt__Belt_internalSetInt.fromArray(xs$50)
-}), {
   data: Belt__Belt_internalSetInt.fromArray(xs$51)
 }));
 
-const xs$52 = Array_data_util.randomRange(0, 20);
+const xs$52 = Array_data_util.randomRange(21, 40);
 
-const xs$53 = Array_data_util.randomRange(0, 40);
+const xs$53 = Array_data_util.randomRange(0, 20);
 
-const xs$54 = Array_data_util.randomRange(0, -1);
+const xs$54 = Array_data_util.randomRange(21, 40);
 
-b("File \"jscomp/test/bs_mutable_set_test.ml\", line 317, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
+b("File \"jscomp/test/bs_mutable_set_test.ml\", line 304, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
   data: Belt__Belt_internalSetInt.fromArray(xs$52)
 }, {
   data: Belt__Belt_internalSetInt.fromArray(xs$53)
 }), {
   data: Belt__Belt_internalSetInt.fromArray(xs$54)
+}));
+
+const xs$55 = Array_data_util.randomRange(0, 20);
+
+const xs$56 = Array_data_util.randomRange(21, 40);
+
+const xs$57 = Array_data_util.randomRange(0, 20);
+
+b("File \"jscomp/test/bs_mutable_set_test.ml\", line 310, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
+  data: Belt__Belt_internalSetInt.fromArray(xs$55)
+}, {
+  data: Belt__Belt_internalSetInt.fromArray(xs$56)
+}), {
+  data: Belt__Belt_internalSetInt.fromArray(xs$57)
+}));
+
+const xs$58 = Array_data_util.randomRange(0, 20);
+
+const xs$59 = Array_data_util.randomRange(0, 40);
+
+const xs$60 = Array_data_util.randomRange(0, -1);
+
+b("File \"jscomp/test/bs_mutable_set_test.ml\", line 317, characters 4-11", Belt__Belt_MutableSetInt.eq(Belt__Belt_MutableSetInt.diff({
+  data: Belt__Belt_internalSetInt.fromArray(xs$58)
+}, {
+  data: Belt__Belt_internalSetInt.fromArray(xs$59)
+}), {
+  data: Belt__Belt_internalSetInt.fromArray(xs$60)
 }));
 
 Mt.from_pair_suites("Bs_mutable_set_test", suites.contents);
@@ -844,4 +856,4 @@ module.exports = {
   f,
   $eq$tilde,
 }
-/* u Not a pure module */
+/* xs Not a pure module */

--- a/jscomp/test/dist/bs_poly_map_test.js
+++ b/jscomp/test/dist/bs_poly_map_test.js
@@ -5,8 +5,8 @@ const Array_data_util = require("./array_data_util.js");
 const Belt__Belt_Array = require("melange.belt/belt_Array.js");
 const Belt__Belt_Id = require("melange.belt/belt_Id.js");
 const Belt__Belt_Map = require("melange.belt/belt_Map.js");
-const Belt__Belt_MapDict = require("melange.belt/belt_MapDict.js");
 const Belt__Belt_Set = require("melange.belt/belt_Set.js");
+const Belt__Belt_internalAVLtree = require("melange.belt/belt_internalAVLtree.js");
 const Caml = require("melange.js/caml.js");
 const Caml_option = require("melange.js/caml_option.js");
 const Mt = require("./mt.js");
@@ -51,7 +51,7 @@ function mergeInter(s1, s2) {
     }
     
   }));
-  return Belt__Belt_Set.fromArray(Belt__Belt_MapDict.keysToArray(m.data), Icmp);
+  return Belt__Belt_Set.fromArray(Belt__Belt_internalAVLtree.keysToArray(m.data), Icmp);
 }
 
 function mergeUnion(s1, s2) {
@@ -61,7 +61,7 @@ function mergeUnion(s1, s2) {
     }
     
   }));
-  return Belt__Belt_Set.fromArray(Belt__Belt_MapDict.keysToArray(m.data), Icmp);
+  return Belt__Belt_Set.fromArray(Belt__Belt_internalAVLtree.keysToArray(m.data), Icmp);
 }
 
 function mergeDiff(s1, s2) {
@@ -71,7 +71,7 @@ function mergeDiff(s1, s2) {
     }
     
   }));
-  return Belt__Belt_Set.fromArray(Belt__Belt_MapDict.keysToArray(m.data), Icmp);
+  return Belt__Belt_Set.fromArray(Belt__Belt_internalAVLtree.keysToArray(m.data), Icmp);
 }
 
 function randomRange(i, j) {
@@ -150,14 +150,16 @@ const a7 = Belt__Belt_Map.removeMany(a0, [
   6
 ]);
 
-eq("File \"jscomp/test/bs_poly_map_test.ml\", line 81, characters 5-12", Belt__Belt_MapDict.keysToArray(a7.data), [
+eq("File \"jscomp/test/bs_poly_map_test.ml\", line 81, characters 5-12", Belt__Belt_internalAVLtree.keysToArray(a7.data), [
   9,
   10
 ]);
 
 const a8 = Belt__Belt_Map.removeMany(a7, Array_data_util.randomRange(0, 100));
 
-b("File \"jscomp/test/bs_poly_map_test.ml\", line 83, characters 4-11", Belt__Belt_MapDict.isEmpty(a8.data));
+const x = a8.data;
+
+b("File \"jscomp/test/bs_poly_map_test.ml\", line 83, characters 4-11", x === undefined);
 
 const u0$1 = Belt__Belt_Map.fromArray(randomRange(0, 100), Icmp);
 
@@ -257,24 +259,28 @@ const map = Belt__Belt_Map.remove({
   data: undefined
 }, 0);
 
-b("File \"jscomp/test/bs_poly_map_test.ml\", line 129, characters 4-11", Belt__Belt_MapDict.isEmpty(map.data));
+const x$1 = map.data;
+
+b("File \"jscomp/test/bs_poly_map_test.ml\", line 129, characters 4-11", x$1 === undefined);
 
 const map$1 = Belt__Belt_Map.removeMany({
   cmp: Icmp.cmp,
   data: undefined
 }, [0]);
 
-b("File \"jscomp/test/bs_poly_map_test.ml\", line 130, characters 4-11", Belt__Belt_MapDict.isEmpty(map$1.data));
+const x$2 = map$1.data;
+
+b("File \"jscomp/test/bs_poly_map_test.ml\", line 130, characters 4-11", x$2 === undefined);
 
 b("File \"jscomp/test/bs_poly_map_test.ml\", line 131, characters 4-11", pres !== undefined ? pres === 5000 : false);
 
-b("File \"jscomp/test/bs_poly_map_test.ml\", line 132, characters 4-11", Belt__Belt_Array.eq(Belt__Belt_MapDict.keysToArray(match$1[0].data), Belt__Belt_Array.makeBy(5000, (function (i) {
+b("File \"jscomp/test/bs_poly_map_test.ml\", line 132, characters 4-11", Belt__Belt_Array.eq(Belt__Belt_internalAVLtree.keysToArray(match$1[0].data), Belt__Belt_Array.makeBy(5000, (function (i) {
   return i;
 })), (function (prim0, prim1) {
   return prim0 === prim1;
 })));
 
-b("File \"jscomp/test/bs_poly_map_test.ml\", line 133, characters 4-11", Belt__Belt_Array.eq(Belt__Belt_MapDict.keysToArray(match$1[1].data), Belt__Belt_Array.makeBy(5000, (function (i) {
+b("File \"jscomp/test/bs_poly_map_test.ml\", line 133, characters 4-11", Belt__Belt_Array.eq(Belt__Belt_internalAVLtree.keysToArray(match$1[1].data), Belt__Belt_Array.makeBy(5000, (function (i) {
   return 5001 + i | 0;
 })), (function (prim0, prim1) {
   return prim0 === prim1;
@@ -288,13 +294,13 @@ const match$6 = match$5[0];
 
 b("File \"jscomp/test/bs_poly_map_test.ml\", line 137, characters 4-11", match$5[1] === undefined);
 
-b("File \"jscomp/test/bs_poly_map_test.ml\", line 138, characters 4-11", Belt__Belt_Array.eq(Belt__Belt_MapDict.keysToArray(match$6[0].data), Belt__Belt_Array.makeBy(5000, (function (i) {
+b("File \"jscomp/test/bs_poly_map_test.ml\", line 138, characters 4-11", Belt__Belt_Array.eq(Belt__Belt_internalAVLtree.keysToArray(match$6[0].data), Belt__Belt_Array.makeBy(5000, (function (i) {
   return i;
 })), (function (prim0, prim1) {
   return prim0 === prim1;
 })));
 
-b("File \"jscomp/test/bs_poly_map_test.ml\", line 139, characters 4-11", Belt__Belt_Array.eq(Belt__Belt_MapDict.keysToArray(match$6[1].data), Belt__Belt_Array.makeBy(5000, (function (i) {
+b("File \"jscomp/test/bs_poly_map_test.ml\", line 139, characters 4-11", Belt__Belt_Array.eq(Belt__Belt_internalAVLtree.keysToArray(match$6[1].data), Belt__Belt_Array.makeBy(5000, (function (i) {
   return 5001 + i | 0;
 })), (function (prim0, prim1) {
   return prim0 === prim1;

--- a/jscomp/test/dist/bs_poly_mutable_set_test.js
+++ b/jscomp/test/dist/bs_poly_mutable_set_test.js
@@ -39,7 +39,7 @@ function empty(param) {
   };
 }
 
-const u = fromArray(Array_data_util.range(0, 30));
+const u = Belt__Belt_MutableSet.fromArray(Array_data_util.range(0, 30), IntCmp);
 
 b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 18, characters 4-11", Belt__Belt_MutableSet.removeCheck(u, 0));
 
@@ -115,7 +115,7 @@ Belt__Belt_MutableSet.removeMany(u, Array_data_util.randomRange(10000, 30000));
 
 b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 56, characters 4-11", Belt__Belt_MutableSet.isEmpty(u));
 
-const v = fromArray(Array_data_util.randomRange(1000, 2000));
+const v = Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(1000, 2000), IntCmp);
 
 const bs = Belt__Belt_Array.map(Array_data_util.randomRange(500, 1499), (function (x) {
   return Belt__Belt_MutableSet.removeCheck(v, x);
@@ -232,60 +232,60 @@ b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 94, characters 4-11", 
 
 b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 95, characters 4-11", Belt__Belt_MutableSet.isEmpty(Belt__Belt_MutableSet.intersect(aa$1, bb$1)));
 
-const aa$2 = fromArray(Array_data_util.randomRange(0, 100));
+const aa$2 = Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 100), IntCmp);
 
-const bb$2 = fromArray(Array_data_util.randomRange(40, 120));
+const bb$2 = Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(40, 120), IntCmp);
 
 const cc = Belt__Belt_MutableSet.union(aa$2, bb$2);
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 104, characters 4-11", Belt__Belt_MutableSet.eq(cc, fromArray(Array_data_util.randomRange(0, 120))));
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 104, characters 4-11", Belt__Belt_MutableSet.eq(cc, Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 120), IntCmp)));
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 106, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.union(fromArray(Array_data_util.randomRange(0, 20)), fromArray(Array_data_util.randomRange(21, 40))), fromArray(Array_data_util.randomRange(0, 40))));
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 106, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.union(Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 20), IntCmp), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(21, 40), IntCmp)), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 40), IntCmp)));
 
 const dd = Belt__Belt_MutableSet.intersect(aa$2, bb$2);
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 111, characters 4-11", Belt__Belt_MutableSet.eq(dd, fromArray(Array_data_util.randomRange(40, 100))));
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 111, characters 4-11", Belt__Belt_MutableSet.eq(dd, Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(40, 100), IntCmp)));
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 112, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.intersect(fromArray(Array_data_util.randomRange(0, 20)), fromArray(Array_data_util.randomRange(21, 40))), {
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 112, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.intersect(Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 20), IntCmp), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(21, 40), IntCmp)), {
   cmp: IntCmp.cmp,
   data: undefined
 }));
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 118, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.intersect(fromArray(Array_data_util.randomRange(21, 40)), fromArray(Array_data_util.randomRange(0, 20))), {
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 118, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.intersect(Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(21, 40), IntCmp), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 20), IntCmp)), {
   cmp: IntCmp.cmp,
   data: undefined
 }));
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 124, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.intersect(fromArray([
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 124, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.intersect(Belt__Belt_MutableSet.fromArray([
   1,
   3,
   4,
   5,
   7,
   9
-]), fromArray([
+], IntCmp), Belt__Belt_MutableSet.fromArray([
   2,
   4,
   5,
   6,
   8,
   10
-])), fromArray([
+], IntCmp)), Belt__Belt_MutableSet.fromArray([
   4,
   5
-])));
+], IntCmp)));
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 130, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(aa$2, bb$2), fromArray(Array_data_util.randomRange(0, 39))));
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 130, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(aa$2, bb$2), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 39), IntCmp)));
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 132, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(bb$2, aa$2), fromArray(Array_data_util.randomRange(101, 120))));
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 132, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(bb$2, aa$2), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(101, 120), IntCmp)));
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 134, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(fromArray(Array_data_util.randomRange(21, 40)), fromArray(Array_data_util.randomRange(0, 20))), fromArray(Array_data_util.randomRange(21, 40))));
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 134, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(21, 40), IntCmp), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 20), IntCmp)), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(21, 40), IntCmp)));
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 140, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(fromArray(Array_data_util.randomRange(0, 20)), fromArray(Array_data_util.randomRange(21, 40))), fromArray(Array_data_util.randomRange(0, 20))));
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 140, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 20), IntCmp), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(21, 40), IntCmp)), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 20), IntCmp)));
 
-b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 147, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(fromArray(Array_data_util.randomRange(0, 20)), fromArray(Array_data_util.randomRange(0, 40))), fromArray(Array_data_util.randomRange(0, -1))));
+b("File \"jscomp/test/bs_poly_mutable_set_test.ml\", line 147, characters 4-11", Belt__Belt_MutableSet.eq(Belt__Belt_MutableSet.diff(Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 20), IntCmp), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 40), IntCmp)), Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, -1), IntCmp)));
 
-const a0 = fromArray(Array_data_util.randomRange(0, 1000));
+const a0 = Belt__Belt_MutableSet.fromArray(Array_data_util.randomRange(0, 1000), IntCmp);
 
 const a1 = Belt__Belt_MutableSet.keep(a0, (function (x) {
   return x % 2 === 0;

--- a/jscomp/test/dist/bs_poly_set_test.js
+++ b/jscomp/test/dist/bs_poly_set_test.js
@@ -6,8 +6,8 @@ const Belt__Belt_Array = require("melange.belt/belt_Array.js");
 const Belt__Belt_Id = require("melange.belt/belt_Id.js");
 const Belt__Belt_List = require("melange.belt/belt_List.js");
 const Belt__Belt_Set = require("melange.belt/belt_Set.js");
-const Belt__Belt_SetDict = require("melange.belt/belt_SetDict.js");
 const Belt__Belt_SortArray = require("melange.belt/belt_SortArray.js");
+const Belt__Belt_internalAVLset = require("melange.belt/belt_internalAVLset.js");
 const Caml = require("melange.js/caml.js");
 const Caml_obj = require("melange.js/caml_obj.js");
 const Mt = require("./mt.js");
@@ -84,43 +84,51 @@ b("File \"jscomp/test/bs_poly_set_test.ml\", line 35, characters 4-11", u0 !== u
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 36, characters 4-11", u2 === u1);
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 37, characters 5-12", Belt__Belt_SetDict.size(u4.data), 28);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 37, characters 5-12", Belt__Belt_internalAVLset.size(u4.data), 28);
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 38, characters 4-11", 29 === Belt__Belt_SetDict.maxUndefined(u4.data));
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 38, characters 4-11", 29 === Belt__Belt_internalAVLset.maxUndefined(u4.data));
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 39, characters 4-11", 1 === Belt__Belt_SetDict.minUndefined(u4.data));
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 39, characters 4-11", 1 === Belt__Belt_internalAVLset.minUndefined(u4.data));
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 40, characters 4-11", u4 === u5);
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 41, characters 4-11", Belt__Belt_SetDict.isEmpty(u6.data));
+const n = u6.data;
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 42, characters 6-13", Belt__Belt_SetDict.size(u7.data), 3);
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 41, characters 4-11", n === undefined);
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 43, characters 4-11", !Belt__Belt_SetDict.isEmpty(u7.data));
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 42, characters 6-13", Belt__Belt_internalAVLset.size(u7.data), 3);
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 44, characters 4-11", Belt__Belt_SetDict.isEmpty(u8.data));
+const n$1 = u7.data;
+
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 43, characters 4-11", n$1 !== undefined);
+
+const n$2 = u8.data;
+
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 44, characters 4-11", n$2 === undefined);
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 47, characters 4-11", Belt__Belt_Set.has(u10, 20));
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 48, characters 4-11", Belt__Belt_Set.has(u10, 21));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 49, characters 5-12", Belt__Belt_SetDict.size(u10.data), 20001);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 49, characters 5-12", Belt__Belt_internalAVLset.size(u10.data), 20001);
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 50, characters 5-12", Belt__Belt_SetDict.size(u11.data), 19800);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 50, characters 5-12", Belt__Belt_internalAVLset.size(u11.data), 19800);
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 51, characters 5-12", Belt__Belt_SetDict.size(u12.data), 19000);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 51, characters 5-12", Belt__Belt_internalAVLset.size(u12.data), 19000);
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 53, characters 5-12", Belt__Belt_SetDict.size(u13.data), Belt__Belt_SetDict.size(u12.data));
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 53, characters 5-12", Belt__Belt_internalAVLset.size(u13.data), Belt__Belt_internalAVLset.size(u12.data));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 54, characters 5-12", Belt__Belt_SetDict.size(u14.data), 10000);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 54, characters 5-12", Belt__Belt_internalAVLset.size(u14.data), 10000);
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 55, characters 5-12", Belt__Belt_SetDict.size(u15.data), 1);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 55, characters 5-12", Belt__Belt_internalAVLset.size(u15.data), 1);
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 56, characters 4-11", Belt__Belt_Set.has(u15, 20000));
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 57, characters 4-11", !Belt__Belt_Set.has(u15, 2000));
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 58, characters 4-11", Belt__Belt_SetDict.isEmpty(u16.data));
+const n$3 = u16.data;
+
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 58, characters 4-11", n$3 === undefined);
 
 const u17 = Belt__Belt_Set.fromArray(Array_data_util.randomRange(0, 100), IntCmp);
 
@@ -157,17 +165,17 @@ const u29 = Belt__Belt_Set.union(u26, u27);
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 72, characters 4-11", Belt__Belt_Set.eq(u28, u29));
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 73, characters 4-11", Caml_obj.caml_equal(Belt__Belt_SetDict.toArray(u29.data), Belt__Belt_SortArray.stableSortBy(Belt__Belt_Array.concat(ss, [3]), Caml.caml_int_compare)));
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 73, characters 4-11", Caml_obj.caml_equal(Belt__Belt_internalAVLset.toArray(u29.data), Belt__Belt_SortArray.stableSortBy(Belt__Belt_Array.concat(ss, [3]), Caml.caml_int_compare)));
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 74, characters 4-11", Belt__Belt_Set.eq(u19, u20));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 75, characters 5-12", Belt__Belt_SetDict.toArray(u21.data), Array_data_util.range(59, 100));
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 75, characters 5-12", Belt__Belt_internalAVLset.toArray(u21.data), Array_data_util.range(59, 100));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 76, characters 5-12", Belt__Belt_SetDict.toArray(u22.data), Array_data_util.range(0, 58));
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 76, characters 5-12", Belt__Belt_internalAVLset.toArray(u22.data), Array_data_util.range(0, 58));
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 77, characters 4-11", Belt__Belt_Set.eq(u24, u19));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 78, characters 5-12", Belt__Belt_SetDict.toArray(u23.data), Array_data_util.range(101, 200));
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 78, characters 5-12", Belt__Belt_internalAVLset.toArray(u23.data), Array_data_util.range(101, 200));
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 79, characters 4-11", Belt__Belt_Set.subset(u23, u18));
 
@@ -185,15 +193,15 @@ b("File \"jscomp/test/bs_poly_set_test.ml\", line 85, characters 4-11", Belt__Be
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 86, characters 4-11", undefined === Belt__Belt_Set.get(u22, 59));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 88, characters 5-12", Belt__Belt_SetDict.size(u25.data), 60);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 88, characters 5-12", Belt__Belt_internalAVLset.size(u25.data), 60);
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 89, characters 4-11", Belt__Belt_SetDict.minimum(undefined) === undefined);
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 89, characters 4-11", Belt__Belt_internalAVLset.minimum(undefined) === undefined);
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 90, characters 4-11", Belt__Belt_SetDict.maximum(undefined) === undefined);
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 90, characters 4-11", Belt__Belt_internalAVLset.maximum(undefined) === undefined);
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 91, characters 4-11", Belt__Belt_SetDict.minUndefined(undefined) === undefined);
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 91, characters 4-11", Belt__Belt_internalAVLset.minUndefined(undefined) === undefined);
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 92, characters 4-11", Belt__Belt_SetDict.maxUndefined(undefined) === undefined);
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 92, characters 4-11", Belt__Belt_internalAVLset.maxUndefined(undefined) === undefined);
 
 function testIterToList(xs) {
   const v = {
@@ -212,7 +220,7 @@ function testIterToList2(xs) {
   const v = {
     contents: /* [] */ 0
   };
-  Belt__Belt_SetDict.forEach(xs.data, (function (x) {
+  Belt__Belt_internalAVLset.forEach(xs.data, (function (x) {
     v.contents = {
       hd: x,
       tl: v.contents
@@ -239,7 +247,7 @@ b("File \"jscomp/test/bs_poly_set_test.ml\", line 110, characters 4-11", Belt__B
   return x === y;
 })));
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 111, characters 4-11", Belt__Belt_List.every2(testIterToList(u0$1), Belt__Belt_SetDict.toList(u0$1.data), (function (x, y) {
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 111, characters 4-11", Belt__Belt_List.every2(testIterToList(u0$1), Belt__Belt_internalAVLset.toList(u0$1.data), (function (x, y) {
   return x === y;
 })));
 
@@ -255,7 +263,7 @@ b("File \"jscomp/test/bs_poly_set_test.ml\", line 114, characters 4-11", Belt__B
   return x < 24;
 })));
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 115, characters 4-11", Belt__Belt_SetDict.every(u0$1.data, (function (x) {
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 115, characters 4-11", Belt__Belt_internalAVLset.every(u0$1.data, (function (x) {
   return x < 24;
 })));
 
@@ -309,9 +317,11 @@ t("File \"jscomp/test/bs_poly_set_test.ml\", line 134, characters 4-11", (functi
   Belt__Belt_Set.getExn(a0, -1);
 }));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 135, characters 5-12", Belt__Belt_SetDict.size(a0.data), 1001);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 135, characters 5-12", Belt__Belt_internalAVLset.size(a0.data), 1001);
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 136, characters 4-11", !Belt__Belt_SetDict.isEmpty(a0.data));
+const n$4 = a0.data;
+
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 136, characters 4-11", n$4 !== undefined);
 
 const match$1 = Belt__Belt_Set.split(a0, 200);
 
@@ -319,11 +329,11 @@ const match$2 = match$1[0];
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 138, characters 4-11", match$1[1]);
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 139, characters 5-12", Belt__Belt_SetDict.toArray(match$2[0].data), Belt__Belt_Array.makeBy(200, (function (i) {
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 139, characters 5-12", Belt__Belt_internalAVLset.toArray(match$2[0].data), Belt__Belt_Array.makeBy(200, (function (i) {
   return i;
 })));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 140, characters 5-12", Belt__Belt_SetDict.toList(match$2[1].data), Belt__Belt_List.makeBy(800, (function (i) {
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 140, characters 5-12", Belt__Belt_internalAVLset.toList(match$2[1].data), Belt__Belt_List.makeBy(800, (function (i) {
   return i + 201 | 0;
 })));
 
@@ -339,17 +349,17 @@ const a8 = match$4[0];
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 143, characters 4-11", !match$3[1]);
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 144, characters 5-12", Belt__Belt_SetDict.toArray(a8.data), Belt__Belt_Array.makeBy(200, (function (i) {
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 144, characters 5-12", Belt__Belt_internalAVLset.toArray(a8.data), Belt__Belt_Array.makeBy(200, (function (i) {
   return i;
 })));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 145, characters 5-12", Belt__Belt_SetDict.toList(a9.data), Belt__Belt_List.makeBy(800, (function (i) {
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 145, characters 5-12", Belt__Belt_internalAVLset.toList(a9.data), Belt__Belt_List.makeBy(800, (function (i) {
   return i + 201 | 0;
 })));
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 146, characters 5-12", Belt__Belt_SetDict.minimum(a8.data), 0);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 146, characters 5-12", Belt__Belt_internalAVLset.minimum(a8.data), 0);
 
-eq("File \"jscomp/test/bs_poly_set_test.ml\", line 147, characters 5-12", Belt__Belt_SetDict.minimum(a9.data), 201);
+eq("File \"jscomp/test/bs_poly_set_test.ml\", line 147, characters 5-12", Belt__Belt_internalAVLset.minimum(a9.data), 201);
 
 Belt__Belt_List.forEach({
   hd: a0,
@@ -367,7 +377,7 @@ Belt__Belt_List.forEach({
     }
   }
 }, (function (x) {
-  Belt__Belt_SetDict.checkInvariantInternal(x.data);
+  Belt__Belt_internalAVLset.checkInvariantInternal(x.data);
 }));
 
 const a = Belt__Belt_Set.fromArray([], IntCmp);
@@ -376,7 +386,9 @@ const m = Belt__Belt_Set.keep(a, (function (x) {
   return x % 2 === 0;
 }));
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 153, characters 4-11", Belt__Belt_SetDict.isEmpty(m.data));
+const n$5 = m.data;
+
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 153, characters 4-11", n$5 === undefined);
 
 const match$5 = Belt__Belt_Set.split({
   cmp: IntCmp.cmp,
@@ -385,9 +397,13 @@ const match$5 = Belt__Belt_Set.split({
 
 const match$6 = match$5[0];
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 157, characters 4-11", Belt__Belt_SetDict.isEmpty(match$6[0].data));
+const n$6 = match$6[0].data;
 
-b("File \"jscomp/test/bs_poly_set_test.ml\", line 158, characters 4-11", Belt__Belt_SetDict.isEmpty(match$6[1].data));
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 157, characters 4-11", n$6 === undefined);
+
+const n$7 = match$6[1].data;
+
+b("File \"jscomp/test/bs_poly_set_test.ml\", line 158, characters 4-11", n$7 === undefined);
 
 b("File \"jscomp/test/bs_poly_set_test.ml\", line 159, characters 4-11", !match$5[1]);
 

--- a/jscomp/test/dist/bs_set_bench.js
+++ b/jscomp/test/dist/bs_set_bench.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const Belt__Belt_SetInt = require("melange.belt/belt_SetInt.js");
+const Belt__Belt_internalAVLset = require("melange.belt/belt_internalAVLset.js");
+const Belt__Belt_internalSetInt = require("melange.belt/belt_internalSetInt.js");
 const Caml_js_exceptions = require("melange.js/caml_js_exceptions.js");
 
 function bench(param) {
@@ -13,7 +15,7 @@ function bench(param) {
   console.timeEnd("bs_set_bench.ml 7");
   console.time("bs_set_bench.ml 11");
   for (let i$1 = 0; i$1 <= 1000000; ++i$1) {
-    if (!Belt__Belt_SetInt.has(data, i$1)) {
+    if (!Belt__Belt_internalSetInt.has(data, i$1)) {
       throw new Caml_js_exceptions.MelangeError("Assert_failure", {
           MEL_EXN_ID: "Assert_failure",
           _1: [
@@ -31,7 +33,7 @@ function bench(param) {
     data = Belt__Belt_SetInt.remove(data, i$2);
   }
   console.timeEnd("bs_set_bench.ml 14");
-  if (Belt__Belt_SetInt.size(data) === 0) {
+  if (Belt__Belt_internalAVLset.size(data) === 0) {
     return;
   }
   throw new Caml_js_exceptions.MelangeError("Assert_failure", {

--- a/jscomp/test/dist/bs_set_int_test.js
+++ b/jscomp/test/dist/bs_set_int_test.js
@@ -4,6 +4,8 @@
 const Array_data_util = require("./array_data_util.js");
 const Belt__Belt_Array = require("melange.belt/belt_Array.js");
 const Belt__Belt_SetInt = require("melange.belt/belt_SetInt.js");
+const Belt__Belt_internalAVLset = require("melange.belt/belt_internalAVLset.js");
+const Belt__Belt_internalSetInt = require("melange.belt/belt_internalSetInt.js");
 const Mt = require("./mt.js");
 const Stdlib__Array = require("melange/array.js");
 const Stdlib__List = require("melange/list.js");
@@ -25,11 +27,11 @@ function b(loc, v) {
 }
 
 function $eq$tilde(s, i) {
-  return Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray(i), s);
+  return Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray(i), s);
 }
 
 function $eq$star(a, b) {
-  return Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray(a), Belt__Belt_SetInt.fromArray(b));
+  return Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray(a), Belt__Belt_internalSetInt.fromArray(b));
 }
 
 b("File \"jscomp/test/bs_set_int_test.ml\", line 17, characters 4-11", $eq$star([
@@ -42,17 +44,17 @@ b("File \"jscomp/test/bs_set_int_test.ml\", line 17, characters 4-11", $eq$star(
   1
 ]));
 
-const u = Belt__Belt_SetInt.intersect(Belt__Belt_SetInt.fromArray([
+const u = Belt__Belt_SetInt.intersect(Belt__Belt_internalSetInt.fromArray([
   1,
   2,
   3
-]), Belt__Belt_SetInt.fromArray([
+]), Belt__Belt_internalSetInt.fromArray([
   3,
   4,
   5
 ]));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 23, characters 4-11", Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray([3]), u));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 23, characters 4-11", Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray([3]), u));
 
 function range(i, j) {
   return Stdlib__Array.init((j - i | 0) + 1 | 0, (function (k) {
@@ -66,13 +68,13 @@ function revRange(i, j) {
   })))));
 }
 
-const v = Belt__Belt_SetInt.fromArray(Stdlib__Array.append(range(100, 1000), revRange(400, 1500)));
+const v = Belt__Belt_internalSetInt.fromArray(Stdlib__Array.append(range(100, 1000), revRange(400, 1500)));
 
 const i = range(100, 1500);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 36, characters 4-11", Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray(i), v));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 36, characters 4-11", Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray(i), v));
 
-const match = Belt__Belt_SetInt.partition(v, (function (x) {
+const match = Belt__Belt_internalAVLset.partitionShared(v, (function (x) {
   return x % 3 === 0;
 }));
 
@@ -92,45 +94,45 @@ const nl = l;
 
 const nr = r;
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 47, characters 4-11", Belt__Belt_SetInt.eq(match[0], nl));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 47, characters 4-11", Belt__Belt_internalSetInt.eq(match[0], nl));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 48, characters 4-11", Belt__Belt_SetInt.eq(match[1], nr));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 48, characters 4-11", Belt__Belt_internalSetInt.eq(match[1], nr));
 
 const i$2 = range(50, 100);
 
-const s = Belt__Belt_SetInt.intersect(Belt__Belt_SetInt.fromArray(range(1, 100)), Belt__Belt_SetInt.fromArray(range(50, 200)));
+const s = Belt__Belt_SetInt.intersect(Belt__Belt_internalSetInt.fromArray(range(1, 100)), Belt__Belt_internalSetInt.fromArray(range(50, 200)));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 51, characters 4-11", Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray(i$2), s));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 51, characters 4-11", Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray(i$2), s));
 
 const i$3 = range(1, 200);
 
-const s$1 = Belt__Belt_SetInt.union(Belt__Belt_SetInt.fromArray(range(1, 100)), Belt__Belt_SetInt.fromArray(range(50, 200)));
+const s$1 = Belt__Belt_SetInt.union(Belt__Belt_internalSetInt.fromArray(range(1, 100)), Belt__Belt_internalSetInt.fromArray(range(50, 200)));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 54, characters 4-11", Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray(i$3), s$1));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 54, characters 4-11", Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray(i$3), s$1));
 
 const i$4 = range(1, 49);
 
-const s$2 = Belt__Belt_SetInt.diff(Belt__Belt_SetInt.fromArray(range(1, 100)), Belt__Belt_SetInt.fromArray(range(50, 200)));
+const s$2 = Belt__Belt_SetInt.diff(Belt__Belt_internalSetInt.fromArray(range(1, 100)), Belt__Belt_internalSetInt.fromArray(range(50, 200)));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 57, characters 6-13", Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray(i$4), s$2));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 57, characters 6-13", Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray(i$4), s$2));
 
 const i$5 = revRange(50, 100);
 
-const s$3 = Belt__Belt_SetInt.intersect(Belt__Belt_SetInt.fromArray(revRange(1, 100)), Belt__Belt_SetInt.fromArray(revRange(50, 200)));
+const s$3 = Belt__Belt_SetInt.intersect(Belt__Belt_internalSetInt.fromArray(revRange(1, 100)), Belt__Belt_internalSetInt.fromArray(revRange(50, 200)));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 60, characters 4-11", Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray(i$5), s$3));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 60, characters 4-11", Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray(i$5), s$3));
 
 const i$6 = revRange(1, 200);
 
-const s$4 = Belt__Belt_SetInt.union(Belt__Belt_SetInt.fromArray(revRange(1, 100)), Belt__Belt_SetInt.fromArray(revRange(50, 200)));
+const s$4 = Belt__Belt_SetInt.union(Belt__Belt_internalSetInt.fromArray(revRange(1, 100)), Belt__Belt_internalSetInt.fromArray(revRange(50, 200)));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 63, characters 4-11", Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray(i$6), s$4));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 63, characters 4-11", Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray(i$6), s$4));
 
 const i$7 = revRange(1, 49);
 
-const s$5 = Belt__Belt_SetInt.diff(Belt__Belt_SetInt.fromArray(revRange(1, 100)), Belt__Belt_SetInt.fromArray(revRange(50, 200)));
+const s$5 = Belt__Belt_SetInt.diff(Belt__Belt_internalSetInt.fromArray(revRange(1, 100)), Belt__Belt_internalSetInt.fromArray(revRange(50, 200)));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 66, characters 6-13", Belt__Belt_SetInt.eq(Belt__Belt_SetInt.fromArray(i$7), s$5));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 66, characters 6-13", Belt__Belt_internalSetInt.eq(Belt__Belt_internalSetInt.fromArray(i$7), s$5));
 
 const ss = [
   1,
@@ -143,7 +145,7 @@ const ss = [
   -1
 ];
 
-const v$1 = Belt__Belt_SetInt.fromArray([
+const v$1 = Belt__Belt_internalSetInt.fromArray([
   1,
   222,
   3,
@@ -154,15 +156,15 @@ const v$1 = Belt__Belt_SetInt.fromArray([
   -1
 ]);
 
-const minv = Belt__Belt_SetInt.minUndefined(v$1);
+const minv = Belt__Belt_internalAVLset.minUndefined(v$1);
 
-const maxv = Belt__Belt_SetInt.maxUndefined(v$1);
+const maxv = Belt__Belt_internalAVLset.maxUndefined(v$1);
 
 function approx(loc, x, y) {
   b(loc, x === y);
 }
 
-eq("File \"jscomp/test/bs_set_int_test.ml\", line 74, characters 5-12", Belt__Belt_SetInt.reduce(v$1, 0, (function (x, y) {
+eq("File \"jscomp/test/bs_set_int_test.ml\", line 74, characters 5-12", Belt__Belt_internalAVLset.reduce(v$1, 0, (function (x, y) {
   return x + y | 0;
 })), Belt__Belt_Array.reduce(ss, 0, (function (prim0, prim1) {
   return prim0 + prim1 | 0;
@@ -174,9 +176,9 @@ approx("File \"jscomp/test/bs_set_int_test.ml\", line 76, characters 9-16", 222,
 
 const v$2 = Belt__Belt_SetInt.remove(v$1, 3);
 
-const minv$1 = Belt__Belt_SetInt.minimum(v$2);
+const minv$1 = Belt__Belt_internalAVLset.minimum(v$2);
 
-const maxv$1 = Belt__Belt_SetInt.maximum(v$2);
+const maxv$1 = Belt__Belt_internalAVLset.maximum(v$2);
 
 eq("File \"jscomp/test/bs_set_int_test.ml\", line 79, characters 5-12", minv$1, -1);
 
@@ -184,9 +186,9 @@ eq("File \"jscomp/test/bs_set_int_test.ml\", line 80, characters 5-12", maxv$1, 
 
 const v$3 = Belt__Belt_SetInt.remove(v$2, 222);
 
-const minv$2 = Belt__Belt_SetInt.minimum(v$3);
+const minv$2 = Belt__Belt_internalAVLset.minimum(v$3);
 
-const maxv$2 = Belt__Belt_SetInt.maximum(v$3);
+const maxv$2 = Belt__Belt_internalAVLset.maximum(v$3);
 
 eq("File \"jscomp/test/bs_set_int_test.ml\", line 83, characters 5-12", minv$2, -1);
 
@@ -194,9 +196,9 @@ eq("File \"jscomp/test/bs_set_int_test.ml\", line 84, characters 5-12", maxv$2, 
 
 const v$4 = Belt__Belt_SetInt.remove(v$3, -1);
 
-const minv$3 = Belt__Belt_SetInt.minimum(v$4);
+const minv$3 = Belt__Belt_internalAVLset.minimum(v$4);
 
-const maxv$3 = Belt__Belt_SetInt.maximum(v$4);
+const maxv$3 = Belt__Belt_internalAVLset.maximum(v$4);
 
 eq("File \"jscomp/test/bs_set_int_test.ml\", line 87, characters 5-12", minv$3, 0);
 
@@ -214,47 +216,47 @@ const v$9 = Belt__Belt_SetInt.remove(v$8, 4);
 
 const v$10 = Belt__Belt_SetInt.remove(v$9, 1);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 95, characters 4-11", Belt__Belt_SetInt.isEmpty(v$10));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 95, characters 4-11", v$10 === undefined);
 
 const v$11 = Belt__Belt_Array.makeByAndShuffle(1000000, (function (i) {
   return i;
 }));
 
-const u$1 = Belt__Belt_SetInt.fromArray(v$11);
+const u$1 = Belt__Belt_internalSetInt.fromArray(v$11);
 
-Belt__Belt_SetInt.checkInvariantInternal(u$1);
+Belt__Belt_internalAVLset.checkInvariantInternal(u$1);
 
 const firstHalf = Belt__Belt_Array.slice(v$11, 0, 2000);
 
 const xx = Belt__Belt_Array.reduce(firstHalf, u$1, Belt__Belt_SetInt.remove);
 
-Belt__Belt_SetInt.checkInvariantInternal(u$1);
+Belt__Belt_internalAVLset.checkInvariantInternal(u$1);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 106, characters 4-11", Belt__Belt_SetInt.eq(Belt__Belt_SetInt.union(Belt__Belt_SetInt.fromArray(firstHalf), xx), u$1));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 106, characters 4-11", Belt__Belt_internalSetInt.eq(Belt__Belt_SetInt.union(Belt__Belt_internalSetInt.fromArray(firstHalf), xx), u$1));
 
-const aa = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(0, 100));
+const aa = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(0, 100));
 
-const bb = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(0, 200));
+const bb = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(0, 200));
 
-const cc = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(120, 200));
+const cc = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(120, 200));
 
 const dd = Belt__Belt_SetInt.union(aa, cc);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 113, characters 4-11", Belt__Belt_SetInt.subset(aa, bb));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 113, characters 4-11", Belt__Belt_internalSetInt.subset(aa, bb));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 114, characters 4-11", Belt__Belt_SetInt.subset(dd, bb));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 114, characters 4-11", Belt__Belt_internalSetInt.subset(dd, bb));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 115, characters 4-11", Belt__Belt_SetInt.subset(Belt__Belt_SetInt.add(dd, 200), bb));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 115, characters 4-11", Belt__Belt_internalSetInt.subset(Belt__Belt_SetInt.add(dd, 200), bb));
 
 b("File \"jscomp/test/bs_set_int_test.ml\", line 116, characters 4-11", Belt__Belt_SetInt.add(dd, 200) === dd);
 
 b("File \"jscomp/test/bs_set_int_test.ml\", line 117, characters 4-11", Belt__Belt_SetInt.add(dd, 0) === dd);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 118, characters 4-11", !Belt__Belt_SetInt.subset(Belt__Belt_SetInt.add(dd, 201), bb));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 118, characters 4-11", !Belt__Belt_internalSetInt.subset(Belt__Belt_SetInt.add(dd, 201), bb));
 
-const aa$1 = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(0, 100));
+const aa$1 = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(0, 100));
 
-const bb$1 = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(0, 100));
+const bb$1 = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(0, 100));
 
 const cc$1 = Belt__Belt_SetInt.add(bb$1, 101);
 
@@ -262,19 +264,19 @@ const dd$1 = Belt__Belt_SetInt.remove(bb$1, 99);
 
 const ee = Belt__Belt_SetInt.add(dd$1, 101);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 127, characters 4-11", Belt__Belt_SetInt.eq(aa$1, bb$1));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 127, characters 4-11", Belt__Belt_internalSetInt.eq(aa$1, bb$1));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 128, characters 4-11", !Belt__Belt_SetInt.eq(aa$1, cc$1));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 128, characters 4-11", !Belt__Belt_internalSetInt.eq(aa$1, cc$1));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 129, characters 4-11", !Belt__Belt_SetInt.eq(dd$1, cc$1));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 129, characters 4-11", !Belt__Belt_internalSetInt.eq(dd$1, cc$1));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 130, characters 4-11", !Belt__Belt_SetInt.eq(bb$1, ee));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 130, characters 4-11", !Belt__Belt_internalSetInt.eq(bb$1, ee));
 
 const a1 = Belt__Belt_SetInt.mergeMany(undefined, Array_data_util.randomRange(0, 100));
 
 const a2 = Belt__Belt_SetInt.removeMany(a1, Array_data_util.randomRange(40, 100));
 
-const a3 = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(0, 39));
+const a3 = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(0, 39));
 
 const match$1 = Belt__Belt_SetInt.split(a1, 40);
 
@@ -284,17 +286,17 @@ const a5 = match$2[1];
 
 const a4 = match$2[0];
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 138, characters 4-11", Belt__Belt_SetInt.eq(a1, Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(0, 100))));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 138, characters 4-11", Belt__Belt_internalSetInt.eq(a1, Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(0, 100))));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 139, characters 4-11", Belt__Belt_SetInt.eq(a2, a3));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 139, characters 4-11", Belt__Belt_internalSetInt.eq(a2, a3));
 
 b("File \"jscomp/test/bs_set_int_test.ml\", line 140, characters 4-11", match$1[1]);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 141, characters 4-11", Belt__Belt_SetInt.eq(a3, a4));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 141, characters 4-11", Belt__Belt_internalSetInt.eq(a3, a4));
 
 const a6 = Belt__Belt_SetInt.remove(Belt__Belt_SetInt.removeMany(a1, Array_data_util.randomRange(0, 39)), 40);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 143, characters 4-11", Belt__Belt_SetInt.eq(a5, a6));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 143, characters 4-11", Belt__Belt_internalSetInt.eq(a5, a6));
 
 const a7 = Belt__Belt_SetInt.remove(a1, 40);
 
@@ -306,35 +308,35 @@ const a9 = match$4[1];
 
 b("File \"jscomp/test/bs_set_int_test.ml\", line 146, characters 4-11", !match$3[1]);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 147, characters 4-11", Belt__Belt_SetInt.eq(a4, match$4[0]));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 147, characters 4-11", Belt__Belt_internalSetInt.eq(a4, match$4[0]));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 148, characters 4-11", Belt__Belt_SetInt.eq(a5, a9));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 148, characters 4-11", Belt__Belt_internalSetInt.eq(a5, a9));
 
 const a10 = Belt__Belt_SetInt.removeMany(a9, Array_data_util.randomRange(42, 2000));
 
-eq("File \"jscomp/test/bs_set_int_test.ml\", line 150, characters 5-12", Belt__Belt_SetInt.size(a10), 1);
+eq("File \"jscomp/test/bs_set_int_test.ml\", line 150, characters 5-12", Belt__Belt_internalAVLset.size(a10), 1);
 
 const a11 = Belt__Belt_SetInt.removeMany(a9, Array_data_util.randomRange(0, 2000));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 152, characters 4-11", Belt__Belt_SetInt.isEmpty(a11));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 152, characters 4-11", a11 === undefined);
 
 const match$5 = Belt__Belt_SetInt.split(undefined, 0);
 
 const match$6 = match$5[0];
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 156, characters 4-11", Belt__Belt_SetInt.isEmpty(match$6[0]));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 156, characters 4-11", match$6[0] === undefined);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 157, characters 4-11", Belt__Belt_SetInt.isEmpty(match$6[1]));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 157, characters 4-11", match$6[1] === undefined);
 
 b("File \"jscomp/test/bs_set_int_test.ml\", line 158, characters 4-11", !match$5[1]);
 
-const v$12 = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(0, 2000));
+const v$12 = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(0, 2000));
 
-const v0 = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(0, 2000));
+const v0 = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(0, 2000));
 
-const v1 = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(1, 2001));
+const v1 = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(1, 2001));
 
-const v2 = Belt__Belt_SetInt.fromArray(Array_data_util.randomRange(3, 2002));
+const v2 = Belt__Belt_internalSetInt.fromArray(Array_data_util.randomRange(3, 2002));
 
 const v3 = Belt__Belt_SetInt.removeMany(v2, [
   2002,
@@ -342,7 +344,7 @@ const v3 = Belt__Belt_SetInt.removeMany(v2, [
 ]);
 
 const us = Belt__Belt_Array.map(Array_data_util.randomRange(1000, 3000), (function (x) {
-  return Belt__Belt_SetInt.has(v$12, x);
+  return Belt__Belt_internalSetInt.has(v$12, x);
 }));
 
 const counted = Belt__Belt_Array.reduce(us, 0, (function (acc, x) {
@@ -355,21 +357,21 @@ const counted = Belt__Belt_Array.reduce(us, 0, (function (acc, x) {
 
 eq("File \"jscomp/test/bs_set_int_test.ml\", line 168, characters 5-12", counted, 1001);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 169, characters 4-11", Belt__Belt_SetInt.eq(v$12, v0));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 169, characters 4-11", Belt__Belt_internalSetInt.eq(v$12, v0));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 170, characters 4-11", Belt__Belt_SetInt.cmp(v$12, v0) === 0);
+b("File \"jscomp/test/bs_set_int_test.ml\", line 170, characters 4-11", Belt__Belt_internalSetInt.cmp(v$12, v0) === 0);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 171, characters 4-11", Belt__Belt_SetInt.cmp(v$12, v1) < 0);
+b("File \"jscomp/test/bs_set_int_test.ml\", line 171, characters 4-11", Belt__Belt_internalSetInt.cmp(v$12, v1) < 0);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 172, characters 4-11", Belt__Belt_SetInt.cmp(v$12, v2) > 0);
+b("File \"jscomp/test/bs_set_int_test.ml\", line 172, characters 4-11", Belt__Belt_internalSetInt.cmp(v$12, v2) > 0);
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 173, characters 4-11", Belt__Belt_SetInt.subset(v3, v0));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 173, characters 4-11", Belt__Belt_internalSetInt.subset(v3, v0));
 
-b("File \"jscomp/test/bs_set_int_test.ml\", line 174, characters 4-11", !Belt__Belt_SetInt.subset(v1, v0));
+b("File \"jscomp/test/bs_set_int_test.ml\", line 174, characters 4-11", !Belt__Belt_internalSetInt.subset(v1, v0));
 
-eq("File \"jscomp/test/bs_set_int_test.ml\", line 175, characters 5-12", Belt__Belt_SetInt.get(v$12, 30), 30);
+eq("File \"jscomp/test/bs_set_int_test.ml\", line 175, characters 5-12", Belt__Belt_internalSetInt.get(v$12, 30), 30);
 
-eq("File \"jscomp/test/bs_set_int_test.ml\", line 176, characters 5-12", Belt__Belt_SetInt.get(v$12, 3000), undefined);
+eq("File \"jscomp/test/bs_set_int_test.ml\", line 176, characters 5-12", Belt__Belt_internalSetInt.get(v$12, 3000), undefined);
 
 Mt.from_pair_suites("Bs_set_int_test", suites.contents);
 

--- a/jscomp/test/dist/ext_string_test.js
+++ b/jscomp/test/dist/ext_string_test.js
@@ -238,7 +238,7 @@ function repeat(n, s) {
   const len = s.length;
   const res = Caml_bytes.caml_create_bytes(Math.imul(n, len));
   for (let i = 0; i < n; ++i) {
-    Stdlib__String.blit(s, 0, res, Math.imul(i, len), len);
+    Stdlib__Bytes.blit_string(s, 0, res, Math.imul(i, len), len);
   }
   return Stdlib__Bytes.to_string(res);
 }

--- a/jscomp/test/dist/gpr_1423_app_test.js
+++ b/jscomp/test/dist/gpr_1423_app_test.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const Curry = require("melange.js/curry.js");
-const Gpr_1423_nav = require("./gpr_1423_nav.js");
 const Mt = require("./mt.js");
 
 const suites = {
@@ -36,7 +35,7 @@ function foo(f) {
 
 foo(function (param) {
   return function (param$1) {
-    return Gpr_1423_nav.busted(param, "a2", param$1);
+    return param + "a2";
   };
 });
 

--- a/jscomp/test/dist/imm_map_bench.js
+++ b/jscomp/test/dist/imm_map_bench.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const Belt__Belt_Array = require("melange.belt/belt_Array.js");
-const Belt__Belt_MapInt = require("melange.belt/belt_MapInt.js");
+const Belt__Belt_internalMapInt = require("melange.belt/belt_internalMapInt.js");
 const Caml_js_exceptions = require("melange.js/caml_js_exceptions.js");
 const Js__Js_exn = require("melange.js/js_exn.js");
 const Immutable = require("immutable");
@@ -40,9 +40,9 @@ function test(param) {
 }
 
 function test2(param) {
-  const v = Belt__Belt_MapInt.fromArray(shuffledDataAdd);
+  const v = Belt__Belt_internalMapInt.fromArray(shuffledDataAdd);
   for (let j = 0; j <= 1000000; ++j) {
-    should(Belt__Belt_MapInt.has(v, j));
+    should(Belt__Belt_internalMapInt.has(v, j));
   }
 }
 

--- a/jscomp/test/dist/libqueue_test.js
+++ b/jscomp/test/dist/libqueue_test.js
@@ -1317,4 +1317,4 @@ module.exports = {
   Q,
   does_raise,
 }
-/* q Not a pure module */
+/*  Not a pure module */

--- a/jscomp/test/dist/qcc.js
+++ b/jscomp/test/dist/qcc.js
@@ -1733,10 +1733,10 @@ function elfgen(outf) {
   symitr(patchloc);
   const strtab = opos.contents;
   opos.contents = opos.contents + 1 | 0;
-  Stdlib__String.blit("/lib64/ld-linux-x86-64.so.2\0libc.so.6", 0, obuf, opos.contents, 37);
+  Stdlib__Bytes.blit_string("/lib64/ld-linux-x86-64.so.2\0libc.so.6", 0, obuf, opos.contents, 37);
   opos.contents = (opos.contents + 37 | 0) + 1 | 0;
   itr(function (s, sl, param) {
-    Stdlib__String.blit(s, 0, obuf, opos.contents, sl);
+    Stdlib__Bytes.blit_string(s, 0, obuf, opos.contents, sl);
     opos.contents = (opos.contents + sl | 0) + 1 | 0;
   });
   opos.contents = opos.contents + 7 & -8;

--- a/jscomp/test/dist/stack_comp_test.js
+++ b/jscomp/test/dist/stack_comp_test.js
@@ -364,10 +364,12 @@ const i$7 = {
   contents: 1
 };
 
-Stdlib__List.iter((function (j) {
+function f(j) {
   assert_("File \"jscomp/test/stack_comp_test.ml\", line 112, characters 27-34", i$7.contents === j);
   i$7.contents = i$7.contents + 1 | 0;
-}), s$5.c);
+}
+
+Stdlib__List.iter(f, s$5.c);
 
 const s1$1 = {
   c: /* [] */ 0,
@@ -457,4 +459,4 @@ module.exports = {
   S,
   does_raise,
 }
-/* s Not a pure module */
+/*  Not a pure module */

--- a/jscomp/test/dist/string_set_test.js
+++ b/jscomp/test/dist/string_set_test.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const Mt = require("./mt.js");
+const Set_gen = require("./set_gen.js");
 const String_set = require("./string_set.js");
 
 const suites = {
@@ -35,7 +36,7 @@ for (let i = 0; i <= 99999; ++i) {
   s = String_set.add(String(i), s);
 }
 
-eq("File \"jscomp/test/string_set_test.ml\", line 16, characters 5-12", String_set.cardinal(s), 100000);
+eq("File \"jscomp/test/string_set_test.ml\", line 16, characters 5-12", Set_gen.cardinal(s), 100000);
 
 Mt.from_pair_suites("String_set_test", suites.contents);
 

--- a/node_modules/melange.belt/belt_Map.js
+++ b/node_modules/melange.belt/belt_Map.js
@@ -2,13 +2,14 @@
 'use strict';
 
 const Belt__Belt_MapDict = require("./belt_MapDict.js");
+const Belt__Belt_internalAVLtree = require("./belt_internalAVLtree.js");
 const Curry = require("melange.js/curry.js");
 
 function fromArray(data, id) {
   const cmp = id.cmp;
   return {
     cmp: cmp,
-    data: Belt__Belt_MapDict.fromArray(data, cmp)
+    data: Belt__Belt_internalAVLtree.fromArray(data, cmp)
   };
 }
 
@@ -102,27 +103,27 @@ function make(id) {
 }
 
 function isEmpty(map) {
-  return Belt__Belt_MapDict.isEmpty(map.data);
+  return Belt__Belt_internalAVLtree.isEmpty(map.data);
 }
 
 function findFirstByU(m, f) {
-  return Belt__Belt_MapDict.findFirstByU(m.data, f);
+  return Belt__Belt_internalAVLtree.findFirstByU(m.data, f);
 }
 
 function findFirstBy(m, f) {
-  return Belt__Belt_MapDict.findFirstByU(m.data, Curry.__2(f));
+  return Belt__Belt_internalAVLtree.findFirstByU(m.data, Curry.__2(f));
 }
 
 function forEachU(m, f) {
-  Belt__Belt_MapDict.forEachU(m.data, f);
+  Belt__Belt_internalAVLtree.forEachU(m.data, f);
 }
 
 function forEach(m, f) {
-  Belt__Belt_MapDict.forEachU(m.data, Curry.__2(f));
+  Belt__Belt_internalAVLtree.forEachU(m.data, Curry.__2(f));
 }
 
 function reduceU(m, acc, f) {
-  return Belt__Belt_MapDict.reduceU(m.data, acc, f);
+  return Belt__Belt_internalAVLtree.reduceU(m.data, acc, f);
 }
 
 function reduce(m, acc, f) {
@@ -130,25 +131,25 @@ function reduce(m, acc, f) {
 }
 
 function everyU(m, f) {
-  return Belt__Belt_MapDict.everyU(m.data, f);
+  return Belt__Belt_internalAVLtree.everyU(m.data, f);
 }
 
 function every(m, f) {
-  return Belt__Belt_MapDict.everyU(m.data, Curry.__2(f));
+  return Belt__Belt_internalAVLtree.everyU(m.data, Curry.__2(f));
 }
 
 function someU(m, f) {
-  return Belt__Belt_MapDict.someU(m.data, f);
+  return Belt__Belt_internalAVLtree.someU(m.data, f);
 }
 
 function some(m, f) {
-  return Belt__Belt_MapDict.someU(m.data, Curry.__2(f));
+  return Belt__Belt_internalAVLtree.someU(m.data, Curry.__2(f));
 }
 
 function keepU(m, f) {
   return {
     cmp: m.cmp,
-    data: Belt__Belt_MapDict.keepU(m.data, f)
+    data: Belt__Belt_internalAVLtree.keepSharedU(m.data, f)
   };
 }
 
@@ -158,7 +159,7 @@ function keep(m, f) {
 
 function partitionU(m, p) {
   const cmp = m.cmp;
-  const match = Belt__Belt_MapDict.partitionU(m.data, p);
+  const match = Belt__Belt_internalAVLtree.partitionSharedU(m.data, p);
   return [
     {
       cmp: cmp,
@@ -178,7 +179,7 @@ function partition(m, p) {
 function mapU(m, f) {
   return {
     cmp: m.cmp,
-    data: Belt__Belt_MapDict.mapU(m.data, f)
+    data: Belt__Belt_internalAVLtree.mapU(m.data, f)
   };
 }
 
@@ -189,7 +190,7 @@ function map(m, f) {
 function mapWithKeyU(m, f) {
   return {
     cmp: m.cmp,
-    data: Belt__Belt_MapDict.mapWithKeyU(m.data, f)
+    data: Belt__Belt_internalAVLtree.mapWithKeyU(m.data, f)
   };
 }
 
@@ -198,83 +199,83 @@ function mapWithKey(m, f) {
 }
 
 function size(map) {
-  return Belt__Belt_MapDict.size(map.data);
+  return Belt__Belt_internalAVLtree.size(map.data);
 }
 
 function toList(map) {
-  return Belt__Belt_MapDict.toList(map.data);
+  return Belt__Belt_internalAVLtree.toList(map.data);
 }
 
 function toArray(m) {
-  return Belt__Belt_MapDict.toArray(m.data);
+  return Belt__Belt_internalAVLtree.toArray(m.data);
 }
 
 function keysToArray(m) {
-  return Belt__Belt_MapDict.keysToArray(m.data);
+  return Belt__Belt_internalAVLtree.keysToArray(m.data);
 }
 
 function valuesToArray(m) {
-  return Belt__Belt_MapDict.valuesToArray(m.data);
+  return Belt__Belt_internalAVLtree.valuesToArray(m.data);
 }
 
 function minKey(m) {
-  return Belt__Belt_MapDict.minKey(m.data);
+  return Belt__Belt_internalAVLtree.minKey(m.data);
 }
 
 function minKeyUndefined(m) {
-  return Belt__Belt_MapDict.minKeyUndefined(m.data);
+  return Belt__Belt_internalAVLtree.minKeyUndefined(m.data);
 }
 
 function maxKey(m) {
-  return Belt__Belt_MapDict.maxKey(m.data);
+  return Belt__Belt_internalAVLtree.maxKey(m.data);
 }
 
 function maxKeyUndefined(m) {
-  return Belt__Belt_MapDict.maxKeyUndefined(m.data);
+  return Belt__Belt_internalAVLtree.maxKeyUndefined(m.data);
 }
 
 function minimum(m) {
-  return Belt__Belt_MapDict.minimum(m.data);
+  return Belt__Belt_internalAVLtree.minimum(m.data);
 }
 
 function minUndefined(m) {
-  return Belt__Belt_MapDict.minUndefined(m.data);
+  return Belt__Belt_internalAVLtree.minUndefined(m.data);
 }
 
 function maximum(m) {
-  return Belt__Belt_MapDict.maximum(m.data);
+  return Belt__Belt_internalAVLtree.maximum(m.data);
 }
 
 function maxUndefined(m) {
-  return Belt__Belt_MapDict.maxUndefined(m.data);
+  return Belt__Belt_internalAVLtree.maxUndefined(m.data);
 }
 
 function get(map, x) {
-  return Belt__Belt_MapDict.get(map.data, x, map.cmp);
+  return Belt__Belt_internalAVLtree.get(map.data, x, map.cmp);
 }
 
 function getUndefined(map, x) {
-  return Belt__Belt_MapDict.getUndefined(map.data, x, map.cmp);
+  return Belt__Belt_internalAVLtree.getUndefined(map.data, x, map.cmp);
 }
 
 function getWithDefault(map, x, def) {
-  return Belt__Belt_MapDict.getWithDefault(map.data, x, def, map.cmp);
+  return Belt__Belt_internalAVLtree.getWithDefault(map.data, x, def, map.cmp);
 }
 
 function getExn(map, x) {
-  return Belt__Belt_MapDict.getExn(map.data, x, map.cmp);
+  return Belt__Belt_internalAVLtree.getExn(map.data, x, map.cmp);
 }
 
 function has(map, x) {
-  return Belt__Belt_MapDict.has(map.data, x, map.cmp);
+  return Belt__Belt_internalAVLtree.has(map.data, x, map.cmp);
 }
 
 function checkInvariantInternal(m) {
-  Belt__Belt_MapDict.checkInvariantInternal(m.data);
+  Belt__Belt_internalAVLtree.checkInvariantInternal(m.data);
 }
 
 function eqU(m1, m2, veq) {
-  return Belt__Belt_MapDict.eqU(m1.data, m2.data, m1.cmp, veq);
+  return Belt__Belt_internalAVLtree.eqU(m1.data, m2.data, m1.cmp, veq);
 }
 
 function eq(m1, m2, veq) {
@@ -282,7 +283,7 @@ function eq(m1, m2, veq) {
 }
 
 function cmpU(m1, m2, vcmp) {
-  return Belt__Belt_MapDict.cmpU(m1.data, m2.data, m1.cmp, vcmp);
+  return Belt__Belt_internalAVLtree.cmpU(m1.data, m2.data, m1.cmp, vcmp);
 }
 
 function cmp(m1, m2, vcmp) {
@@ -365,4 +366,4 @@ module.exports = {
   packIdData,
   checkInvariantInternal,
 }
-/* No side effect */
+/* Belt__Belt_internalAVLtree Not a pure module */

--- a/node_modules/melange.belt/belt_Set.js
+++ b/node_modules/melange.belt/belt_Set.js
@@ -2,13 +2,14 @@
 'use strict';
 
 const Belt__Belt_SetDict = require("./belt_SetDict.js");
+const Belt__Belt_internalAVLset = require("./belt_internalAVLset.js");
 const Curry = require("melange.js/curry.js");
 
 function fromArray(data, id) {
   const cmp = id.cmp;
   return {
     cmp: cmp,
-    data: Belt__Belt_SetDict.fromArray(data, cmp)
+    data: Belt__Belt_internalAVLset.fromArray(data, cmp)
   };
 }
 
@@ -82,7 +83,7 @@ function diff(m, n) {
 
 function subset(m, n) {
   const cmp = m.cmp;
-  return Belt__Belt_SetDict.subset(m.data, n.data, cmp);
+  return Belt__Belt_internalAVLset.subset(m.data, n.data, cmp);
 }
 
 function split(m, e) {
@@ -112,28 +113,28 @@ function make(id) {
 }
 
 function isEmpty(m) {
-  return Belt__Belt_SetDict.isEmpty(m.data);
+  return Belt__Belt_internalAVLset.isEmpty(m.data);
 }
 
 function cmp(m, n) {
   const cmp$1 = m.cmp;
-  return Belt__Belt_SetDict.cmp(m.data, n.data, cmp$1);
+  return Belt__Belt_internalAVLset.cmp(m.data, n.data, cmp$1);
 }
 
 function eq(m, n) {
-  return Belt__Belt_SetDict.eq(m.data, n.data, m.cmp);
+  return Belt__Belt_internalAVLset.eq(m.data, n.data, m.cmp);
 }
 
 function forEachU(m, f) {
-  Belt__Belt_SetDict.forEachU(m.data, f);
+  Belt__Belt_internalAVLset.forEachU(m.data, f);
 }
 
 function forEach(m, f) {
-  Belt__Belt_SetDict.forEachU(m.data, Curry.__1(f));
+  Belt__Belt_internalAVLset.forEachU(m.data, Curry.__1(f));
 }
 
 function reduceU(m, acc, f) {
-  return Belt__Belt_SetDict.reduceU(m.data, acc, f);
+  return Belt__Belt_internalAVLset.reduceU(m.data, acc, f);
 }
 
 function reduce(m, acc, f) {
@@ -141,25 +142,25 @@ function reduce(m, acc, f) {
 }
 
 function everyU(m, f) {
-  return Belt__Belt_SetDict.everyU(m.data, f);
+  return Belt__Belt_internalAVLset.everyU(m.data, f);
 }
 
 function every(m, f) {
-  return Belt__Belt_SetDict.everyU(m.data, Curry.__1(f));
+  return Belt__Belt_internalAVLset.everyU(m.data, Curry.__1(f));
 }
 
 function someU(m, f) {
-  return Belt__Belt_SetDict.someU(m.data, f);
+  return Belt__Belt_internalAVLset.someU(m.data, f);
 }
 
 function some(m, f) {
-  return Belt__Belt_SetDict.someU(m.data, Curry.__1(f));
+  return Belt__Belt_internalAVLset.someU(m.data, Curry.__1(f));
 }
 
 function keepU(m, f) {
   return {
     cmp: m.cmp,
-    data: Belt__Belt_SetDict.keepU(m.data, f)
+    data: Belt__Belt_internalAVLset.keepSharedU(m.data, f)
   };
 }
 
@@ -168,7 +169,7 @@ function keep(m, f) {
 }
 
 function partitionU(m, f) {
-  const match = Belt__Belt_SetDict.partitionU(m.data, f);
+  const match = Belt__Belt_internalAVLset.partitionSharedU(m.data, f);
   const cmp = m.cmp;
   return [
     {
@@ -187,53 +188,53 @@ function partition(m, f) {
 }
 
 function size(m) {
-  return Belt__Belt_SetDict.size(m.data);
+  return Belt__Belt_internalAVLset.size(m.data);
 }
 
 function toList(m) {
-  return Belt__Belt_SetDict.toList(m.data);
+  return Belt__Belt_internalAVLset.toList(m.data);
 }
 
 function toArray(m) {
-  return Belt__Belt_SetDict.toArray(m.data);
+  return Belt__Belt_internalAVLset.toArray(m.data);
 }
 
 function minimum(m) {
-  return Belt__Belt_SetDict.minimum(m.data);
+  return Belt__Belt_internalAVLset.minimum(m.data);
 }
 
 function minUndefined(m) {
-  return Belt__Belt_SetDict.minUndefined(m.data);
+  return Belt__Belt_internalAVLset.minUndefined(m.data);
 }
 
 function maximum(m) {
-  return Belt__Belt_SetDict.maximum(m.data);
+  return Belt__Belt_internalAVLset.maximum(m.data);
 }
 
 function maxUndefined(m) {
-  return Belt__Belt_SetDict.maxUndefined(m.data);
+  return Belt__Belt_internalAVLset.maxUndefined(m.data);
 }
 
 function get(m, e) {
-  return Belt__Belt_SetDict.get(m.data, e, m.cmp);
+  return Belt__Belt_internalAVLset.get(m.data, e, m.cmp);
 }
 
 function getUndefined(m, e) {
-  return Belt__Belt_SetDict.getUndefined(m.data, e, m.cmp);
+  return Belt__Belt_internalAVLset.getUndefined(m.data, e, m.cmp);
 }
 
 function getExn(m, e) {
-  return Belt__Belt_SetDict.getExn(m.data, e, m.cmp);
+  return Belt__Belt_internalAVLset.getExn(m.data, e, m.cmp);
 }
 
 function has(m, e) {
-  return Belt__Belt_SetDict.has(m.data, e, m.cmp);
+  return Belt__Belt_internalAVLset.has(m.data, e, m.cmp);
 }
 
 function fromSortedArrayUnsafe(xs, id) {
   return {
     cmp: id.cmp,
-    data: Belt__Belt_SetDict.fromSortedArrayUnsafe(xs)
+    data: Belt__Belt_internalAVLset.fromSortedArrayUnsafe(xs)
   };
 }
 
@@ -256,7 +257,7 @@ function packIdData(id, data) {
 }
 
 function checkInvariantInternal(d) {
-  Belt__Belt_SetDict.checkInvariantInternal(d.data);
+  Belt__Belt_internalAVLset.checkInvariantInternal(d.data);
 }
 
 module.exports = {
@@ -303,4 +304,4 @@ module.exports = {
   getId,
   packIdData,
 }
-/* No side effect */
+/* Belt__Belt_internalAVLset Not a pure module */

--- a/node_modules/melange/bytes.js
+++ b/node_modules/melange/bytes.js
@@ -1244,7 +1244,8 @@ function get_utf_16be_uchar(b, i) {
   }
   const last = i + 3 | 0;
   if (last > max) {
-    return (((max - i | 0) + 1 | 0) << 24) | 65533;
+    const n = (max - i | 0) + 1 | 0;
+    return (n << 24) | 65533;
   }
   const u$1 = unsafe_get_uint16_be(b, i + 2 | 0);
   if (u$1 < 56320 || u$1 > 57343) {
@@ -1355,7 +1356,8 @@ function get_utf_16le_uchar(b, i) {
   }
   const last = i + 3 | 0;
   if (last > max) {
-    return (((max - i | 0) + 1 | 0) << 24) | 65533;
+    const n = (max - i | 0) + 1 | 0;
+    return (n << 24) | 65533;
   }
   const u$1 = unsafe_get_uint16_le(b, i + 2 | 0);
   if (u$1 < 56320 || u$1 > 57343) {

--- a/node_modules/melange/bytes.mjs
+++ b/node_modules/melange/bytes.mjs
@@ -1243,7 +1243,8 @@ function get_utf_16be_uchar(b, i) {
   }
   const last = i + 3 | 0;
   if (last > max) {
-    return (((max - i | 0) + 1 | 0) << 24) | 65533;
+    const n = (max - i | 0) + 1 | 0;
+    return (n << 24) | 65533;
   }
   const u$1 = unsafe_get_uint16_be(b, i + 2 | 0);
   if (u$1 < 56320 || u$1 > 57343) {
@@ -1354,7 +1355,8 @@ function get_utf_16le_uchar(b, i) {
   }
   const last = i + 3 | 0;
   if (last > max) {
-    return (((max - i | 0) + 1 | 0) << 24) | 65533;
+    const n = (max - i | 0) + 1 | 0;
+    return (n << 24) | 65533;
   }
   const u$1 = unsafe_get_uint16_le(b, i + 2 | 0);
   if (u$1 < 56320 || u$1 > 57343) {

--- a/node_modules/melange/camlinternalFormat.js
+++ b/node_modules/melange/camlinternalFormat.js
@@ -262,7 +262,7 @@ function buffer_add_char(buf, c) {
 function buffer_add_string(buf, s) {
   const str_len = s.length;
   buffer_check_size(buf, str_len);
-  Stdlib__String.blit(s, 0, buf.bytes, buf.ind, str_len);
+  Stdlib__Bytes.blit_string(s, 0, buf.bytes, buf.ind, str_len);
   buf.ind = buf.ind + str_len | 0;
 }
 
@@ -3082,20 +3082,20 @@ function fix_padding(padty, width, str) {
   const res = Stdlib__Bytes.make(width$1, padty$1 === /* Zeros */ 2 ? /* '0' */48 : /* ' ' */32);
   switch (padty$1) {
     case /* Left */ 0 :
-      Stdlib__String.blit(str, 0, res, 0, len);
+      Stdlib__Bytes.blit_string(str, 0, res, 0, len);
       break;
     case /* Right */ 1 :
-      Stdlib__String.blit(str, 0, res, width$1 - len | 0, len);
+      Stdlib__Bytes.blit_string(str, 0, res, width$1 - len | 0, len);
       break;
     case /* Zeros */ 2 :
       if (len > 0 && (Caml_string.get(str, 0) === /* '+' */43 || Caml_string.get(str, 0) === /* '-' */45 || Caml_string.get(str, 0) === /* ' ' */32)) {
         Caml_bytes.set(res, 0, Caml_string.get(str, 0));
-        Stdlib__String.blit(str, 1, res, (width$1 - len | 0) + 1 | 0, len - 1 | 0);
+        Stdlib__Bytes.blit_string(str, 1, res, (width$1 - len | 0) + 1 | 0, len - 1 | 0);
       } else if (len > 1 && Caml_string.get(str, 0) === /* '0' */48 && (Caml_string.get(str, 1) === /* 'x' */120 || Caml_string.get(str, 1) === /* 'X' */88)) {
         Caml_bytes.set(res, 1, Caml_string.get(str, 1));
-        Stdlib__String.blit(str, 2, res, (width$1 - len | 0) + 2 | 0, len - 2 | 0);
+        Stdlib__Bytes.blit_string(str, 2, res, (width$1 - len | 0) + 2 | 0, len - 2 | 0);
       } else {
-        Stdlib__String.blit(str, 0, res, width$1 - len | 0, len);
+        Stdlib__Bytes.blit_string(str, 0, res, width$1 - len | 0, len);
       }
       break;
   }
@@ -3136,7 +3136,7 @@ function fix_int_precision(prec, str) {
         if ((prec$1 + 2 | 0) > len && len > 1 && (Caml_string.get(str, 1) === /* 'x' */120 || Caml_string.get(str, 1) === /* 'X' */88)) {
           const res = Stdlib__Bytes.make(prec$1 + 2 | 0, /* '0' */48);
           Caml_bytes.set(res, 1, Caml_string.get(str, 1));
-          Stdlib__String.blit(str, 2, res, (prec$1 - len | 0) + 4 | 0, len - 2 | 0);
+          Stdlib__Bytes.blit_string(str, 2, res, (prec$1 - len | 0) + 4 | 0, len - 2 | 0);
           return Caml_bytes.bytes_to_string(res);
         }
         exit = 2;
@@ -3163,14 +3163,14 @@ function fix_int_precision(prec, str) {
       }
       const res$1 = Stdlib__Bytes.make(prec$1 + 1 | 0, /* '0' */48);
       Caml_bytes.set(res$1, 0, c);
-      Stdlib__String.blit(str, 1, res$1, (prec$1 - len | 0) + 2 | 0, len - 1 | 0);
+      Stdlib__Bytes.blit_string(str, 1, res$1, (prec$1 - len | 0) + 2 | 0, len - 1 | 0);
       return Caml_bytes.bytes_to_string(res$1);
     case 2 :
       if (prec$1 <= len) {
         return str;
       }
       const res$2 = Stdlib__Bytes.make(prec$1, /* '0' */48);
-      Stdlib__String.blit(str, 0, res$2, prec$1 - len | 0, len);
+      Stdlib__Bytes.blit_string(str, 0, res$2, prec$1 - len | 0, len);
       return Caml_bytes.bytes_to_string(res$2);
   }
 }

--- a/node_modules/melange/camlinternalFormat.mjs
+++ b/node_modules/melange/camlinternalFormat.mjs
@@ -261,7 +261,7 @@ function buffer_add_char(buf, c) {
 function buffer_add_string(buf, s) {
   const str_len = s.length;
   buffer_check_size(buf, str_len);
-  Stdlib__String.blit(s, 0, buf.bytes, buf.ind, str_len);
+  Stdlib__Bytes.blit_string(s, 0, buf.bytes, buf.ind, str_len);
   buf.ind = buf.ind + str_len | 0;
 }
 
@@ -3081,20 +3081,20 @@ function fix_padding(padty, width, str) {
   const res = Stdlib__Bytes.make(width$1, padty$1 === /* Zeros */ 2 ? /* '0' */48 : /* ' ' */32);
   switch (padty$1) {
     case /* Left */ 0 :
-      Stdlib__String.blit(str, 0, res, 0, len);
+      Stdlib__Bytes.blit_string(str, 0, res, 0, len);
       break;
     case /* Right */ 1 :
-      Stdlib__String.blit(str, 0, res, width$1 - len | 0, len);
+      Stdlib__Bytes.blit_string(str, 0, res, width$1 - len | 0, len);
       break;
     case /* Zeros */ 2 :
       if (len > 0 && (Caml_string.get(str, 0) === /* '+' */43 || Caml_string.get(str, 0) === /* '-' */45 || Caml_string.get(str, 0) === /* ' ' */32)) {
         Caml_bytes.set(res, 0, Caml_string.get(str, 0));
-        Stdlib__String.blit(str, 1, res, (width$1 - len | 0) + 1 | 0, len - 1 | 0);
+        Stdlib__Bytes.blit_string(str, 1, res, (width$1 - len | 0) + 1 | 0, len - 1 | 0);
       } else if (len > 1 && Caml_string.get(str, 0) === /* '0' */48 && (Caml_string.get(str, 1) === /* 'x' */120 || Caml_string.get(str, 1) === /* 'X' */88)) {
         Caml_bytes.set(res, 1, Caml_string.get(str, 1));
-        Stdlib__String.blit(str, 2, res, (width$1 - len | 0) + 2 | 0, len - 2 | 0);
+        Stdlib__Bytes.blit_string(str, 2, res, (width$1 - len | 0) + 2 | 0, len - 2 | 0);
       } else {
-        Stdlib__String.blit(str, 0, res, width$1 - len | 0, len);
+        Stdlib__Bytes.blit_string(str, 0, res, width$1 - len | 0, len);
       }
       break;
   }
@@ -3135,7 +3135,7 @@ function fix_int_precision(prec, str) {
         if ((prec$1 + 2 | 0) > len && len > 1 && (Caml_string.get(str, 1) === /* 'x' */120 || Caml_string.get(str, 1) === /* 'X' */88)) {
           const res = Stdlib__Bytes.make(prec$1 + 2 | 0, /* '0' */48);
           Caml_bytes.set(res, 1, Caml_string.get(str, 1));
-          Stdlib__String.blit(str, 2, res, (prec$1 - len | 0) + 4 | 0, len - 2 | 0);
+          Stdlib__Bytes.blit_string(str, 2, res, (prec$1 - len | 0) + 4 | 0, len - 2 | 0);
           return Caml_bytes.bytes_to_string(res);
         }
         exit = 2;
@@ -3162,14 +3162,14 @@ function fix_int_precision(prec, str) {
       }
       const res$1 = Stdlib__Bytes.make(prec$1 + 1 | 0, /* '0' */48);
       Caml_bytes.set(res$1, 0, c);
-      Stdlib__String.blit(str, 1, res$1, (prec$1 - len | 0) + 2 | 0, len - 1 | 0);
+      Stdlib__Bytes.blit_string(str, 1, res$1, (prec$1 - len | 0) + 2 | 0, len - 1 | 0);
       return Caml_bytes.bytes_to_string(res$1);
     case 2 :
       if (prec$1 <= len) {
         return str;
       }
       const res$2 = Stdlib__Bytes.make(prec$1, /* '0' */48);
-      Stdlib__String.blit(str, 0, res$2, prec$1 - len | 0, len);
+      Stdlib__Bytes.blit_string(str, 0, res$2, prec$1 - len | 0, len);
       return Caml_bytes.bytes_to_string(res$2);
   }
 }

--- a/node_modules/melange/camlinternalOO.js
+++ b/node_modules/melange/camlinternalOO.js
@@ -7,10 +7,10 @@ const Caml_js_exceptions = require("melange.js/caml_js_exceptions.js");
 const Caml_obj = require("melange.js/caml_obj.js");
 const Caml_oo = require("melange.js/caml_oo.js");
 const Caml_string = require("melange.js/caml_string.js");
+const CamlinternalAtomic = require("./camlinternalAtomic.js");
 const Curry = require("melange.js/curry.js");
 const Stdlib = require("./stdlib.js");
 const Stdlib__Array = require("./array.js");
-const Stdlib__Atomic = require("./atomic.js");
 const Stdlib__List = require("./list.js");
 
 const new_object_tag_block = (function(size){
@@ -529,7 +529,7 @@ function fit_size(n) {
 }
 
 function new_table(pub_labels) {
-  Stdlib__Atomic.incr(table_count);
+  CamlinternalAtomic.incr(table_count);
   const len = pub_labels.length;
   const methods = Caml_array.make((len << 1) + 2 | 0, /* DummyA */ 0);
   Caml_array.set(methods, 0, len);
@@ -596,7 +596,7 @@ function get_method_labels(table, names) {
 }
 
 function set_method(table, label, element) {
-  Stdlib__Atomic.incr(method_count);
+  CamlinternalAtomic.incr(method_count);
   if (Curry._2(find$2, label, table.methods_by_label)) {
     resize(table, label + 1 | 0);
     return Caml_array.set(table.methods, label, element);
@@ -815,7 +815,7 @@ function create_table(public_methods) {
 }
 
 function init_class(table) {
-  Stdlib__Atomic.fetch_and_add(inst_var_count, table.size - 1 | 0);
+  CamlinternalAtomic.fetch_and_add(inst_var_count, table.size - 1 | 0);
   table.initializers = Stdlib__List.rev(table.initializers);
   resize(table, 3 + ((Caml_array.get(table.methods, 1) << 4) / 32 | 0) | 0);
 }

--- a/node_modules/melange/camlinternalOO.mjs
+++ b/node_modules/melange/camlinternalOO.mjs
@@ -6,10 +6,10 @@ import * as Caml_js_exceptions from "melange.js/caml_js_exceptions.mjs";
 import * as Caml_obj from "melange.js/caml_obj.mjs";
 import * as Caml_oo from "melange.js/caml_oo.mjs";
 import * as Caml_string from "melange.js/caml_string.mjs";
+import * as CamlinternalAtomic from "./camlinternalAtomic.mjs";
 import * as Curry from "melange.js/curry.mjs";
 import * as Stdlib from "./stdlib.mjs";
 import * as Stdlib__Array from "./array.mjs";
-import * as Stdlib__Atomic from "./atomic.mjs";
 import * as Stdlib__List from "./list.mjs";
 
 const new_object_tag_block = (function(size){
@@ -528,7 +528,7 @@ function fit_size(n) {
 }
 
 function new_table(pub_labels) {
-  Stdlib__Atomic.incr(table_count);
+  CamlinternalAtomic.incr(table_count);
   const len = pub_labels.length;
   const methods = Caml_array.make((len << 1) + 2 | 0, /* DummyA */ 0);
   Caml_array.set(methods, 0, len);
@@ -595,7 +595,7 @@ function get_method_labels(table, names) {
 }
 
 function set_method(table, label, element) {
-  Stdlib__Atomic.incr(method_count);
+  CamlinternalAtomic.incr(method_count);
   if (Curry._2(find$2, label, table.methods_by_label)) {
     resize(table, label + 1 | 0);
     return Caml_array.set(table.methods, label, element);
@@ -814,7 +814,7 @@ function create_table(public_methods) {
 }
 
 function init_class(table) {
-  Stdlib__Atomic.fetch_and_add(inst_var_count, table.size - 1 | 0);
+  CamlinternalAtomic.fetch_and_add(inst_var_count, table.size - 1 | 0);
   table.initializers = Stdlib__List.rev(table.initializers);
   resize(table, 3 + ((Caml_array.get(table.methods, 1) << 4) / 32 | 0) | 0);
 }

--- a/node_modules/melange/digest.js
+++ b/node_modules/melange/digest.js
@@ -99,7 +99,7 @@ function channel(ic, toread) {
   if (toread < 0) {
     let _param;
     while (true) {
-      const n = Stdlib__In_channel.input(ic, buf, 0, 4096);
+      const n = Stdlib.input(ic, buf, 0, 4096);
       if (n === 0) {
         return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 16);
       }
@@ -114,7 +114,7 @@ function channel(ic, toread) {
     if (toread$1 === 0) {
       return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 16);
     }
-    const n$1 = Stdlib__In_channel.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
+    const n$1 = Stdlib.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
     if (n$1 === 0) {
       throw new Caml_js_exceptions.MelangeError(Stdlib.End_of_file, {
           MEL_EXN_ID: Stdlib.End_of_file
@@ -208,7 +208,7 @@ function channel$1(ic, toread) {
   if (toread < 0) {
     let _param;
     while (true) {
-      const n = Stdlib__In_channel.input(ic, buf, 0, 4096);
+      const n = Stdlib.input(ic, buf, 0, 4096);
       if (n === 0) {
         return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 32);
       }
@@ -223,7 +223,7 @@ function channel$1(ic, toread) {
     if (toread$1 === 0) {
       return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 32);
     }
-    const n$1 = Stdlib__In_channel.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
+    const n$1 = Stdlib.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
     if (n$1 === 0) {
       throw new Caml_js_exceptions.MelangeError(Stdlib.End_of_file, {
           MEL_EXN_ID: Stdlib.End_of_file
@@ -317,7 +317,7 @@ function channel$2(ic, toread) {
   if (toread < 0) {
     let _param;
     while (true) {
-      const n = Stdlib__In_channel.input(ic, buf, 0, 4096);
+      const n = Stdlib.input(ic, buf, 0, 4096);
       if (n === 0) {
         return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 64);
       }
@@ -332,7 +332,7 @@ function channel$2(ic, toread) {
     if (toread$1 === 0) {
       return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 64);
     }
-    const n$1 = Stdlib__In_channel.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
+    const n$1 = Stdlib.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
     if (n$1 === 0) {
       throw new Caml_js_exceptions.MelangeError(Stdlib.End_of_file, {
           MEL_EXN_ID: Stdlib.End_of_file

--- a/node_modules/melange/digest.mjs
+++ b/node_modules/melange/digest.mjs
@@ -98,7 +98,7 @@ function channel(ic, toread) {
   if (toread < 0) {
     let _param;
     while (true) {
-      const n = Stdlib__In_channel.input(ic, buf, 0, 4096);
+      const n = Stdlib.input(ic, buf, 0, 4096);
       if (n === 0) {
         return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 16);
       }
@@ -113,7 +113,7 @@ function channel(ic, toread) {
     if (toread$1 === 0) {
       return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 16);
     }
-    const n$1 = Stdlib__In_channel.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
+    const n$1 = Stdlib.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
     if (n$1 === 0) {
       throw new Caml_js_exceptions.MelangeError(Stdlib.End_of_file, {
           MEL_EXN_ID: Stdlib.End_of_file
@@ -207,7 +207,7 @@ function channel$1(ic, toread) {
   if (toread < 0) {
     let _param;
     while (true) {
-      const n = Stdlib__In_channel.input(ic, buf, 0, 4096);
+      const n = Stdlib.input(ic, buf, 0, 4096);
       if (n === 0) {
         return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 32);
       }
@@ -222,7 +222,7 @@ function channel$1(ic, toread) {
     if (toread$1 === 0) {
       return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 32);
     }
-    const n$1 = Stdlib__In_channel.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
+    const n$1 = Stdlib.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
     if (n$1 === 0) {
       throw new Caml_js_exceptions.MelangeError(Stdlib.End_of_file, {
           MEL_EXN_ID: Stdlib.End_of_file
@@ -316,7 +316,7 @@ function channel$2(ic, toread) {
   if (toread < 0) {
     let _param;
     while (true) {
-      const n = Stdlib__In_channel.input(ic, buf, 0, 4096);
+      const n = Stdlib.input(ic, buf, 0, 4096);
       if (n === 0) {
         return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 64);
       }
@@ -331,7 +331,7 @@ function channel$2(ic, toread) {
     if (toread$1 === 0) {
       return Caml_external_polyfill.resolve("caml_blake2_final")(ctx, 64);
     }
-    const n$1 = Stdlib__In_channel.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
+    const n$1 = Stdlib.input(ic, buf, 0, Stdlib__Int.min(4096, toread$1));
     if (n$1 === 0) {
       throw new Caml_js_exceptions.MelangeError(Stdlib.End_of_file, {
           MEL_EXN_ID: Stdlib.End_of_file

--- a/node_modules/melange/lazy.js
+++ b/node_modules/melange/lazy.js
@@ -3,9 +3,9 @@
 
 const Caml_external_polyfill = require("melange.js/caml_external_polyfill.js");
 const Caml_js_exceptions = require("melange.js/caml_js_exceptions.js");
+const CamlinternalAtomic = require("./camlinternalAtomic.js");
 const CamlinternalLazy = require("./camlinternalLazy.js");
 const Curry = require("melange.js/curry.js");
-const Stdlib__Atomic = require("./atomic.js");
 
 function from_fun(f) {
   return {
@@ -91,7 +91,7 @@ function force(th) {
       case /* Thunk */ 0 :
         const mut$1 = Caml_external_polyfill.resolve("caml_ml_mutex_new")();
         Caml_external_polyfill.resolve("caml_ml_mutex_lock")(mut$1);
-        if (Stdlib__Atomic.compare_and_set(th, mut, {
+        if (CamlinternalAtomic.compare_and_set(th, mut, {
             TAG: /* Forcing */ 1,
             _0: mut$1
           })) {

--- a/node_modules/melange/lazy.mjs
+++ b/node_modules/melange/lazy.mjs
@@ -2,9 +2,9 @@
 
 import * as Caml_external_polyfill from "melange.js/caml_external_polyfill.mjs";
 import * as Caml_js_exceptions from "melange.js/caml_js_exceptions.mjs";
+import * as CamlinternalAtomic from "./camlinternalAtomic.mjs";
 import * as CamlinternalLazy from "./camlinternalLazy.mjs";
 import * as Curry from "melange.js/curry.mjs";
-import * as Stdlib__Atomic from "./atomic.mjs";
 
 function from_fun(f) {
   return {
@@ -90,7 +90,7 @@ function force(th) {
       case /* Thunk */ 0 :
         const mut$1 = Caml_external_polyfill.resolve("caml_ml_mutex_new")();
         Caml_external_polyfill.resolve("caml_ml_mutex_lock")(mut$1);
-        if (Stdlib__Atomic.compare_and_set(th, mut, {
+        if (CamlinternalAtomic.compare_and_set(th, mut, {
             TAG: /* Forcing */ 1,
             _0: mut$1
           })) {

--- a/node_modules/melange/printexc.js
+++ b/node_modules/melange/printexc.js
@@ -7,9 +7,9 @@ const Caml_external_polyfill = require("melange.js/caml_external_polyfill.js");
 const Caml_io = require("melange.js/caml_io.js");
 const Caml_js_exceptions = require("melange.js/caml_js_exceptions.js");
 const Caml_option = require("melange.js/caml_option.js");
+const CamlinternalAtomic = require("./camlinternalAtomic.js");
 const Curry = require("melange.js/curry.js");
 const Stdlib = require("./stdlib.js");
-const Stdlib__Atomic = require("./atomic.js");
 const Stdlib__Buffer = require("./buffer.js");
 const Stdlib__Printf = require("./printf.js");
 
@@ -506,7 +506,7 @@ function register_printer(fn) {
       hd: fn,
       tl: old_printers
     };
-    const success = Stdlib__Atomic.compare_and_set(printers, old_printers, new_printers);
+    const success = CamlinternalAtomic.compare_and_set(printers, old_printers, new_printers);
     if (success) {
       return;
     }

--- a/node_modules/melange/printexc.mjs
+++ b/node_modules/melange/printexc.mjs
@@ -6,9 +6,9 @@ import * as Caml_external_polyfill from "melange.js/caml_external_polyfill.mjs";
 import * as Caml_io from "melange.js/caml_io.mjs";
 import * as Caml_js_exceptions from "melange.js/caml_js_exceptions.mjs";
 import * as Caml_option from "melange.js/caml_option.mjs";
+import * as CamlinternalAtomic from "./camlinternalAtomic.mjs";
 import * as Curry from "melange.js/curry.mjs";
 import * as Stdlib from "./stdlib.mjs";
-import * as Stdlib__Atomic from "./atomic.mjs";
 import * as Stdlib__Buffer from "./buffer.mjs";
 import * as Stdlib__Printf from "./printf.mjs";
 
@@ -505,7 +505,7 @@ function register_printer(fn) {
       hd: fn,
       tl: old_printers
     };
-    const success = Stdlib__Atomic.compare_and_set(printers, old_printers, new_printers);
+    const success = CamlinternalAtomic.compare_and_set(printers, old_printers, new_printers);
     if (success) {
       return;
     }

--- a/node_modules/melange/seq.js
+++ b/node_modules/melange/seq.js
@@ -801,22 +801,19 @@ function failure(param) {
 }
 
 function memoize(xs) {
-  let s = function (param) {
-    const match = Curry._1(xs, undefined);
-    if (/* tag */ typeof match !== "object" && typeof match !== "function") {
-      return /* Nil */ 0;
-    } else {
-      return {
-        TAG: /* Cons */ 0,
-        _0: match._0,
-        _1: memoize(match._1)
-      };
-    }
-  };
   const partial_arg = {
     LAZY_DONE: false,
     VAL: (function () {
-      return Curry._1(s, undefined);
+      const match = Curry._1(xs, undefined);
+      if (/* tag */ typeof match !== "object" && typeof match !== "function") {
+        return /* Nil */ 0;
+      } else {
+        return {
+          TAG: /* Cons */ 0,
+          _0: match._0,
+          _1: memoize(match._1)
+        };
+      }
     })
   };
   return function (param) {

--- a/node_modules/melange/seq.js
+++ b/node_modules/melange/seq.js
@@ -801,19 +801,22 @@ function failure(param) {
 }
 
 function memoize(xs) {
+  let s = function (param) {
+    const match = Curry._1(xs, undefined);
+    if (/* tag */ typeof match !== "object" && typeof match !== "function") {
+      return /* Nil */ 0;
+    } else {
+      return {
+        TAG: /* Cons */ 0,
+        _0: match._0,
+        _1: memoize(match._1)
+      };
+    }
+  };
   const partial_arg = {
     LAZY_DONE: false,
     VAL: (function () {
-      const match = Curry._1(xs, undefined);
-      if (/* tag */ typeof match !== "object" && typeof match !== "function") {
-        return /* Nil */ 0;
-      } else {
-        return {
-          TAG: /* Cons */ 0,
-          _0: match._0,
-          _1: memoize(match._1)
-        };
-      }
+      return Curry._1(s, undefined);
     })
   };
   return function (param) {

--- a/node_modules/melange/seq.js
+++ b/node_modules/melange/seq.js
@@ -4,9 +4,9 @@
 const Caml_exceptions = require("melange.js/caml_exceptions.js");
 const Caml_js_exceptions = require("melange.js/caml_js_exceptions.js");
 const Caml_option = require("melange.js/caml_option.js");
+const CamlinternalAtomic = require("./camlinternalAtomic.js");
 const CamlinternalLazy = require("./camlinternalLazy.js");
 const Curry = require("melange.js/curry.js");
-const Stdlib__Atomic = require("./atomic.js");
 
 function empty(param) {
   return /* Nil */ 0;
@@ -801,19 +801,22 @@ function failure(param) {
 }
 
 function memoize(xs) {
+  let s = function (param) {
+    const match = Curry._1(xs, undefined);
+    if (/* tag */ typeof match !== "object" && typeof match !== "function") {
+      return /* Nil */ 0;
+    } else {
+      return {
+        TAG: /* Cons */ 0,
+        _0: match._0,
+        _1: memoize(match._1)
+      };
+    }
+  };
   const partial_arg = {
     LAZY_DONE: false,
     VAL: (function () {
-      const match = Curry._1(xs, undefined);
-      if (/* tag */ typeof match !== "object" && typeof match !== "function") {
-        return /* Nil */ 0;
-      } else {
-        return {
-          TAG: /* Cons */ 0,
-          _0: match._0,
-          _1: memoize(match._1)
-        };
-      }
+      return Curry._1(s, undefined);
     })
   };
   return function (param) {
@@ -838,7 +841,7 @@ function once(xs) {
     v: f
   };
   return function (param) {
-    const f = Stdlib__Atomic.exchange(action, failure);
+    const f = CamlinternalAtomic.exchange(action, failure);
     return Curry._1(f, undefined);
   };
 }

--- a/node_modules/melange/seq.mjs
+++ b/node_modules/melange/seq.mjs
@@ -800,19 +800,22 @@ function failure(param) {
 }
 
 function memoize(xs) {
+  let s = function (param) {
+    const match = Curry._1(xs, undefined);
+    if (/* tag */ typeof match !== "object" && typeof match !== "function") {
+      return /* Nil */ 0;
+    } else {
+      return {
+        TAG: /* Cons */ 0,
+        _0: match._0,
+        _1: memoize(match._1)
+      };
+    }
+  };
   const partial_arg = {
     LAZY_DONE: false,
     VAL: (function () {
-      const match = Curry._1(xs, undefined);
-      if (/* tag */ typeof match !== "object" && typeof match !== "function") {
-        return /* Nil */ 0;
-      } else {
-        return {
-          TAG: /* Cons */ 0,
-          _0: match._0,
-          _1: memoize(match._1)
-        };
-      }
+      return Curry._1(s, undefined);
     })
   };
   return function (param) {

--- a/node_modules/melange/seq.mjs
+++ b/node_modules/melange/seq.mjs
@@ -3,9 +3,9 @@
 import * as Caml_exceptions from "melange.js/caml_exceptions.mjs";
 import * as Caml_js_exceptions from "melange.js/caml_js_exceptions.mjs";
 import * as Caml_option from "melange.js/caml_option.mjs";
+import * as CamlinternalAtomic from "./camlinternalAtomic.mjs";
 import * as CamlinternalLazy from "./camlinternalLazy.mjs";
 import * as Curry from "melange.js/curry.mjs";
-import * as Stdlib__Atomic from "./atomic.mjs";
 
 function empty(param) {
   return /* Nil */ 0;
@@ -800,19 +800,22 @@ function failure(param) {
 }
 
 function memoize(xs) {
+  let s = function (param) {
+    const match = Curry._1(xs, undefined);
+    if (/* tag */ typeof match !== "object" && typeof match !== "function") {
+      return /* Nil */ 0;
+    } else {
+      return {
+        TAG: /* Cons */ 0,
+        _0: match._0,
+        _1: memoize(match._1)
+      };
+    }
+  };
   const partial_arg = {
     LAZY_DONE: false,
     VAL: (function () {
-      const match = Curry._1(xs, undefined);
-      if (/* tag */ typeof match !== "object" && typeof match !== "function") {
-        return /* Nil */ 0;
-      } else {
-        return {
-          TAG: /* Cons */ 0,
-          _0: match._0,
-          _1: memoize(match._1)
-        };
-      }
+      return Curry._1(s, undefined);
     })
   };
   return function (param) {
@@ -837,7 +840,7 @@ function once(xs) {
     v: f
   };
   return function (param) {
-    const f = Stdlib__Atomic.exchange(action, failure);
+    const f = CamlinternalAtomic.exchange(action, failure);
     return Curry._1(f, undefined);
   };
 }

--- a/node_modules/melange/seq.mjs
+++ b/node_modules/melange/seq.mjs
@@ -800,22 +800,19 @@ function failure(param) {
 }
 
 function memoize(xs) {
-  let s = function (param) {
-    const match = Curry._1(xs, undefined);
-    if (/* tag */ typeof match !== "object" && typeof match !== "function") {
-      return /* Nil */ 0;
-    } else {
-      return {
-        TAG: /* Cons */ 0,
-        _0: match._0,
-        _1: memoize(match._1)
-      };
-    }
-  };
   const partial_arg = {
     LAZY_DONE: false,
     VAL: (function () {
-      return Curry._1(s, undefined);
+      const match = Curry._1(xs, undefined);
+      if (/* tag */ typeof match !== "object" && typeof match !== "function") {
+        return /* Nil */ 0;
+      } else {
+        return {
+          TAG: /* Cons */ 0,
+          _0: match._0,
+          _1: memoize(match._1)
+        };
+      }
     })
   };
   return function (param) {


### PR DESCRIPTION
## Summary

Track direct imported call summaries so fully-applied aliases to imported functions can be rewritten to direct calls.

Also keep the parameter-capture beta-reduction guard in this PR, because promotion showed it is not independently justified on `main`: by itself it regresses generated `Bytes` output. In this PR it prevents the direct-summary rewrite from freezing the worse `Seq.memoize` shape with an extra local thunk and `Curry._1(s, undefined)`.

## Verification

- `dune build @install`
- `dune promote`
- checked generated `Seq.memoize` does not introduce the extra local thunk / `Curry._1(s, undefined)`
- checked Belt direct calls remain direct and do not introduce `Curry._n(Belt__Belt_internal...)`