### PR TITLE
Track local module field arities

### DIFF
--- a/jscomp/core/lam_arity_analysis.ml
+++ b/jscomp/core/lam_arity_analysis.ml
@@ -32,6 +32,19 @@ let arity_of_var (meta : Lam_stats.t) (v : Ident.t) =
   | FunctionId { arity; _ } -> arity
   | _ | (exception Not_found) -> Lam_arity.na
 
+let rec field_element (meta : Lam_stats.t) (lam : Lam.t) (i : int) =
+  match lam with
+  | Lvar v | Lmutvar v -> (
+      match Ident.Hashtbl.find meta.ident_tbl v with
+      | ImmutableBlock elems -> elems.(i)
+      | _ | (exception Not_found) -> Lam_id_kind.Element.NA
+      | exception _ -> Lam_id_kind.Element.NA)
+  | Lprim { primitive = Pfield (j, _); args = [ owner ]; _ } -> (
+      match field_element meta owner j with
+      | Lam_id_kind.Element.ImmutableBlock elems -> elems.(i)
+      | _ | exception _ -> Lam_id_kind.Element.NA)
+  | _ -> Lam_id_kind.Element.NA
+
 (* we need record all aliases -- since not all aliases are eliminated,
    mostly are toplevel bindings
    We will keep iterating such environment
@@ -69,6 +82,16 @@ let rec get_arity (meta : Lam_stats.t) (lam : Lam.t) : Lam_arity.t =
       | Some { arity = Submodule subs; _ } ->
           subs.(m) (* TODO: shall we store it as array?*)
       | Some { arity = Single _; _ } | None -> Lam_arity.na)
+  | Lprim
+      {
+        primitive = Pfield (m, _);
+        args = [ owner ];
+        _;
+      } -> (
+      match field_element meta owner m with
+      | Lam_id_kind.Element.Function arity -> arity
+      | SimpleForm lam -> get_arity meta lam
+      | NA | ImmutableBlock _ -> Lam_arity.na)
   (* TODO: all information except Pccall is complete, we could
      get more arity information
   *)

--- a/jscomp/core/lam_id_kind.ml
+++ b/jscomp/core/lam_id_kind.ml
@@ -34,9 +34,13 @@ type rec_flag = Lam_rec | Lam_non_rec | Lam_self_rec
 *)
 
 module Element = struct
-  type t = NA | SimpleForm of Lam.t
+  type t =
+    | NA
+    | SimpleForm of Lam.t
+    | Function of Lam_arity.t
+    | ImmutableBlock of t array
 
-  let of_lambda = function
+  let rec of_lambda = function
     | ( Lam.Lvar _ | Lconst _
       | Lprim
           {
@@ -45,7 +49,9 @@ module Element = struct
             _;
           } ) as lam ->
         SimpleForm lam
-    (* | Lfunction _  *)
+    | Lfunction { arity; _ } -> Function (Lam_arity.info [ arity ] false)
+    | Lprim { primitive = Pmakeblock (_, _, Immutable); args; _ } ->
+        ImmutableBlock (Array.of_list_map args ~f:of_lambda)
     | _ -> NA
 end
 

--- a/jscomp/core/lam_id_kind.mli
+++ b/jscomp/core/lam_id_kind.mli
@@ -32,7 +32,11 @@ type rec_flag =
 (* not inlining in this case *)
 
 module Element : sig
-  type t = NA | SimpleForm of Lam.t
+  type t =
+    | NA
+    | SimpleForm of Lam.t
+    | Function of Lam_arity.t
+    | ImmutableBlock of t array
 end
 
 type boxed_nullable = Undefined | Null | Null_undefined

--- a/jscomp/core/lam_pass_remove_alias.ml
+++ b/jscomp/core/lam_pass_remove_alias.ml
@@ -62,7 +62,10 @@ let field_flatten_get (tbl : Lam_id_kind.t Ident.Hashtbl.t) ~f v i
         ~args:[ Lam.global_module ~dynamic_import:false g ]
         ~loc:Location.none
   | ImmutableBlock arr -> (
-      match arr.(i) with NA -> f () | SimpleForm l -> l | exception _ -> f ())
+      match arr.(i) with
+      | NA | Function _ | ImmutableBlock _ -> f ()
+      | SimpleForm l -> l
+      | exception _ -> f ())
   | Constant (Const_block (_, _, ls)) -> (
       match List.nth ls i with exception Failure _ -> f () | x -> Lam.const x)
   | _ | (exception Not_found) -> f ()

--- a/jscomp/core/lam_stats_export.ml
+++ b/jscomp/core/lam_stats_export.ml
@@ -51,6 +51,8 @@ let values_of_export =
               Submodule
                 (Array.map elems ~f:(function
                   | Lam_id_kind.Element.NA -> Lam_arity.na
+                  | Function arity -> arity
+                  | ImmutableBlock _ -> Lam_arity.na
                   | SimpleForm lam -> Lam_arity_analysis.get_arity meta lam))
           | _ | (exception Not_found) -> (
               match Ident.Map.find x export_map with

--- a/jscomp/test/arity_deopt_test.ml
+++ b/jscomp/test/arity_deopt_test.ml
@@ -82,7 +82,7 @@ let () =
             eq __LOC__ 6  @@ (f3 1 ) 2 3  [@u];
             eq __LOC__ 1 @@ utf_8_byte_length (Uchar.of_int 0x007F);
             eq __LOC__ 3 @@ utf_8_byte_length (Uchar.of_int 0x0800);
-            eq __LOC__ 3 @@ captures_after_effect 1 2
+            eq __LOC__ 3 @@ captures_after_effect 1 2;
             eq __LOC__ 3 local_module_field_result;
             eq __LOC__ ["inner"; "outer"] !(Local_module_field.effects);
             eq __LOC__ 3 nested_module_field_result;

--- a/jscomp/test/arity_deopt_test.ml
+++ b/jscomp/test/arity_deopt_test.ml
@@ -50,6 +50,30 @@ let captures_after_effect a = Arity_deopt_helper.captures_after_effect a
    (Ml_app) will not hold any more.
    So the best is never shrink functions which could change arity
 *)
+
+module Local_module_field = struct
+  module Nested = struct
+    let effects = ref []
+
+    let x a =
+      effects := "outer" :: !effects;
+      fun b ->
+        effects := "inner" :: !effects;
+        a + b
+  end
+
+  let effects = ref []
+
+  let x a =
+    effects := "outer" :: !effects;
+    fun b ->
+      effects := "inner" :: !effects;
+      a + b
+end
+
+let local_module_field_result = Local_module_field.x 1 2
+let nested_module_field_result = Local_module_field.Nested.x 1 2
+
 let () =
   begin
     eq __LOC__ 6 @@ f0 1 2 3 [@u] ;
@@ -59,5 +83,9 @@ let () =
             eq __LOC__ 1 @@ utf_8_byte_length (Uchar.of_int 0x007F);
             eq __LOC__ 3 @@ utf_8_byte_length (Uchar.of_int 0x0800);
             eq __LOC__ 3 @@ captures_after_effect 1 2
+            eq __LOC__ 3 local_module_field_result;
+            eq __LOC__ ["inner"; "outer"] !(Local_module_field.effects);
+            eq __LOC__ 3 nested_module_field_result;
+            eq __LOC__ ["inner"; "outer"] !(Local_module_field.Nested.effects)
   end
 let () = Mt.from_pair_suites __MODULE__ !suites

--- a/jscomp/test/dist/arity_deopt_test.js
+++ b/jscomp/test/dist/arity_deopt_test.js
@@ -67,19 +67,90 @@ function utf_8_byte_length(u) {
 
 const captures_after_effect = Arity_deopt_helper.captures_after_effect;
 
-eq("File \"jscomp/test/arity_deopt_test.ml\", line 55, characters 7-14", 6, f0(1, 2, 3));
+const effects = {
+  contents: /* [] */ 0
+};
 
-eq("File \"jscomp/test/arity_deopt_test.ml\", line 56, characters 11-18", 6, f1(1)(2, 3));
+function x(a) {
+  effects.contents = {
+    hd: "outer",
+    tl: effects.contents
+  };
+  return function (b) {
+    effects.contents = {
+      hd: "inner",
+      tl: effects.contents
+    };
+    return a + b | 0;
+  };
+}
 
-eq("File \"jscomp/test/arity_deopt_test.ml\", line 57, characters 15-22", 6, Curry._1(f2(1, 2), 3));
+const Nested = {
+  effects: effects,
+  x: x
+};
 
-eq("File \"jscomp/test/arity_deopt_test.ml\", line 58, characters 15-22", 6, f3(1)(2, 3));
+const effects$1 = {
+  contents: /* [] */ 0
+};
 
-eq("File \"jscomp/test/arity_deopt_test.ml\", line 59, characters 15-22", 1, utf_8_byte_length(Stdlib__Uchar.of_int(127)));
+function x$1(a) {
+  effects$1.contents = {
+    hd: "outer",
+    tl: effects$1.contents
+  };
+  return function (b) {
+    effects$1.contents = {
+      hd: "inner",
+      tl: effects$1.contents
+    };
+    return a + b | 0;
+  };
+}
 
-eq("File \"jscomp/test/arity_deopt_test.ml\", line 60, characters 15-22", 3, utf_8_byte_length(Stdlib__Uchar.of_int(2048)));
+const Local_module_field = {
+  Nested: Nested,
+  effects: effects$1,
+  x: x$1
+};
 
-eq("File \"jscomp/test/arity_deopt_test.ml\", line 61, characters 15-22", 3, Arity_deopt_helper.captures_after_effect(1)(2));
+const local_module_field_result = x$1(1)(2);
+
+const nested_module_field_result = x(1)(2);
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 79, characters 7-14", 6, f0(1, 2, 3));
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 80, characters 11-18", 6, f1(1)(2, 3));
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 81, characters 15-22", 6, Curry._1(f2(1, 2), 3));
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 82, characters 15-22", 6, f3(1)(2, 3));
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 83, characters 15-22", 1, utf_8_byte_length(Stdlib__Uchar.of_int(127)));
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 84, characters 15-22", 3, utf_8_byte_length(Stdlib__Uchar.of_int(2048)));
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 85, characters 15-22", 3, Arity_deopt_helper.captures_after_effect(1)(2));
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 86, characters 15-22", 3, local_module_field_result);
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 87, characters 15-22", {
+  hd: "inner",
+  tl: {
+    hd: "outer",
+    tl: /* [] */ 0
+  }
+}, effects$1.contents);
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 88, characters 15-22", 3, nested_module_field_result);
+
+eq("File \"jscomp/test/arity_deopt_test.ml\", line 89, characters 15-22", {
+  hd: "inner",
+  tl: {
+    hd: "outer",
+    tl: /* [] */ 0
+  }
+}, effects.contents);
 
 Mt.from_pair_suites("Arity_deopt_test", suites.contents);
 
@@ -93,5 +164,8 @@ module.exports = {
   f3,
   utf_8_byte_length,
   captures_after_effect,
+  Local_module_field,
+  local_module_field_result,
+  nested_module_field_result,
 }
-/*  Not a pure module */
+/* local_module_field_result Not a pure module */

--- a/jscomp/test/dist/flow_parser_reg_test.js
+++ b/jscomp/test/dist/flow_parser_reg_test.js
@@ -6766,13 +6766,13 @@ function filter_duplicate_errors(errs) {
 }
 
 function with_loc(fn, env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   const result = Curry._1(fn, env);
   const loc = env.last_loc.contents;
   const end_loc = loc !== undefined ? loc : (error$1(env, {
       TAG: /* Assertion */ 0,
       _0: "did not consume any tokens"
-    }), Curry._2(Parser_env_Peek.loc, undefined, env));
+    }), Parser_env_Peek.loc(undefined, env));
   return [
     btwn(start_loc, end_loc),
     result
@@ -6890,10 +6890,10 @@ function union(env) {
 function postfix_with(env, _t) {
   while (true) {
     const t = _t;
-    if (!(!Curry._1(Parser_env_Peek.is_line_terminator, env) && maybe(env, /* T_LBRACKET */ 5))) {
+    if (!(!Parser_env_Peek.is_line_terminator(env) && maybe(env, /* T_LBRACKET */ 5))) {
       return t;
     }
-    const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const end_loc = Parser_env_Peek.loc(undefined, env);
     token$4(env, /* T_RBRACKET */ 6);
     const loc = btwn(t[0], end_loc);
     const t_1 = {
@@ -6982,8 +6982,8 @@ function generic(env) {
 }
 
 function primary(env) {
-  const loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  const token$5 = Curry._2(Parser_env_Peek.token, undefined, env);
+  const loc = Parser_env_Peek.loc(undefined, env);
+  const token$5 = Parser_env_Peek.token(undefined, env);
   let exit = 0;
   if (/* tag */ typeof token$5 !== "object" && typeof token$5 !== "function") {
     switch (token$5) {
@@ -7006,7 +7006,7 @@ function primary(env) {
           }
         ];
       case /* T_LPAREN */ 3 :
-        const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+        const start_loc = Parser_env_Peek.loc(undefined, env);
         const _type = param_list_or_type(env);
         if (_type.TAG !== /* ParamList */ 0) {
           return _type._0;
@@ -7028,10 +7028,10 @@ function primary(env) {
           }
         ];
       case /* T_LBRACKET */ 5 :
-        const start_loc$1 = Curry._2(Parser_env_Peek.loc, undefined, env);
+        const start_loc$1 = Parser_env_Peek.loc(undefined, env);
         token$4(env, /* T_LBRACKET */ 5);
         const tl = types(env, /* [] */ 0);
-        const end_loc$1 = Curry._2(Parser_env_Peek.loc, undefined, env);
+        const end_loc$1 = Parser_env_Peek.loc(undefined, env);
         token$4(env, /* T_RBRACKET */ 6);
         return [
           btwn(start_loc$1, end_loc$1),
@@ -7045,7 +7045,7 @@ function primary(env) {
         exit = 2;
         break;
       case /* T_TYPEOF */ 44 :
-        const start_loc$2 = Curry._2(Parser_env_Peek.loc, undefined, env);
+        const start_loc$2 = Parser_env_Peek.loc(undefined, env);
         token$4(env, /* T_TYPEOF */ 44);
         const t = primary(env);
         return [
@@ -7056,7 +7056,7 @@ function primary(env) {
           }
         ];
       case /* T_LESS_THAN */ 89 :
-        const start_loc$3 = Curry._2(Parser_env_Peek.loc, undefined, env);
+        const start_loc$3 = Parser_env_Peek.loc(undefined, env);
         const typeParameters = Curry._2(type_parameter_declaration, false, env);
         const match$3 = function_param_list(env);
         token$4(env, /* T_ARROW */ 10);
@@ -7116,7 +7116,7 @@ function primary(env) {
       case /* T_NUMBER_SINGLETON_TYPE */ 5 :
         const value$1 = token$5._1;
         const number_type = token$5._0;
-        const raw$1 = Curry._2(Parser_env_Peek.value, undefined, env);
+        const raw$1 = Parser_env_Peek.value(undefined, env);
         token$4(env, {
           TAG: /* T_NUMBER_SINGLETON_TYPE */ 5,
           _0: number_type,
@@ -7156,7 +7156,7 @@ function primary(env) {
         ];
       }
     case 2 :
-      const raw$2 = Curry._2(Parser_env_Peek.value, undefined, env);
+      const raw$2 = Parser_env_Peek.value(undefined, env);
       token$4(env, token$5);
       const value$2 = Caml_obj.caml_equal(token$5, /* T_TRUE */ 29);
       return [
@@ -7196,7 +7196,7 @@ function primitive(param) {
 
 function param_list_or_type(env) {
   token$4(env, /* T_LPAREN */ 3);
-  const token$5 = Curry._2(Parser_env_Peek.token, undefined, env);
+  const token$5 = Parser_env_Peek.token(undefined, env);
   let ret;
   let exit = 0;
   if (/* tag */ typeof token$5 !== "object" && typeof token$5 !== "function") {
@@ -7229,7 +7229,7 @@ function param_list_or_type(env) {
   if (exit === 1) {
     const match = primitive(token$5);
     if (match !== undefined) {
-      const match$1 = Curry._2(Parser_env_Peek.token, 1, env);
+      const match$1 = Parser_env_Peek.token(1, env);
       let exit$1 = 0;
       if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
         switch (match$1) {
@@ -7258,7 +7258,7 @@ function param_list_or_type(env) {
         const optional = maybe(env, /* T_PLING */ 76);
         token$4(env, /* T_COLON */ 77);
         const typeAnnotation = union(env);
-        if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RPAREN */ 4)) {
+        if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RPAREN */ 4)) {
           token$4(env, /* T_COMMA */ 8);
         }
         const param_0 = btwn(name[0], typeAnnotation[0]);
@@ -7292,14 +7292,14 @@ function param_list_or_type(env) {
 }
 
 function prefix(env) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
     return postfix(env);
   }
   if (match !== /* T_PLING */ 76) {
     return postfix(env);
   }
-  const loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_PLING */ 76);
   const t = prefix(env);
   return [
@@ -7325,7 +7325,7 @@ function postfix(env) {
 
 function function_param_or_generic_type(env) {
   const id = Curry._2(Parse.identifier, undefined, env);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   let exit = 0;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
@@ -7359,14 +7359,14 @@ function function_param_or_generic_type(env) {
 }
 
 function union_with(env, left) {
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_BIT_OR */ 80)) {
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_BIT_OR */ 80)) {
     let _acc = {
       hd: left,
       tl: /* [] */ 0
     };
     while (true) {
       const acc = _acc;
-      const match = Curry._2(Parser_env_Peek.token, undefined, env);
+      const match = Parser_env_Peek.token(undefined, env);
       if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_BIT_OR */ 80) {
         token$4(env, /* T_BIT_OR */ 80);
         _acc = {
@@ -7390,14 +7390,14 @@ function union_with(env, left) {
 }
 
 function intersection_with(env, left) {
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_BIT_AND */ 82)) {
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_BIT_AND */ 82)) {
     let _acc = {
       hd: left,
       tl: /* [] */ 0
     };
     while (true) {
       const acc = _acc;
-      const match = Curry._2(Parser_env_Peek.token, undefined, env);
+      const match = Parser_env_Peek.token(undefined, env);
       if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_BIT_AND */ 82) {
         token$4(env, /* T_BIT_AND */ 82);
         _acc = {
@@ -7430,7 +7430,7 @@ function function_param_list_without_parens(env) {
     let _acc = param$1;
     while (true) {
       const acc = _acc;
-      const t = Curry._2(Parser_env_Peek.token, undefined, env);
+      const t = Parser_env_Peek.token(undefined, env);
       let exit = 0;
       if (/* tag */ typeof t !== "object" && typeof t !== "function") {
         switch (t) {
@@ -7452,7 +7452,7 @@ function function_param_list_without_parens(env) {
             hd: acc_0,
             tl: acc
           };
-          if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RPAREN */ 4)) {
+          if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RPAREN */ 4)) {
             token$4(env, /* T_COMMA */ 8);
           }
           _acc = acc$1;
@@ -7473,7 +7473,7 @@ function identifier(env, _param) {
     const param = _param;
     const qualification = param[1];
     const q_loc = param[0];
-    if (!Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_PERIOD */ 9)) {
+    if (!Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_PERIOD */ 9)) {
       return [
         q_loc,
         qualification
@@ -7564,7 +7564,7 @@ function method_property(env, start_loc, $$static, key) {
 }
 
 function call_property(env, start_loc, $$static) {
-  const value = methodish(env, Curry._2(Parser_env_Peek.loc, undefined, env));
+  const value = methodish(env, Parser_env_Peek.loc(undefined, env));
   return [
     btwn(start_loc, value[0]),
     {
@@ -7613,7 +7613,7 @@ function indexer_property(env, start_loc, $$static) {
 }
 
 function semicolon$1(env) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
     return error_unexpected(env);
   }
@@ -7634,9 +7634,9 @@ function properties(allow_static, env, _param) {
     const callProperties = param[2];
     const indexers = param[1];
     const acc = param[0];
-    const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const start_loc = Parser_env_Peek.loc(undefined, env);
     const $$static = allow_static && maybe(env, /* T_STATIC */ 40);
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     let exit = 0;
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
@@ -7668,7 +7668,7 @@ function properties(allow_static, env, _param) {
     }
     switch (exit) {
       case 1 :
-        const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+        const match$1 = Parser_env_Peek.token(undefined, env);
         let match$2;
         let exit$1 = 0;
         if ($$static && /* tag */ typeof match$1 !== "object" && typeof match$1 !== "function" && match$1 === /* T_COLON */ 77) {
@@ -7709,7 +7709,7 @@ function properties(allow_static, env, _param) {
         }
         const key$1 = match$2[1][1];
         const $$static$1 = match$2[0];
-        const match$3 = Curry._2(Parser_env_Peek.token, undefined, env);
+        const match$3 = Parser_env_Peek.token(undefined, env);
         let property$1;
         if (/* tag */ typeof match$3 !== "object" && typeof match$3 !== "function") {
           switch (match$3) {
@@ -7757,14 +7757,14 @@ function properties(allow_static, env, _param) {
 
 function _object(allow_staticOpt, env) {
   const allow_static = allow_staticOpt !== undefined ? allow_staticOpt : false;
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LCURLY */ 1);
   const match = properties(allow_static, env, [
     /* [] */ 0,
     /* [] */ 0,
     /* [] */ 0
   ]);
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RCURLY */ 2);
   return [
     btwn(start_loc, end_loc),
@@ -7779,7 +7779,7 @@ function _object(allow_staticOpt, env) {
 function types(env, _acc) {
   while (true) {
     const acc = _acc;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_RBRACKET */ 6 :
@@ -7792,7 +7792,7 @@ function types(env, _acc) {
       hd: acc_0,
       tl: acc
     };
-    if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RBRACKET */ 6)) {
+    if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RBRACKET */ 6)) {
       token$4(env, /* T_COMMA */ 8);
     }
     _acc = acc$1;
@@ -7803,7 +7803,7 @@ function types(env, _acc) {
 function params(env, _acc) {
   while (true) {
     const acc = _acc;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_GREATER_THAN */ 90 :
@@ -7816,7 +7816,7 @@ function params(env, _acc) {
       hd: acc_0,
       tl: acc
     };
-    if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_GREATER_THAN */ 90)) {
+    if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_GREATER_THAN */ 90)) {
       token$4(env, /* T_COMMA */ 8);
     }
     _acc = acc$1;
@@ -7825,13 +7825,13 @@ function params(env, _acc) {
 }
 
 function type_parameter_instantiation(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  if (!Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_LESS_THAN */ 89)) {
+  const start_loc = Parser_env_Peek.loc(undefined, env);
+  if (!Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_LESS_THAN */ 89)) {
     return;
   }
   token$4(env, /* T_LESS_THAN */ 89);
   const params$1 = params(env, /* [] */ 0);
-  const loc = btwn(start_loc, Curry._2(Parser_env_Peek.loc, undefined, env));
+  const loc = btwn(start_loc, Parser_env_Peek.loc(undefined, env));
   token$4(env, /* T_GREATER_THAN */ 90);
   return [
     loc,
@@ -7845,7 +7845,7 @@ function params$1(env, allow_default, _require_default, _acc) {
   while (true) {
     const acc = _acc;
     const require_default = _require_default;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     let variance;
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
@@ -7866,7 +7866,7 @@ function params$1(env, allow_default, _require_default, _acc) {
     const match$1 = Curry._2(Parse.identifier_with_type, env, /* StrictParamName */ 28);
     const id = match$1[1];
     const loc = match$1[0];
-    const match$2 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match$2 = Parser_env_Peek.token(undefined, env);
     let match$3;
     if (allow_default) {
       let exit = 0;
@@ -7912,7 +7912,7 @@ function params$1(env, allow_default, _require_default, _acc) {
       hd: param,
       tl: acc
     };
-    const match$4 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match$4 = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match$4 !== "object" && typeof match$4 !== "function") {
       switch (match$4) {
         case /* T_GREATER_THAN */ 90 :
@@ -7921,7 +7921,7 @@ function params$1(env, allow_default, _require_default, _acc) {
       }
     }
     token$4(env, /* T_COMMA */ 8);
-    if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_GREATER_THAN */ 90)) {
+    if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_GREATER_THAN */ 90)) {
       return Stdlib__List.rev(acc$1);
     }
     _acc = acc$1;
@@ -7931,8 +7931,8 @@ function params$1(env, allow_default, _require_default, _acc) {
 }
 
 function type_parameter_declaration(allow_default, env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  if (!Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_LESS_THAN */ 89)) {
+  const start_loc = Parser_env_Peek.loc(undefined, env);
+  if (!Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_LESS_THAN */ 89)) {
     return;
   }
   if (!env.parse_options.types) {
@@ -7940,7 +7940,7 @@ function type_parameter_declaration(allow_default, env) {
   }
   token$4(env, /* T_LESS_THAN */ 89);
   const params$2 = params$1(env, allow_default, false, /* [] */ 0);
-  const loc = btwn(start_loc, Curry._2(Parser_env_Peek.loc, undefined, env));
+  const loc = btwn(start_loc, Parser_env_Peek.loc(undefined, env));
   token$4(env, /* T_GREATER_THAN */ 90);
   return [
     loc,
@@ -7956,7 +7956,7 @@ function annotation(env) {
   if (!env.parse_options.types) {
     error$1(env, /* UnexpectedTypeAnnotation */ 6);
   }
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_COLON */ 77);
   const typeAnnotation = union(env);
   const loc = env.last_loc.contents;
@@ -7980,7 +7980,7 @@ function annotation(env) {
 }
 
 function annotation_opt(env) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_COLON */ 77) {
     return annotation(env);
   }
@@ -8138,7 +8138,7 @@ function strict_post_check(env, strict, simple, id, params) {
 
 function param$1(env) {
   const id = Curry._2(Parse.pattern, env, /* StrictParamName */ 28);
-  if (!Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_ASSIGN */ 75)) {
+  if (!Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_ASSIGN */ 75)) {
     return [
       id,
       undefined
@@ -8158,7 +8158,7 @@ function param_list(env, _param) {
     const has_default = param$2[2];
     const defaults = param$2[1];
     const params = param$2[0];
-    const t = Curry._2(Parser_env_Peek.token, undefined, env);
+    const t = Parser_env_Peek.token(undefined, env);
     let exit = 0;
     if (/* tag */ typeof t !== "object" && typeof t !== "function") {
       switch (t) {
@@ -8178,7 +8178,7 @@ function param_list(env, _param) {
         const match = param$1(env);
         const $$default = match[1];
         const has_default$1 = has_default || $$default !== undefined;
-        if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RPAREN */ 4)) {
+        if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RPAREN */ 4)) {
           token$4(env, /* T_COMMA */ 8);
         }
         _param = [
@@ -8195,7 +8195,7 @@ function param_list(env, _param) {
         continue;
       case 2 :
         const rest = Caml_obj.caml_equal(t, /* T_ELLIPSIS */ 11) ? (token$4(env, /* T_ELLIPSIS */ 11), Curry._2(Parse.identifier_with_type, env, /* StrictParamName */ 28)) : undefined;
-        if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RPAREN */ 4)) {
+        if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RPAREN */ 4)) {
           error$1(env, /* ParameterAfterRestParameter */ 47);
         }
         return [
@@ -8266,12 +8266,12 @@ function is_simple_function_params(params, defaults, rest) {
 }
 
 function _function(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   const async = maybe(env, /* T_ASYNC */ 61);
   token$4(env, /* T_FUNCTION */ 13);
   const generator$1 = generator(env, async);
   const match = env.in_export;
-  const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match$1 = Parser_env_Peek.token(undefined, env);
   let match$2;
   let exit = 0;
   if (match && /* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
@@ -8284,7 +8284,7 @@ function _function(env) {
         break;
       case /* T_LESS_THAN */ 89 :
         const typeParams = Curry._1(type_parameter_declaration$1, env);
-        const id = Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_LPAREN */ 3) ? undefined : Curry._2(Parse.identifier, /* StrictFunctionName */ 30, env);
+        const id = Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_LPAREN */ 3) ? undefined : Curry._2(Parse.identifier, /* StrictFunctionName */ 30, env);
         match$2 = [
           typeParams,
           id
@@ -8346,7 +8346,7 @@ function _function(env) {
 function variable_declaration(env) {
   const id = Curry._2(Parse.pattern, env, /* StrictVarName */ 27);
   let match;
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_ASSIGN */ 75)) {
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_ASSIGN */ 75)) {
     token$4(env, /* T_ASSIGN */ 75);
     match = [
       Curry._1(Parse.assignment, env),
@@ -8392,7 +8392,7 @@ function helper(env, _decls, _errs) {
       tl: decls
     };
     const errs$1 = Stdlib.$at(match[1], errs);
-    if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_COMMA */ 8)) {
+    if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_COMMA */ 8)) {
       token$4(env, /* T_COMMA */ 8);
       _errs = errs$1;
       _decls = decls$1;
@@ -8410,7 +8410,7 @@ function helper(env, _decls, _errs) {
 }
 
 function declarations(token$5, kind, env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, token$5);
   const match = helper(env, /* [] */ 0, /* [] */ 0);
   return [
@@ -8458,8 +8458,8 @@ function _let(env) {
 }
 
 function variable(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   let match$1;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
@@ -8530,7 +8530,7 @@ function is_assignable_lhs(param) {
 }
 
 function assignment_op(env) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   let op;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
@@ -8586,9 +8586,9 @@ function assignment_op(env) {
 }
 
 function conditional(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   const expr = Curry._1(logical, env);
-  if (!Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_PLING */ 76)) {
+  if (!Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_PLING */ 76)) {
     return expr;
   }
   token$4(env, /* T_PLING */ 76);
@@ -8611,7 +8611,7 @@ function conditional(env) {
 }
 
 function peek_unary_op(env) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
     return;
   }
@@ -8642,7 +8642,7 @@ function peek_unary_op(env) {
 }
 
 function unary(env) {
-  const begin_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const begin_loc = Parser_env_Peek.loc(undefined, env);
   const op = peek_unary_op(env);
   if (op !== undefined) {
     token$3(env);
@@ -8670,7 +8670,7 @@ function unary(env) {
       }
     ];
   }
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   let op$1;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
@@ -8688,10 +8688,10 @@ function unary(env) {
   }
   if (op$1 === undefined) {
     const argument$1 = left_hand_side(env);
-    if (Curry._1(Parser_env_Peek.is_line_terminator, env)) {
+    if (Parser_env_Peek.is_line_terminator(env)) {
       return argument$1;
     }
-    const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match$1 = Parser_env_Peek.token(undefined, env);
     let op$2;
     if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
       switch (match$1) {
@@ -8723,7 +8723,7 @@ function unary(env) {
       }
       
     }
-    const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const end_loc = Parser_env_Peek.loc(undefined, env);
     token$3(env);
     return [
       btwn(argument$1[0], end_loc),
@@ -8766,7 +8766,7 @@ function unary(env) {
 }
 
 function left_hand_side(env) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   let expr;
   let exit = 0;
   if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_NEW */ 42) {
@@ -8777,10 +8777,10 @@ function left_hand_side(env) {
     exit = 1;
   }
   if (exit === 1) {
-    expr = Curry._2(Parser_env_Peek.is_function, undefined, env) ? _function$1(env) : primary$1(env);
+    expr = Parser_env_Peek.is_function(undefined, env) ? _function$1(env) : primary$1(env);
   }
   const expr$1 = member(env, expr);
-  const part = Curry._2(Parser_env_Peek.token, undefined, env);
+  const part = Parser_env_Peek.token(undefined, env);
   if (/* tag */ typeof part !== "object" && typeof part !== "function") {
     if (part === /* T_LPAREN */ 3) {
       return call(env, expr$1);
@@ -8797,7 +8797,7 @@ function left_hand_side(env) {
 function call(env, _left) {
   while (true) {
     const left = _left;
-    const part = Curry._2(Parser_env_Peek.token, undefined, env);
+    const part = Parser_env_Peek.token(undefined, env);
     if (!/* tag */ (typeof part !== "object" && typeof part !== "function")) {
       if (part.TAG === /* T_TEMPLATE_PART */ 2) {
         return tagged_template(env, left, part._0);
@@ -8825,7 +8825,7 @@ function call(env, _left) {
       case /* T_LBRACKET */ 5 :
         token$4(env, /* T_LBRACKET */ 5);
         const expr = Curry._1(Parse.expression, env);
-        const last_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+        const last_loc = Parser_env_Peek.loc(undefined, env);
         const loc = btwn(left[0], last_loc);
         token$4(env, /* T_RBRACKET */ 6);
         _left = [
@@ -8871,9 +8871,9 @@ function call(env, _left) {
 function _new(env, _finish_fn) {
   while (true) {
     const finish_fn = _finish_fn;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_NEW */ 42) {
-      const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+      const start_loc = Parser_env_Peek.loc(undefined, env);
       token$4(env, /* T_NEW */ 42);
       const finish_fn$p = function (callee, args) {
         const match = args !== undefined ? [
@@ -8900,13 +8900,13 @@ function _new(env, _finish_fn) {
       _finish_fn = finish_fn$p;
       continue;
     }
-    Curry._2(Parser_env_Peek.token, undefined, env);
-    const expr = Curry._2(Parser_env_Peek.is_function, undefined, env) ? _function$1(env) : primary$1(env);
+    Parser_env_Peek.token(undefined, env);
+    const expr = Parser_env_Peek.is_function(undefined, env) ? _function$1(env) : primary$1(env);
     const callee = member(with_no_call(true, env), expr);
-    const part = Curry._2(Parser_env_Peek.token, undefined, env);
+    const part = Parser_env_Peek.token(undefined, env);
     let callee$1;
     callee$1 = /* tag */ typeof part !== "object" && typeof part !== "function" || part.TAG !== /* T_TEMPLATE_PART */ 2 ? callee : tagged_template(env, callee, part._0);
-    const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match$1 = Parser_env_Peek.token(undefined, env);
     let args;
     args = /* tag */ typeof match$1 !== "object" && typeof match$1 !== "function" && match$1 === /* T_LPAREN */ 3 ? Curry._1($$arguments, env) : undefined;
     return Curry._2(finish_fn, callee$1, args);
@@ -8914,7 +8914,7 @@ function _new(env, _finish_fn) {
 }
 
 function member(env, left) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
     return left;
   }
@@ -8922,7 +8922,7 @@ function member(env, left) {
     case /* T_LBRACKET */ 5 :
       token$4(env, /* T_LBRACKET */ 5);
       const expr = Curry._1(Parse.expression, with_no_call(false, env));
-      const last_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+      const last_loc = Parser_env_Peek.loc(undefined, env);
       token$4(env, /* T_RBRACKET */ 6);
       return call(env, [
         btwn(left[0], last_loc),
@@ -8962,18 +8962,18 @@ function member(env, left) {
 }
 
 function _function$1(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   const async = maybe(env, /* T_ASYNC */ 61);
   token$4(env, /* T_FUNCTION */ 13);
   const generator$1 = generator(env, async);
   let match;
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_LPAREN */ 3)) {
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_LPAREN */ 3)) {
     match = [
       undefined,
       undefined
     ];
   } else {
-    const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match$1 = Parser_env_Peek.token(undefined, env);
     let id;
     id = /* tag */ typeof match$1 !== "object" && typeof match$1 !== "function" && match$1 === /* T_LESS_THAN */ 89 ? undefined : Curry._2(Parse.identifier, /* StrictFunctionName */ 30, env);
     match = [
@@ -9016,7 +9016,7 @@ function _function$1(env) {
 }
 
 function number(env, number_type) {
-  const value = Curry._2(Parser_env_Peek.value, undefined, env);
+  const value = Parser_env_Peek.value(undefined, env);
   let value$1;
   switch (number_type) {
     case /* LEGACY_OCTAL */ 1 :
@@ -9049,8 +9049,8 @@ function number(env, number_type) {
 }
 
 function primary$1(env) {
-  const loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  const number_type = Curry._2(Parser_env_Peek.token, undefined, env);
+  const loc = Parser_env_Peek.loc(undefined, env);
+  const number_type = Parser_env_Peek.token(undefined, env);
   let exit = 0;
   if (/* tag */ typeof number_type !== "object" && typeof number_type !== "function") {
     switch (number_type) {
@@ -9066,7 +9066,7 @@ function primary$1(env) {
       case /* T_LPAREN */ 3 :
         token$4(env, /* T_LPAREN */ 3);
         const expression = Curry._1(assignment, env);
-        const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+        const match$1 = Parser_env_Peek.token(undefined, env);
         let ret;
         if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
           switch (match$1) {
@@ -9113,7 +9113,7 @@ function primary$1(env) {
           /* This */ 0
         ];
       case /* T_NULL */ 27 :
-        const raw = Curry._2(Parser_env_Peek.value, undefined, env);
+        const raw = Parser_env_Peek.value(undefined, env);
         token$4(env, /* T_NULL */ 27);
         return [
           loc,
@@ -9132,7 +9132,7 @@ function primary$1(env) {
       case /* T_CLASS */ 38 :
         return Curry._1(Parse.class_expression, env);
       case /* T_SUPER */ 49 :
-        const loc$1 = Curry._2(Parser_env_Peek.loc, undefined, env);
+        const loc$1 = Parser_env_Peek.loc(undefined, env);
         token$4(env, /* T_SUPER */ 49);
         const id_1 = {
           name: "super",
@@ -9162,8 +9162,8 @@ function primary$1(env) {
       case /* T_DIV_ASSIGN */ 70 :
       case /* T_DIV */ 96 :
         push_lex_mode(env, /* REGEXP */ 5);
-        const loc$2 = Curry._2(Parser_env_Peek.loc, undefined, env);
-        const match$4 = Curry._2(Parser_env_Peek.token, undefined, env);
+        const loc$2 = Parser_env_Peek.loc(undefined, env);
+        const match$4 = Parser_env_Peek.token(undefined, env);
         let match$5;
         if (/* tag */ typeof match$4 !== "object" && typeof match$4 !== "function") {
           throw new Caml_js_exceptions.MelangeError("Assert_failure", {
@@ -9177,7 +9177,7 @@ function primary$1(env) {
         }
         if (match$4.TAG === /* T_REGEXP */ 3) {
           const match$6 = match$4._0;
-          const raw$1 = Curry._2(Parser_env_Peek.value, undefined, env);
+          const raw$1 = Parser_env_Peek.value(undefined, env);
           token$3(env);
           match$5 = [
             raw$1,
@@ -9250,7 +9250,7 @@ function primary$1(env) {
   } else {
     switch (number_type.TAG) {
       case /* T_NUMBER */ 0 :
-        const raw$2 = Curry._2(Parser_env_Peek.value, undefined, env);
+        const raw$2 = Parser_env_Peek.value(undefined, env);
         const value$1 = {
           TAG: /* Number */ 2,
           _0: number(env, number_type._0)
@@ -9312,7 +9312,7 @@ function primary$1(env) {
   }
   switch (exit) {
     case 1 :
-      if (Curry._2(Parser_env_Peek.is_identifier, undefined, env)) {
+      if (Parser_env_Peek.is_identifier(undefined, env)) {
         const id$1 = Curry._2(Parse.identifier, undefined, env);
         return [
           id$1[0],
@@ -9337,7 +9337,7 @@ function primary$1(env) {
         }
       ];
     case 2 :
-      const raw$4 = Curry._2(Parser_env_Peek.value, undefined, env);
+      const raw$4 = Parser_env_Peek.value(undefined, env);
       token$4(env, number_type);
       const value$4 = {
         TAG: /* Boolean */ 1,
@@ -9373,7 +9373,7 @@ function tagged_template(env, tag, part) {
 function sequence(env, _acc) {
   while (true) {
     const acc = _acc;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_COMMA */ 8) {
       token$4(env, /* T_COMMA */ 8);
       const expr = Curry._1(assignment, env);
@@ -9399,9 +9399,9 @@ function sequence(env, _acc) {
 }
 
 function identifier_or_reserved_keyword(env) {
-  const lex_token = Curry._2(Parser_env_Peek.token, undefined, env);
-  const lex_value = Curry._2(Parser_env_Peek.value, undefined, env);
-  const lex_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const lex_token = Parser_env_Peek.token(undefined, env);
+  const lex_value = Parser_env_Peek.value(undefined, env);
+  const lex_loc = Parser_env_Peek.loc(undefined, env);
   let exit = 0;
   if (/* tag */ typeof lex_token !== "object" && typeof lex_token !== "function") {
     switch (lex_token) {
@@ -9561,7 +9561,7 @@ function error_callback(param, param$1) {
 function try_assignment_but_not_arrow_function(env) {
   const env$1 = with_error_callback(error_callback, env);
   const ret = assignment_but_not_arrow_function(env$1);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env$1);
+  const match = Parser_env_Peek.token(undefined, env$1);
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
       case /* T_ARROW */ 10 :
@@ -9571,10 +9571,10 @@ function try_assignment_but_not_arrow_function(env) {
           });
     }
   }
-  if (!Curry._2(Parser_env_Peek.is_identifier, undefined, env$1)) {
+  if (!Parser_env_Peek.is_identifier(undefined, env$1)) {
     return ret;
   }
-  if (Curry._2(Parser_env_Peek.value, undefined, env$1) === "checks") {
+  if (Parser_env_Peek.value(undefined, env$1) === "checks") {
     throw new Caml_js_exceptions.MelangeError(Parser_env_Try.Rollback, {
         MEL_EXN_ID: Parser_env_Try.Rollback
       });
@@ -9589,7 +9589,7 @@ function try_assignment_but_not_arrow_function(env) {
   if (match$1._0[1].name !== "async") {
     return ret;
   }
-  if (!Curry._1(Parser_env_Peek.is_line_terminator, env$1)) {
+  if (!Parser_env_Peek.is_line_terminator(env$1)) {
     throw new Caml_js_exceptions.MelangeError(Parser_env_Try.Rollback, {
         MEL_EXN_ID: Parser_env_Try.Rollback
       });
@@ -9598,26 +9598,26 @@ function try_assignment_but_not_arrow_function(env) {
 }
 
 function assignment(env) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
-  const match$1 = Curry._2(Parser_env_Peek.is_identifier, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
+  const match$1 = Parser_env_Peek.is_identifier(undefined, env);
   let exit = 0;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
       case /* T_YIELD */ 56 :
         if (env.allow_yield) {
-          const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_YIELD */ 56);
           if (!env.allow_yield) {
             error$1(env, /* IllegalYield */ 24);
           }
           const delegate = maybe(env, /* T_MULT */ 97);
-          const has_argument = !(Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_SEMICOLON */ 7) || Curry._1(Parser_env_Peek.is_implicit_semicolon, env));
+          const has_argument = !(Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_SEMICOLON */ 7) || Parser_env_Peek.is_implicit_semicolon(env));
           const argument = delegate || has_argument ? Curry._1(assignment, env) : undefined;
           let end_loc;
           if (argument !== undefined) {
             end_loc = argument[0];
           } else {
-            const loc = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+            const loc = Parser_env_Peek.semicolon_loc(undefined, env);
             const end_loc$1 = loc !== undefined ? loc : start_loc;
             semicolon(env);
             end_loc = end_loc$1;
@@ -9647,11 +9647,11 @@ function assignment(env) {
   if (exit === 2 && !match$1) {
     return assignment_but_not_arrow_function(env);
   }
-  const expr = Curry._2(Parser_env_Try.to_parse, env, try_assignment_but_not_arrow_function);
+  const expr = Parser_env_Try.to_parse(env, try_assignment_but_not_arrow_function);
   if (!/* tag */ (typeof expr !== "object" && typeof expr !== "function")) {
     return expr._0;
   }
-  const expr$1 = Curry._2(Parser_env_Try.to_parse, env, try_arrow_function);
+  const expr$1 = Parser_env_Try.to_parse(env, try_arrow_function);
   if (/* tag */ typeof expr$1 !== "object" && typeof expr$1 !== "function") {
     return assignment_but_not_arrow_function(env);
   } else {
@@ -9677,7 +9677,7 @@ function logical_and(env, _left, _lloc) {
   while (true) {
     const lloc = _lloc;
     const left = _left;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
       return [
         lloc,
@@ -9703,7 +9703,7 @@ function logical_or(env, _left, _lloc) {
   while (true) {
     const lloc = _lloc;
     const left = _left;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
       return [
         lloc,
@@ -9733,7 +9733,7 @@ function logical(env) {
 }
 
 function binary_op(env) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   let ret;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
@@ -10004,13 +10004,13 @@ function binary(env) {
   let _stack = /* [] */ 0;
   while (true) {
     const stack = _stack;
-    const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const start_loc = Parser_env_Peek.loc(undefined, env);
     const is_unary = peek_unary_op(env) !== undefined;
     const right = unary(with_no_in(false, env));
     const loc = env.last_loc.contents;
     const end_loc = loc !== undefined ? loc : right[0];
     const right_loc = btwn(start_loc, end_loc);
-    if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_LESS_THAN */ 89)) {
+    if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_LESS_THAN */ 89)) {
       let tmp = right[1];
       if (!/* tag */ (typeof tmp !== "object" && typeof tmp !== "function") && tmp.TAG === /* JSXElement */ 22) {
         error$1(env, /* AdjacentJSXElements */ 46);
@@ -10053,7 +10053,7 @@ function binary(env) {
 }
 
 function argument(env) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
     return {
       TAG: /* Expression */ 0,
@@ -10066,7 +10066,7 @@ function argument(env) {
       _0: Curry._1(assignment, env)
     };
   }
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_ELLIPSIS */ 11);
   const argument$1 = Curry._1(assignment, env);
   const loc = btwn(start_loc, argument$1[0]);
@@ -10084,7 +10084,7 @@ function argument(env) {
 function arguments$p(env, _acc) {
   while (true) {
     const acc = _acc;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_RPAREN */ 4 :
@@ -10097,7 +10097,7 @@ function arguments$p(env, _acc) {
       hd: acc_0,
       tl: acc
     };
-    if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RPAREN */ 4)) {
+    if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RPAREN */ 4)) {
       token$4(env, /* T_COMMA */ 8);
     }
     _acc = acc$1;
@@ -10106,10 +10106,10 @@ function arguments$p(env, _acc) {
 }
 
 function $$arguments(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LPAREN */ 3);
   const args = arguments$p(env, /* [] */ 0);
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RPAREN */ 4);
   return [
     btwn(start_loc, end_loc),
@@ -10126,10 +10126,10 @@ function template_parts(env, _quasis, _expressions) {
       hd: expr,
       tl: expressions
     };
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_RCURLY */ 2) {
       push_lex_mode(env, /* TEMPLATE */ 4);
-      const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+      const match$1 = Parser_env_Peek.token(undefined, env);
       let match$2;
       if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
         throw new Caml_js_exceptions.MelangeError("Assert_failure", {
@@ -10255,7 +10255,7 @@ function template_literal(env, part) {
 function elements(env, _acc) {
   while (true) {
     const acc = _acc;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_COMMA */ 8 :
@@ -10266,7 +10266,7 @@ function elements(env, _acc) {
           };
           continue;
         case /* T_ELLIPSIS */ 11 :
-          const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_ELLIPSIS */ 11);
           const argument = Curry._1(assignment, env);
           const loc = btwn(start_loc, argument[0]);
@@ -10293,7 +10293,7 @@ function elements(env, _acc) {
       TAG: /* Expression */ 0,
       _0: Curry._1(assignment, env)
     };
-    if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RBRACKET */ 6)) {
+    if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RBRACKET */ 6)) {
       token$4(env, /* T_COMMA */ 8);
     }
     _acc = {
@@ -10305,10 +10305,10 @@ function elements(env, _acc) {
 }
 
 function array_initializer(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LBRACKET */ 5);
   const elements$1 = elements(env, /* [] */ 0);
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RBRACKET */ 6);
   return [
     btwn(start_loc, end_loc),
@@ -10339,11 +10339,11 @@ function error_callback$1(param, param$1) {
 
 function try_arrow_function(env) {
   const env$1 = with_error_callback(error_callback$1, env);
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env$1);
-  const async = Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, 1, env$1), /* T_ARROW */ 10) && maybe(env$1, /* T_ASYNC */ 61);
+  const start_loc = Parser_env_Peek.loc(undefined, env$1);
+  const async = Caml_obj.caml_notequal(Parser_env_Peek.token(1, env$1), /* T_ARROW */ 10) && maybe(env$1, /* T_ASYNC */ 61);
   const typeParameters = Curry._1(type_parameter_declaration$1, env$1);
   let match;
-  if (Curry._2(Parser_env_Peek.is_identifier, undefined, env$1) && typeParameters === undefined) {
+  if (Parser_env_Peek.is_identifier(undefined, env$1) && typeParameters === undefined) {
     const id = Curry._2(Parse.identifier, /* StrictParamName */ 28, env$1);
     const param_0 = id[0];
     const param_1 = {
@@ -10377,7 +10377,7 @@ function try_arrow_function(env) {
   const params = match[0];
   const predicate = Curry._1(Parse.predicate, env$1);
   const env$2 = Caml_obj.caml_equal(params, /* [] */ 0) || rest !== undefined ? without_error_callback(env$1) : env$1;
-  if (Curry._1(Parser_env_Peek.is_line_terminator, env$2) && Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env$2), /* T_ARROW */ 10)) {
+  if (Parser_env_Peek.is_line_terminator(env$2) && Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env$2), /* T_ARROW */ 10)) {
     error$1(env$2, /* NewlineBeforeArrow */ 44);
   }
   token$4(env$2, /* T_ARROW */ 10);
@@ -10385,7 +10385,7 @@ function try_arrow_function(env) {
   const match$2 = with_loc((function (param) {
     let generator = false;
     const env = with_in_function(true, param);
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_LCURLY */ 1) {
       const match$1 = function_body(env, async, generator);
       return [
@@ -10434,7 +10434,7 @@ function try_arrow_function(env) {
 function decorator_list_helper(env, _decorators) {
   while (true) {
     const decorators = _decorators;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
       return decorators;
     }
@@ -10459,13 +10459,13 @@ function decorator_list(env) {
 }
 
 function key(env) {
-  const number_type = Curry._2(Parser_env_Peek.token, undefined, env);
+  const number_type = Parser_env_Peek.token(undefined, env);
   if (/* tag */ typeof number_type !== "object" && typeof number_type !== "function") {
     if (number_type === /* T_LBRACKET */ 5) {
-      const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+      const start_loc = Parser_env_Peek.loc(undefined, env);
       token$4(env, /* T_LBRACKET */ 5);
       const expr = Curry._1(Parse.assignment, with_no_in(false, env));
-      const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+      const end_loc = Parser_env_Peek.loc(undefined, env);
       token$4(env, /* T_RBRACKET */ 6);
       return [
         btwn(start_loc, end_loc),
@@ -10479,8 +10479,8 @@ function key(env) {
   } else {
     switch (number_type.TAG) {
       case /* T_NUMBER */ 0 :
-        const raw = Curry._2(Parser_env_Peek.value, undefined, env);
-        const loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+        const raw = Parser_env_Peek.value(undefined, env);
+        const loc = Parser_env_Peek.loc(undefined, env);
         const value = number(env, number_type._0);
         const value$1 = {
           TAG: /* Number */ 2,
@@ -10628,8 +10628,8 @@ function _method(env, kind) {
 }
 
 function property$1(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_ELLIPSIS */ 11)) {
+  const start_loc = Parser_env_Peek.loc(undefined, env);
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_ELLIPSIS */ 11)) {
     token$4(env, /* T_ELLIPSIS */ 11);
     const argument = Curry._1(Parse.assignment, env);
     return {
@@ -10642,7 +10642,7 @@ function property$1(env) {
       ]
     };
   }
-  const async = Curry._2(Parser_env_Peek.is_identifier, 1, env) && maybe(env, /* T_ASYNC */ 61);
+  const async = Parser_env_Peek.is_identifier(1, env) && maybe(env, /* T_ASYNC */ 61);
   const match = generator(env, async);
   const match$1 = key(env);
   let tmp;
@@ -10655,7 +10655,7 @@ function property$1(env) {
       case /* Identifier */ 1 :
         switch (key$1._0[1].name) {
           case "get" :
-            const match$2 = Curry._2(Parser_env_Peek.token, undefined, env);
+            const match$2 = Parser_env_Peek.token(undefined, env);
             let exit$1 = 0;
             if (/* tag */ typeof match$2 !== "object" && typeof match$2 !== "function") {
               switch (match$2) {
@@ -10675,7 +10675,7 @@ function property$1(env) {
             }
             break;
           case "set" :
-            const match$3 = Curry._2(Parser_env_Peek.token, undefined, env);
+            const match$3 = Parser_env_Peek.token(undefined, env);
             let exit$2 = 0;
             if (/* tag */ typeof match$3 !== "object" && typeof match$3 !== "function") {
               switch (match$3) {
@@ -10762,7 +10762,7 @@ function set(env, start_loc) {
 }
 
 function init(env, start_loc, key, async, generator) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   let match$1;
   let exit = 0;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
@@ -11009,7 +11009,7 @@ function properties$1(env, _param) {
   while (true) {
     const param = _param;
     const acc = param[1];
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_RCURLY */ 2 :
@@ -11019,7 +11019,7 @@ function properties$1(env, _param) {
     }
     const prop = property$1(env);
     const prop_map = check_property(env, param[0], prop);
-    if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RCURLY */ 2)) {
+    if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RCURLY */ 2)) {
       token$4(env, /* T_COMMA */ 8);
     }
     _param = [
@@ -11034,13 +11034,13 @@ function properties$1(env, _param) {
 }
 
 function _initializer(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LCURLY */ 1);
   const props = properties$1(env, [
     /* Empty */ 0,
     /* [] */ 0
   ]);
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RCURLY */ 2);
   return [
     btwn(start_loc, end_loc),
@@ -11068,7 +11068,7 @@ function class_implements(env, _acc) {
       hd: implement,
       tl: acc
     };
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
       return Stdlib__List.rev(acc$1);
     }
@@ -11118,7 +11118,7 @@ function set$1(env, start_loc, decorators, $$static) {
 }
 
 function init$1(env, start_loc, decorators, key, async, generator, $$static) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   let exit = 0;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
@@ -11132,9 +11132,9 @@ function init$1(env, start_loc, decorators, key, async, generator, $$static) {
   if (exit === 2 && !async && !generator) {
     const typeAnnotation = wrap(annotation_opt, env);
     const options = env.parse_options;
-    const value = Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_ASSIGN */ 75) && ($$static && options.esproposal_class_static_fields || !$$static && options.esproposal_class_instance_fields) ? (token$4(env, /* T_ASSIGN */ 75), Curry._1(Parse.expression, env)) : undefined;
-    const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-    if (maybe(env, /* T_SEMICOLON */ 7) || !(Curry._2(Parser_env_Peek.token, undefined, env) === /* T_LBRACKET */ 5 || Curry._2(Parser_env_Peek.token, undefined, env) === /* T_LPAREN */ 3)) {
+    const value = Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_ASSIGN */ 75) && ($$static && options.esproposal_class_static_fields || !$$static && options.esproposal_class_instance_fields) ? (token$4(env, /* T_ASSIGN */ 75), Curry._1(Parse.expression, env)) : undefined;
+    const end_loc = Parser_env_Peek.loc(undefined, env);
+    if (maybe(env, /* T_SEMICOLON */ 7) || !(Parser_env_Peek.token(undefined, env) === /* T_LBRACKET */ 5 || Parser_env_Peek.token(undefined, env) === /* T_LPAREN */ 3)) {
       
     } else {
       error_unexpected(env);
@@ -11218,10 +11218,10 @@ function init$1(env, start_loc, decorators, key, async, generator, $$static) {
 }
 
 function class_element(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   const decorators = decorator_list(env);
   const $$static = maybe(env, /* T_STATIC */ 40);
-  const async = Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, 1, env), /* T_LPAREN */ 3) && Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, 1, env), /* T_COLON */ 77) && maybe(env, /* T_ASYNC */ 61);
+  const async = Caml_obj.caml_notequal(Parser_env_Peek.token(1, env), /* T_LPAREN */ 3) && Caml_obj.caml_notequal(Parser_env_Peek.token(1, env), /* T_COLON */ 77) && maybe(env, /* T_ASYNC */ 61);
   const generator$1 = generator(env, async);
   const match = key(env);
   if (!async && !generator$1) {
@@ -11230,7 +11230,7 @@ function class_element(env) {
       case /* Identifier */ 1 :
         switch (key$1._0[1].name) {
           case "get" :
-            const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+            const match$1 = Parser_env_Peek.token(undefined, env);
             let exit = 0;
             if (!/* tag */ (typeof match$1 !== "object" && typeof match$1 !== "function")) {
               return get$1(env, start_loc, decorators, $$static);
@@ -11251,7 +11251,7 @@ function class_element(env) {
             }
             break;
           case "set" :
-            const match$2 = Curry._2(Parser_env_Peek.token, undefined, env);
+            const match$2 = Parser_env_Peek.token(undefined, env);
             let exit$1 = 0;
             if (!/* tag */ (typeof match$2 !== "object" && typeof match$2 !== "function")) {
               return set$1(env, start_loc, decorators, $$static);
@@ -11284,7 +11284,7 @@ function class_element(env) {
 function elements$1(env, _acc) {
   while (true) {
     const acc = _acc;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_SEMICOLON */ 7 :
@@ -11311,10 +11311,10 @@ function elements$1(env, _acc) {
 }
 
 function class_body(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LCURLY */ 1);
   const body = elements$1(env, /* [] */ 0);
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RCURLY */ 2);
   return [
     btwn(start_loc, end_loc),
@@ -11326,7 +11326,7 @@ function class_body(env) {
 
 function _class(env) {
   let match;
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_EXTENDS */ 39)) {
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_EXTENDS */ 39)) {
     token$4(env, /* T_EXTENDS */ 39);
     const superClass = left_hand_side(with_allow_yield(false, env));
     const superTypeParameters = wrap(type_parameter_instantiation, env);
@@ -11340,7 +11340,7 @@ function _class(env) {
       undefined
     ];
   }
-  const $$implements = Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_IMPLEMENTS */ 50) ? (!env.parse_options.types ? error$1(env, /* UnexpectedTypeInterface */ 10) : undefined, token$4(env, /* T_IMPLEMENTS */ 50), class_implements(env, /* [] */ 0)) : /* [] */ 0;
+  const $$implements = Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_IMPLEMENTS */ 50) ? (!env.parse_options.types ? error$1(env, /* UnexpectedTypeInterface */ 10) : undefined, token$4(env, /* T_IMPLEMENTS */ 50), class_implements(env, /* [] */ 0)) : /* [] */ 0;
   const body = Curry._1(class_body, env);
   return [
     body,
@@ -11352,12 +11352,12 @@ function _class(env) {
 
 function class_declaration(env, decorators) {
   const env$1 = with_strict(true, env);
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env$1);
+  const start_loc = Parser_env_Peek.loc(undefined, env$1);
   const decorators$1 = Stdlib.$at(decorators, decorator_list(env$1));
   token$4(env$1, /* T_CLASS */ 38);
   const tmp_env = with_no_let(true, env$1);
   const match = env$1.in_export;
-  const match$1 = Curry._2(Parser_env_Peek.is_identifier, undefined, tmp_env);
+  const match$1 = Parser_env_Peek.is_identifier(undefined, tmp_env);
   const id = match && !match$1 ? undefined : Curry._2(Parse.identifier, undefined, tmp_env);
   const typeParameters = Curry._1(type_parameter_declaration_with_defaults, env$1);
   const match$2 = _class(env$1);
@@ -11381,10 +11381,10 @@ function class_declaration(env, decorators) {
 }
 
 function class_expression(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   const decorators = decorator_list(env);
   token$4(env, /* T_CLASS */ 38);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   let match$1;
   let exit = 0;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
@@ -11434,7 +11434,7 @@ function class_expression(env) {
 function declare_function(env, start_loc) {
   token$4(env, /* T_FUNCTION */ 13);
   const id = Curry._2(Parse.identifier, undefined, env);
-  const start_sig_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_sig_loc = Parser_env_Peek.loc(undefined, env);
   const typeParameters = Curry._1(type_parameter_declaration$1, env);
   const match = wrap(function_param_list, env);
   token$4(env, /* T_COLON */ 77);
@@ -11469,7 +11469,7 @@ function declare_function(env, start_loc) {
     id_0,
     id_1
   ];
-  const end_loc$1 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+  const end_loc$1 = Parser_env_Peek.semicolon_loc(undefined, env);
   const end_loc$2 = end_loc$1 !== undefined ? end_loc$1 : end_loc;
   const predicate = Curry._1(Parse.predicate, env);
   semicolon(env);
@@ -11485,7 +11485,7 @@ function declare_function(env, start_loc) {
 
 function expression(env) {
   const expression$1 = Curry._1(Parse.expression, env);
-  const loc = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+  const loc = Parser_env_Peek.semicolon_loc(undefined, env);
   const end_loc = loc !== undefined ? loc : expression$1[0];
   semicolon(env);
   return [
@@ -11502,7 +11502,7 @@ function expression(env) {
 function declare_var(env, start_loc) {
   token$4(env, /* T_VAR */ 22);
   const id = Curry._2(Parse.identifier_with_type, env, /* StrictVarName */ 27);
-  const loc = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+  const loc = Parser_env_Peek.semicolon_loc(undefined, env);
   const end_loc = loc !== undefined ? loc : id[0];
   const loc$1 = btwn(start_loc, end_loc);
   semicolon(env);
@@ -11518,7 +11518,7 @@ function export_specifiers_and_errs(env, _specifiers, _errs) {
   while (true) {
     const errs = _errs;
     const specifiers = _specifiers;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_RCURLY */ 2 :
@@ -11532,7 +11532,7 @@ function export_specifiers_and_errs(env, _specifiers, _errs) {
     const match$1 = Curry._1(Parse.identifier_or_reserved_keyword, env);
     const id = match$1[0];
     let match$2;
-    if (Curry._2(Parser_env_Peek.value, undefined, env) === "as") {
+    if (Parser_env_Peek.value(undefined, env) === "as") {
       contextual(env, "as");
       const match$3 = Curry._1(Parse.identifier_or_reserved_keyword, env);
       const name = match$3[0];
@@ -11567,7 +11567,7 @@ function export_specifiers_and_errs(env, _specifiers, _errs) {
       loc$1,
       specifier_1
     ];
-    if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_COMMA */ 8)) {
+    if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_COMMA */ 8)) {
       token$4(env, /* T_COMMA */ 8);
     }
     const errs$1 = err !== undefined ? ({
@@ -11584,7 +11584,7 @@ function export_specifiers_and_errs(env, _specifiers, _errs) {
 }
 
 function type_alias_helper(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   if (!env.parse_options.types) {
     error$1(env, /* UnexpectedTypeAlias */ 5);
   }
@@ -11594,7 +11594,7 @@ function type_alias_helper(env) {
   const typeParameters = Curry._1(type_parameter_declaration_with_defaults, env);
   token$4(env, /* T_ASSIGN */ 75);
   const right = wrap(_type, env);
-  const end_loc = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+  const end_loc = Parser_env_Peek.semicolon_loc(undefined, env);
   const end_loc$1 = end_loc !== undefined ? end_loc : right[0];
   semicolon(env);
   pop_lex_mode(env);
@@ -11610,7 +11610,7 @@ function type_alias_helper(env) {
 
 function export_source(env) {
   contextual(env, "from");
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function") && match.TAG === /* T_STRING */ 1) {
     const match$1 = match._0;
     const octal = match$1[3];
@@ -11641,12 +11641,12 @@ function export_source(env) {
       }
     ];
   }
-  const raw$1 = Curry._2(Parser_env_Peek.value, undefined, env);
+  const raw$1 = Parser_env_Peek.value(undefined, env);
   const value$2 = {
     TAG: /* String */ 0,
     _0: raw$1
   };
-  const ret_0 = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const ret_0 = Parser_env_Peek.loc(undefined, env);
   const ret_1 = {
     value: value$2,
     raw: raw$1
@@ -11660,7 +11660,7 @@ function export_source(env) {
 }
 
 function type_alias(env) {
-  if (!Curry._2(Parser_env_Peek.is_identifier, 1, env)) {
+  if (!Parser_env_Peek.is_identifier(1, env)) {
     return Curry._1(Parse.statement, env);
   }
   const match = type_alias_helper(env);
@@ -11696,7 +11696,7 @@ function declare_function_statement(env, start_loc) {
 }
 
 function $$interface(env) {
-  if (!Curry._2(Parser_env_Peek.is_identifier, 1, env)) {
+  if (!Parser_env_Peek.is_identifier(1, env)) {
     return expression(env);
   }
   const match = Curry._1(interface_helper, env);
@@ -11714,17 +11714,17 @@ function declare_export_declaration(allow_export_typeOpt, env) {
   if (!env.parse_options.types) {
     error$1(env, /* UnexpectedTypeDeclaration */ 7);
   }
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_DECLARE */ 58);
   const env$1 = with_in_export(true, with_strict(true, env));
   token$4(env$1, /* T_EXPORT */ 47);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env$1);
+  const match = Parser_env_Peek.token(undefined, env$1);
   let exit = 0;
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
       case /* T_DEFAULT */ 34 :
         token$4(env$1, /* T_DEFAULT */ 34);
-        const match$1 = Curry._2(Parser_env_Peek.token, undefined, env$1);
+        const match$1 = Parser_env_Peek.token(undefined, env$1);
         let match$2;
         let exit$1 = 0;
         if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
@@ -11757,7 +11757,7 @@ function declare_export_declaration(allow_export_typeOpt, env) {
         }
         if (exit$1 === 3) {
           const _type$1 = wrap(_type, env$1);
-          const loc = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env$1);
+          const loc = Parser_env_Peek.semicolon_loc(undefined, env$1);
           const end_loc = loc !== undefined ? loc : _type$1[0];
           semicolon(env$1);
           match$2 = [
@@ -11840,17 +11840,17 @@ function declare_export_declaration(allow_export_typeOpt, env) {
         exit = 1;
         break;
       case /* T_MULT */ 97 :
-        const loc$3 = Curry._2(Parser_env_Peek.loc, undefined, env$1);
+        const loc$3 = Parser_env_Peek.loc(undefined, env$1);
         token$4(env$1, /* T_MULT */ 97);
         const parse_export_star_as = env$1.parse_options.esproposal_export_star_as;
-        const local_name = Curry._2(Parser_env_Peek.value, undefined, env$1) === "as" ? (contextual(env$1, "as"), parse_export_star_as ? Curry._2(Parse.identifier, undefined, env$1) : (error$1(env$1, /* UnexpectedTypeDeclaration */ 7), undefined)) : undefined;
+        const local_name = Parser_env_Peek.value(undefined, env$1) === "as" ? (contextual(env$1, "as"), parse_export_star_as ? Curry._2(Parse.identifier, undefined, env$1) : (error$1(env$1, /* UnexpectedTypeDeclaration */ 7), undefined)) : undefined;
         const specifiers = {
           TAG: /* ExportBatchSpecifier */ 1,
           _0: loc$3,
           _1: local_name
         };
         const source = export_source(env$1);
-        const loc$4 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env$1);
+        const loc$4 = Parser_env_Peek.semicolon_loc(undefined, env$1);
         const end_loc$1 = loc$4 !== undefined ? loc$4 : source[0];
         const source$1 = source;
         semicolon(env$1);
@@ -11874,7 +11874,7 @@ function declare_export_declaration(allow_export_typeOpt, env) {
   }
   switch (exit) {
     case 1 :
-      const match$5 = Curry._2(Parser_env_Peek.token, undefined, env$1);
+      const match$5 = Parser_env_Peek.token(undefined, env$1);
       if (/* tag */ typeof match$5 !== "object" && typeof match$5 !== "function") {
         switch (match$5) {
           case /* T_INTERFACE */ 51 :
@@ -11891,12 +11891,12 @@ function declare_export_declaration(allow_export_typeOpt, env) {
         TAG: /* ExportSpecifiers */ 0,
         _0: match$6[0]
       };
-      const end_loc$2 = Curry._2(Parser_env_Peek.loc, undefined, env$1);
+      const end_loc$2 = Parser_env_Peek.loc(undefined, env$1);
       token$4(env$1, /* T_RCURLY */ 2);
-      const source$2 = Curry._2(Parser_env_Peek.value, undefined, env$1) === "from" ? export_source(env$1) : (Stdlib__List.iter((function (param) {
+      const source$2 = Parser_env_Peek.value(undefined, env$1) === "from" ? export_source(env$1) : (Stdlib__List.iter((function (param) {
           return error_at(env$1, param);
         }), match$6[1]), undefined);
-      const loc$5 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env$1);
+      const loc$5 = Parser_env_Peek.semicolon_loc(undefined, env$1);
       const end_loc$3 = loc$5 !== undefined ? loc$5 : (
           source$2 !== undefined ? source$2[0] : end_loc$2
         );
@@ -11914,7 +11914,7 @@ function declare_export_declaration(allow_export_typeOpt, env) {
         }
       ];
     case 2 :
-      const token$5 = Curry._2(Parser_env_Peek.token, undefined, env$1);
+      const token$5 = Parser_env_Peek.token(undefined, env$1);
       let match$7;
       let exit$2 = 0;
       if (/* tag */ typeof token$5 !== "object" && typeof token$5 !== "function") {
@@ -12004,19 +12004,19 @@ function declare(in_moduleOpt, env) {
   if (!env.parse_options.types) {
     error$1(env, /* UnexpectedTypeDeclaration */ 7);
   }
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  const match = Curry._2(Parser_env_Peek.token, 1, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
+  const match = Parser_env_Peek.token(1, env);
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
       case /* T_IDENTIFIER */ 0 :
-        if (Curry._2(Parser_env_Peek.value, 1, env) === "module") {
+        if (Parser_env_Peek.value(1, env) === "module") {
           token$4(env, /* T_DECLARE */ 58);
           contextual(env, "module");
-          if (in_module || Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_PERIOD */ 9)) {
+          if (in_module || Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_PERIOD */ 9)) {
             token$4(env, /* T_PERIOD */ 9);
             contextual(env, "exports");
             const type_annot = wrap(annotation, env);
-            const loc = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+            const loc = Parser_env_Peek.semicolon_loc(undefined, env);
             const end_loc = loc !== undefined ? loc : type_annot[0];
             semicolon(env);
             const loc$1 = btwn(start_loc, end_loc);
@@ -12028,7 +12028,7 @@ function declare(in_moduleOpt, env) {
               }
             ];
           } else {
-            const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+            const match$1 = Parser_env_Peek.token(undefined, env);
             let id;
             if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function" || match$1.TAG !== /* T_STRING */ 1) {
               id = {
@@ -12068,12 +12068,12 @@ function declare(in_moduleOpt, env) {
                 ]
               };
             }
-            const body_start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+            const body_start_loc = Parser_env_Peek.loc(undefined, env);
             token$4(env, /* T_LCURLY */ 1);
             const match$3 = module_items(env, undefined, /* [] */ 0);
             const module_kind = match$3[0];
             token$4(env, /* T_RCURLY */ 2);
-            const body_end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+            const body_end_loc = Parser_env_Peek.loc(undefined, env);
             const body_loc = btwn(body_start_loc, body_end_loc);
             const body_1 = {
               body: match$3[1]
@@ -12155,7 +12155,7 @@ function supers(env, _acc) {
       hd: $$super,
       tl: acc
     };
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
       return Stdlib__List.rev(acc$1);
     }
@@ -12169,14 +12169,14 @@ function supers(env, _acc) {
 }
 
 function interface_helper(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   if (!env.parse_options.types) {
     error$1(env, /* UnexpectedTypeInterface */ 10);
   }
   token$4(env, /* T_INTERFACE */ 51);
   const id = Curry._2(Parse.identifier, undefined, env);
   const typeParameters = Curry._1(type_parameter_declaration_with_defaults, env);
-  const $$extends = Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_EXTENDS */ 39) ? (token$4(env, /* T_EXTENDS */ 39), supers(env, /* [] */ 0)) : /* [] */ 0;
+  const $$extends = Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_EXTENDS */ 39) ? (token$4(env, /* T_EXTENDS */ 39), supers(env, /* [] */ 0)) : /* [] */ 0;
   const body = _object$1(true, env);
   const loc = btwn(start_loc, body[0]);
   return [
@@ -12199,7 +12199,7 @@ function supers$1(env, _acc) {
       hd: $$super,
       tl: acc
     };
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
       return Stdlib__List.rev(acc$1);
     }
@@ -12217,8 +12217,8 @@ function declare_class(env, start_loc) {
   token$4(env$1, /* T_CLASS */ 38);
   const id = Curry._2(Parse.identifier, undefined, env$1);
   const typeParameters = Curry._1(type_parameter_declaration_with_defaults, env$1);
-  const $$extends = Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env$1), /* T_EXTENDS */ 39) ? (token$4(env$1, /* T_EXTENDS */ 39), supers$1(env$1, /* [] */ 0)) : /* [] */ 0;
-  const mixins = Curry._2(Parser_env_Peek.value, undefined, env$1) === "mixins" ? (contextual(env$1, "mixins"), supers$1(env$1, /* [] */ 0)) : /* [] */ 0;
+  const $$extends = Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env$1), /* T_EXTENDS */ 39) ? (token$4(env$1, /* T_EXTENDS */ 39), supers$1(env$1, /* [] */ 0)) : /* [] */ 0;
+  const mixins = Parser_env_Peek.value(undefined, env$1) === "mixins" ? (contextual(env$1, "mixins"), supers$1(env$1, /* [] */ 0)) : /* [] */ 0;
   const body = _object$1(true, env$1);
   const loc = btwn(start_loc, body[0]);
   return [
@@ -12237,7 +12237,7 @@ function module_items(env, _module_kind, _acc) {
   while (true) {
     const acc = _acc;
     const module_kind = _module_kind;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_RCURLY */ 2 :
@@ -12407,14 +12407,14 @@ function assert_can_be_forin_or_forof(env, err, param) {
 }
 
 function _if(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_IF */ 14);
   token$4(env, /* T_LPAREN */ 3);
   const test = Curry._1(Parse.expression, env);
   token$4(env, /* T_RPAREN */ 4);
-  Curry._2(Parser_env_Peek.token, undefined, env);
-  const consequent = Curry._2(Parser_env_Peek.is_function, undefined, env) ? (strict_error(env, /* StrictFunctionStatement */ 45), _function(env)) : Curry._1(Parse.statement, env);
-  const alternate = Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_ELSE */ 41) ? (token$4(env, /* T_ELSE */ 41), Curry._1(Parse.statement, env)) : undefined;
+  Parser_env_Peek.token(undefined, env);
+  const consequent = Parser_env_Peek.is_function(undefined, env) ? (strict_error(env, /* StrictFunctionStatement */ 45), _function(env)) : Curry._1(Parse.statement, env);
+  const alternate = Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_ELSE */ 41) ? (token$4(env, /* T_ELSE */ 41), Curry._1(Parse.statement, env)) : undefined;
   const end_loc = alternate !== undefined ? alternate[0] : consequent[0];
   return [
     btwn(start_loc, end_loc),
@@ -12434,7 +12434,7 @@ function case_list(env, _param) {
     const param = _param;
     const acc = param[1];
     const seen_default = param[0];
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_RCURLY */ 2 :
@@ -12442,8 +12442,8 @@ function case_list(env, _param) {
           return Stdlib__List.rev(acc);
       }
     }
-    const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-    const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const start_loc = Parser_env_Peek.loc(undefined, env);
+    const match$1 = Parser_env_Peek.token(undefined, env);
     let test;
     if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function" && match$1 === /* T_DEFAULT */ 34) {
       if (seen_default) {
@@ -12456,7 +12456,7 @@ function case_list(env, _param) {
       test = Curry._1(Parse.expression, env);
     }
     const seen_default$1 = seen_default || test === undefined;
-    const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const end_loc = Parser_env_Peek.loc(undefined, env);
     token$4(env, /* T_COLON */ 77);
     const term_fn = function (param) {
       if (!/* tag */ (typeof param !== "object" && typeof param !== "function")) {
@@ -12497,7 +12497,7 @@ function var_or_const(env) {
   const match = variable(env);
   const match$1 = match[0];
   const start_loc = match$1[0];
-  const end_loc = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+  const end_loc = Parser_env_Peek.semicolon_loc(undefined, env);
   const end_loc$1 = end_loc !== undefined ? end_loc : start_loc;
   semicolon(env);
   Stdlib__List.iter((function (param) {
@@ -12511,7 +12511,7 @@ function var_or_const(env) {
 
 function source(env) {
   contextual(env, "from");
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function") && match.TAG === /* T_STRING */ 1) {
     const match$1 = match._0;
     const octal = match$1[3];
@@ -12542,12 +12542,12 @@ function source(env) {
       }
     ];
   }
-  const raw$1 = Curry._2(Parser_env_Peek.value, undefined, env);
+  const raw$1 = Parser_env_Peek.value(undefined, env);
   const value$2 = {
     TAG: /* String */ 0,
     _0: raw$1
   };
-  const ret_0 = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const ret_0 = Parser_env_Peek.loc(undefined, env);
   const ret_1 = {
     value: value$2,
     raw: raw$1
@@ -12563,7 +12563,7 @@ function source(env) {
 function specifier_list(env, _acc) {
   while (true) {
     const acc = _acc;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_RCURLY */ 2 :
@@ -12575,7 +12575,7 @@ function specifier_list(env, _acc) {
     const err = match$1[1];
     const remote = match$1[0];
     let specifier;
-    if (Curry._2(Parser_env_Peek.value, undefined, env) === "as") {
+    if (Parser_env_Peek.value(undefined, env) === "as") {
       contextual(env, "as");
       const local = Curry._2(Parse.identifier, undefined, env);
       specifier = {
@@ -12597,7 +12597,7 @@ function specifier_list(env, _acc) {
         }
       };
     }
-    if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_COMMA */ 8)) {
+    if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_COMMA */ 8)) {
       token$4(env, /* T_COMMA */ 8);
     }
     _acc = {
@@ -12609,8 +12609,8 @@ function specifier_list(env, _acc) {
 }
 
 function named_or_namespace_specifier(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_MULT */ 97) {
     token$4(env, /* T_MULT */ 97);
     contextual(env, "as");
@@ -12783,7 +12783,7 @@ function from_expr(env, param) {
 
 function _object$2(restricted_error) {
   const property = function (env) {
-    const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const start_loc = Parser_env_Peek.loc(undefined, env);
     if (maybe(env, /* T_ELLIPSIS */ 11)) {
       const argument = pattern$1(env, restricted_error);
       const loc = btwn(start_loc, argument[0]);
@@ -12820,7 +12820,7 @@ function _object$2(restricted_error) {
         };
         break;
     }
-    const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match$1 = Parser_env_Peek.token(undefined, env);
     let prop;
     let exit = 0;
     if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function" && match$1 === /* T_COLON */ 77) {
@@ -12861,7 +12861,7 @@ function _object$2(restricted_error) {
       return;
     }
     const pattern$3 = prop[0];
-    const match$2 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match$2 = Parser_env_Peek.token(undefined, env);
     let pattern$4;
     if (/* tag */ typeof match$2 !== "object" && typeof match$2 !== "function" && match$2 === /* T_ASSIGN */ 75) {
       token$4(env, /* T_ASSIGN */ 75);
@@ -12896,7 +12896,7 @@ function _object$2(restricted_error) {
   const properties = function (env, _acc) {
     while (true) {
       const acc = _acc;
-      const match = Curry._2(Parser_env_Peek.token, undefined, env);
+      const match = Parser_env_Peek.token(undefined, env);
       if (/* tag */ typeof match !== "object" && typeof match !== "function") {
         switch (match) {
           case /* T_RCURLY */ 2 :
@@ -12906,7 +12906,7 @@ function _object$2(restricted_error) {
       }
       const prop = property(env);
       if (prop !== undefined) {
-        if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RCURLY */ 2)) {
+        if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RCURLY */ 2)) {
           token$4(env, /* T_COMMA */ 8);
         }
         _acc = {
@@ -12919,13 +12919,13 @@ function _object$2(restricted_error) {
     };
   };
   return function (env) {
-    const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const start_loc = Parser_env_Peek.loc(undefined, env);
     token$4(env, /* T_LCURLY */ 1);
     const properties$1 = properties(env, /* [] */ 0);
-    const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const end_loc = Parser_env_Peek.loc(undefined, env);
     token$4(env, /* T_RCURLY */ 2);
     let match;
-    if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_COLON */ 77)) {
+    if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_COLON */ 77)) {
       const typeAnnotation = wrap(annotation, env);
       match = [
         typeAnnotation[0],
@@ -12954,7 +12954,7 @@ function _array(restricted_error) {
   const elements = function (env, _acc) {
     while (true) {
       const acc = _acc;
-      const match = Curry._2(Parser_env_Peek.token, undefined, env);
+      const match = Parser_env_Peek.token(undefined, env);
       if (/* tag */ typeof match !== "object" && typeof match !== "function") {
         switch (match) {
           case /* T_COMMA */ 8 :
@@ -12965,7 +12965,7 @@ function _array(restricted_error) {
             };
             continue;
           case /* T_ELLIPSIS */ 11 :
-            const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+            const start_loc = Parser_env_Peek.loc(undefined, env);
             token$4(env, /* T_ELLIPSIS */ 11);
             const argument = pattern$1(env, restricted_error);
             const loc = btwn(start_loc, argument[0]);
@@ -12989,7 +12989,7 @@ function _array(restricted_error) {
         }
       }
       const pattern$2 = pattern$1(env, restricted_error);
-      const match$1 = Curry._2(Parser_env_Peek.token, undefined, env);
+      const match$1 = Parser_env_Peek.token(undefined, env);
       let pattern$3;
       if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function" && match$1 === /* T_ASSIGN */ 75) {
         token$4(env, /* T_ASSIGN */ 75);
@@ -13012,7 +13012,7 @@ function _array(restricted_error) {
         TAG: /* Element */ 0,
         _0: pattern$3
       };
-      if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RBRACKET */ 6)) {
+      if (Caml_obj.caml_notequal(Parser_env_Peek.token(undefined, env), /* T_RBRACKET */ 6)) {
         token$4(env, /* T_COMMA */ 8);
       }
       _acc = {
@@ -13023,13 +13023,13 @@ function _array(restricted_error) {
     };
   };
   return function (env) {
-    const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const start_loc = Parser_env_Peek.loc(undefined, env);
     token$4(env, /* T_LBRACKET */ 5);
     const elements$1 = elements(env, /* [] */ 0);
-    const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+    const end_loc = Parser_env_Peek.loc(undefined, env);
     token$4(env, /* T_RBRACKET */ 6);
     let match;
-    if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_COLON */ 77)) {
+    if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_COLON */ 77)) {
       const typeAnnotation = wrap(annotation, env);
       match = [
         typeAnnotation[0],
@@ -13055,7 +13055,7 @@ function _array(restricted_error) {
 }
 
 function pattern$1(env, restricted_error) {
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
       case /* T_LCURLY */ 1 :
@@ -13076,11 +13076,11 @@ function pattern$1(env, restricted_error) {
 
 function spread_attribute(env) {
   push_lex_mode(env, /* NORMAL */ 0);
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LCURLY */ 1);
   token$4(env, /* T_ELLIPSIS */ 11);
   const argument = Curry._1(assignment, env);
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RCURLY */ 2);
   pop_lex_mode(env);
   return [
@@ -13093,11 +13093,11 @@ function spread_attribute(env) {
 
 function expression_container(env) {
   push_lex_mode(env, /* NORMAL */ 0);
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LCURLY */ 1);
   let expression;
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_RCURLY */ 2)) {
-    const empty_loc = btwn_exclusive(start_loc, Curry._2(Parser_env_Peek.loc, undefined, env));
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_RCURLY */ 2)) {
+    const empty_loc = btwn_exclusive(start_loc, Parser_env_Peek.loc(undefined, env));
     expression = {
       TAG: /* EmptyExpression */ 1,
       _0: empty_loc
@@ -13108,7 +13108,7 @@ function expression_container(env) {
       _0: Curry._1(Parse.expression, env)
     };
   }
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RCURLY */ 2);
   pop_lex_mode(env);
   return [
@@ -13120,8 +13120,8 @@ function expression_container(env) {
 }
 
 function identifier$1(env) {
-  const loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  const name = Curry._2(Parser_env_Peek.value, undefined, env);
+  const loc = Parser_env_Peek.loc(undefined, env);
+  const name = Parser_env_Peek.value(undefined, env);
   token$4(env, /* T_JSX_IDENTIFIER */ 106);
   return [
     loc,
@@ -13134,7 +13134,7 @@ function identifier$1(env) {
 function member_expression(env, _member) {
   while (true) {
     const member = _member;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
       return member;
     }
@@ -13163,7 +13163,7 @@ function member_expression(env, _member) {
 
 function name(env) {
   const name$1 = identifier$1(env);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
     return {
       TAG: /* Identifier */ 0,
@@ -13214,10 +13214,10 @@ function name(env) {
 }
 
 function attribute(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   const name = identifier$1(env);
   let match;
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_COLON */ 77)) {
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_COLON */ 77)) {
     token$4(env, /* T_COLON */ 77);
     const name$1 = identifier$1(env);
     const loc = btwn(name[0], name$1[0]);
@@ -13244,9 +13244,9 @@ function attribute(env) {
     ];
   }
   let match$1;
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_ASSIGN */ 75)) {
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_ASSIGN */ 75)) {
     token$4(env, /* T_ASSIGN */ 75);
-    const token$5 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const token$5 = Parser_env_Peek.token(undefined, env);
     let exit = 0;
     if (/* tag */ typeof token$5 !== "object" && typeof token$5 !== "function") {
       if (token$5 === /* T_LCURLY */ 1) {
@@ -13292,7 +13292,7 @@ function attribute(env) {
     }
     if (exit === 1) {
       error$1(env, /* InvalidJSXAttributeValue */ 41);
-      const loc$3 = Curry._2(Parser_env_Peek.loc, undefined, env);
+      const loc$3 = Parser_env_Peek.loc(undefined, env);
       match$1 = [
         loc$3,
         {
@@ -13327,7 +13327,7 @@ function attribute(env) {
 function attributes(env, _acc) {
   while (true) {
     const acc = _acc;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_LCURLY */ 1 :
@@ -13361,11 +13361,11 @@ function attributes(env, _acc) {
 function opening_element_without_lt(env, start_loc) {
   const name$1 = name(env);
   const attributes$1 = attributes(env, /* [] */ 0);
-  const selfClosing = Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_DIV */ 96);
+  const selfClosing = Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_DIV */ 96);
   if (selfClosing) {
     token$4(env, /* T_DIV */ 96);
   }
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_GREATER_THAN */ 90);
   pop_lex_mode(env);
   return [
@@ -13381,7 +13381,7 @@ function opening_element_without_lt(env, start_loc) {
 function closing_element_without_lt(env, start_loc) {
   token$4(env, /* T_DIV */ 96);
   const name$1 = name(env);
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_GREATER_THAN */ 90);
   double_pop_lex_mode(env);
   return [
@@ -13393,7 +13393,7 @@ function closing_element_without_lt(env, start_loc) {
 }
 
 function child(env) {
-  const token$5 = Curry._2(Parser_env_Peek.token, undefined, env);
+  const token$5 = Parser_env_Peek.token(undefined, env);
   if (/* tag */ typeof token$5 !== "object" && typeof token$5 !== "function") {
     if (token$5 === /* T_LCURLY */ 1) {
       const expression_container$1 = expression_container(env);
@@ -13431,7 +13431,7 @@ function child(env) {
 }
 
 function element(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   push_lex_mode(env, /* JSX_TAG */ 2);
   token$4(env, /* T_LESS_THAN */ 89);
   return Curry._2(element_without_lt, env, start_loc);
@@ -13439,9 +13439,9 @@ function element(env) {
 
 function element_or_closing(env) {
   push_lex_mode(env, /* JSX_TAG */ 2);
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LESS_THAN */ 89);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
     return {
       TAG: /* ChildElement */ 1,
@@ -13466,7 +13466,7 @@ function element_or_closing(env) {
 function children_and_closing(env, _acc) {
   while (true) {
     const acc = _acc;
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
         case /* T_LESS_THAN */ 89 :
@@ -13566,18 +13566,18 @@ function element_without_lt(env, start_loc) {
 
 function statement_list_item(decoratorsOpt, env) {
   const decorators = decoratorsOpt !== undefined ? decoratorsOpt : /* [] */ 0;
-  if (!Curry._2(Parser_env_Peek.is_class, undefined, env)) {
+  if (!Parser_env_Peek.is_class(undefined, env)) {
     error_on_decorators(env)(decorators);
   }
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     switch (match) {
       case /* T_CONST */ 25 :
         return var_or_const(env);
       case /* T_LET */ 26 :
-        const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+        const start_loc = Parser_env_Peek.loc(undefined, env);
         token$4(env, /* T_LET */ 26);
-        if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_LPAREN */ 3)) {
+        if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_LPAREN */ 3)) {
           token$4(env, /* T_LPAREN */ 3);
           const match$1 = helper(with_no_let(true, env), /* [] */ 0, /* [] */ 0);
           const head = Stdlib__List.map((function (param) {
@@ -13589,7 +13589,7 @@ function statement_list_item(decoratorsOpt, env) {
           }), match$1[1]);
           token$4(env, /* T_RPAREN */ 4);
           const body = Curry._1(Parse.statement, env);
-          const end_loc = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+          const end_loc = Parser_env_Peek.semicolon_loc(undefined, env);
           const end_loc$1 = end_loc !== undefined ? end_loc : match$1[0];
           semicolon(env);
           Stdlib__List.iter((function (param) {
@@ -13614,7 +13614,7 @@ function statement_list_item(decoratorsOpt, env) {
             kind: /* Let */ 1
           }
         };
-        const end_loc$2 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+        const end_loc$2 = Parser_env_Peek.semicolon_loc(undefined, env);
         const end_loc$3 = end_loc$2 !== undefined ? end_loc$2 : match$2[0];
         semicolon(env);
         Stdlib__List.iter((function (param) {
@@ -13626,10 +13626,10 @@ function statement_list_item(decoratorsOpt, env) {
         ];
     }
   }
-  if (Curry._2(Parser_env_Peek.is_function, undefined, env)) {
+  if (Parser_env_Peek.is_function(undefined, env)) {
     return _function(env);
   }
-  if (Curry._2(Parser_env_Peek.is_class, undefined, env)) {
+  if (Parser_env_Peek.is_class(undefined, env)) {
     return class_declaration$1(env, decorators);
   }
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
@@ -13649,7 +13649,7 @@ function statement_list_item(decoratorsOpt, env) {
 
 function statement(env) {
   while (true) {
-    const match = Curry._2(Parser_env_Peek.token, undefined, env);
+    const match = Parser_env_Peek.token(undefined, env);
     let exit = 0;
     if (/* tag */ typeof match !== "object" && typeof match !== "function") {
       switch (match) {
@@ -13663,7 +13663,7 @@ function statement(env) {
             }
           ];
         case /* T_SEMICOLON */ 7 :
-          const loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const loc = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_SEMICOLON */ 7);
           return [
             loc,
@@ -13675,10 +13675,10 @@ function statement(env) {
           if (!env.in_function) {
             error$1(env, /* IllegalReturn */ 23);
           }
-          const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_RETURN */ 17);
-          const argument = Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_SEMICOLON */ 7) || Curry._1(Parser_env_Peek.is_implicit_semicolon, env) ? undefined : Curry._1(Parse.expression, env);
-          const loc$1 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+          const argument = Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_SEMICOLON */ 7) || Parser_env_Peek.is_implicit_semicolon(env) ? undefined : Curry._1(Parse.expression, env);
+          const loc$1 = Parser_env_Peek.semicolon_loc(undefined, env);
           const end_loc = loc$1 !== undefined ? loc$1 : (
               argument !== undefined ? argument[0] : start_loc
             );
@@ -13693,7 +13693,7 @@ function statement(env) {
             }
           ];
         case /* T_SWITCH */ 18 :
-          const start_loc$1 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$1 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_SWITCH */ 18);
           token$4(env, /* T_LPAREN */ 3);
           const discriminant = Curry._1(Parse.expression, env);
@@ -13703,7 +13703,7 @@ function statement(env) {
             false,
             /* [] */ 0
           ]);
-          const end_loc$1 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const end_loc$1 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_RCURLY */ 2);
           return [
             btwn(start_loc$1, end_loc$1),
@@ -13717,16 +13717,16 @@ function statement(env) {
             }
           ];
         case /* T_THROW */ 20 :
-          const start_loc$2 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$2 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_THROW */ 20);
-          if (Curry._1(Parser_env_Peek.is_line_terminator, env)) {
+          if (Parser_env_Peek.is_line_terminator(env)) {
             error_at(env, [
               start_loc$2,
               /* NewlineAfterThrow */ 11
             ]);
           }
           const argument$1 = Curry._1(Parse.expression, env);
-          const loc$2 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+          const loc$2 = Parser_env_Peek.semicolon_loc(undefined, env);
           const end_loc$2 = loc$2 !== undefined ? loc$2 : argument$1[0];
           semicolon(env);
           return [
@@ -13739,13 +13739,13 @@ function statement(env) {
             }
           ];
         case /* T_TRY */ 21 :
-          const start_loc$3 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$3 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_TRY */ 21);
           const block = Curry._1(Parse.block_body, env);
-          const match$2 = Curry._2(Parser_env_Peek.token, undefined, env);
+          const match$2 = Parser_env_Peek.token(undefined, env);
           let handler;
           if (/* tag */ typeof match$2 !== "object" && typeof match$2 !== "function" && match$2 === /* T_CATCH */ 32) {
-            const start_loc$4 = Curry._2(Parser_env_Peek.loc, undefined, env);
+            const start_loc$4 = Parser_env_Peek.loc(undefined, env);
             token$4(env, /* T_CATCH */ 32);
             token$4(env, /* T_LPAREN */ 3);
             const id = Curry._2(Parse.identifier, /* StrictCatchVariable */ 26, env);
@@ -13772,7 +13772,7 @@ function statement(env) {
           } else {
             handler = undefined;
           }
-          const match$3 = Curry._2(Parser_env_Peek.token, undefined, env);
+          const match$3 = Parser_env_Peek.token(undefined, env);
           let finalizer;
           if (/* tag */ typeof match$3 !== "object" && typeof match$3 !== "function" && match$3 === /* T_FINALLY */ 36) {
             token$4(env, /* T_FINALLY */ 36);
@@ -13801,7 +13801,7 @@ function statement(env) {
         case /* T_VAR */ 22 :
           return var_or_const(env);
         case /* T_WHILE */ 23 :
-          const start_loc$5 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$5 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_WHILE */ 23);
           token$4(env, /* T_LPAREN */ 3);
           const test = Curry._1(Parse.expression, env);
@@ -13818,7 +13818,7 @@ function statement(env) {
             }
           ];
         case /* T_WITH */ 24 :
-          const start_loc$6 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$6 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_WITH */ 24);
           token$4(env, /* T_LPAREN */ 3);
           const _object = Curry._1(Parse.expression, env);
@@ -13840,10 +13840,10 @@ function statement(env) {
             }
           ];
         case /* T_BREAK */ 30 :
-          const start_loc$7 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$7 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_BREAK */ 30);
           let label;
-          if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_SEMICOLON */ 7) || Curry._1(Parser_env_Peek.is_implicit_semicolon, env)) {
+          if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_SEMICOLON */ 7) || Parser_env_Peek.is_implicit_semicolon(env)) {
             label = undefined;
           } else {
             const label$1 = Curry._2(Parse.identifier, undefined, env);
@@ -13856,7 +13856,7 @@ function statement(env) {
             }
             label = label$1;
           }
-          const loc$5 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+          const loc$5 = Parser_env_Peek.semicolon_loc(undefined, env);
           const end_loc$4 = loc$5 !== undefined ? loc$5 : (
               label !== undefined ? label[0] : start_loc$7
             );
@@ -13878,10 +13878,10 @@ function statement(env) {
             }
           ];
         case /* T_CONTINUE */ 33 :
-          const start_loc$8 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$8 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_CONTINUE */ 33);
           let label$2;
-          if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_SEMICOLON */ 7) || Curry._1(Parser_env_Peek.is_implicit_semicolon, env)) {
+          if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_SEMICOLON */ 7) || Parser_env_Peek.is_implicit_semicolon(env)) {
             label$2 = undefined;
           } else {
             const label$3 = Curry._2(Parse.identifier, undefined, env);
@@ -13894,7 +13894,7 @@ function statement(env) {
             }
             label$2 = label$3;
           }
-          const loc$7 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+          const loc$7 = Parser_env_Peek.semicolon_loc(undefined, env);
           const end_loc$5 = loc$7 !== undefined ? loc$7 : (
               label$2 !== undefined ? label$2[0] : start_loc$8
             );
@@ -13916,17 +13916,17 @@ function statement(env) {
             }
           ];
         case /* T_DO */ 35 :
-          const start_loc$9 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$9 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_DO */ 35);
           const body$3 = Curry._1(Parse.statement, with_in_loop(true, env));
           token$4(env, /* T_WHILE */ 23);
           token$4(env, /* T_LPAREN */ 3);
           const test$1 = Curry._1(Parse.expression, env);
-          const end_loc$6 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const end_loc$6 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_RPAREN */ 4);
-          const loc$9 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+          const loc$9 = Parser_env_Peek.semicolon_loc(undefined, env);
           const end_loc$7 = loc$9 !== undefined ? loc$9 : end_loc$6;
-          if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_SEMICOLON */ 7)) {
+          if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_SEMICOLON */ 7)) {
             semicolon(env);
           }
           return [
@@ -13940,10 +13940,10 @@ function statement(env) {
             }
           ];
         case /* T_FOR */ 37 :
-          const start_loc$10 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$10 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_FOR */ 37);
           token$4(env, /* T_LPAREN */ 3);
-          const match$4 = Curry._2(Parser_env_Peek.token, undefined, env);
+          const match$4 = Parser_env_Peek.token(undefined, env);
           let match$5;
           let exit$1 = 0;
           if (/* tag */ typeof match$4 !== "object" && typeof match$4 !== "function") {
@@ -14001,7 +14001,7 @@ function statement(env) {
             ];
           }
           const init = match$5[0];
-          const match$9 = Curry._2(Parser_env_Peek.token, undefined, env);
+          const match$9 = Parser_env_Peek.token(undefined, env);
           if (/* tag */ typeof match$9 !== "object" && typeof match$9 !== "function") {
             switch (match$9) {
               case /* T_IN */ 15 :
@@ -14083,11 +14083,11 @@ function statement(env) {
             return error_at(env, param);
           }), match$5[1]);
           token$4(env, /* T_SEMICOLON */ 7);
-          const match$10 = Curry._2(Parser_env_Peek.token, undefined, env);
+          const match$10 = Parser_env_Peek.token(undefined, env);
           let test$2;
           test$2 = /* tag */ typeof match$10 !== "object" && typeof match$10 !== "function" && match$10 === /* T_SEMICOLON */ 7 ? undefined : Curry._1(Parse.expression, env);
           token$4(env, /* T_SEMICOLON */ 7);
-          const match$11 = Curry._2(Parser_env_Peek.token, undefined, env);
+          const match$11 = Parser_env_Peek.token(undefined, env);
           let update;
           update = /* tag */ typeof match$11 !== "object" && typeof match$11 !== "function" && match$11 === /* T_RPAREN */ 4 ? undefined : Curry._1(Parse.expression, env);
           token$4(env, /* T_RPAREN */ 4);
@@ -14105,9 +14105,9 @@ function statement(env) {
             }
           ];
         case /* T_DEBUGGER */ 57 :
-          const start_loc$11 = Curry._2(Parser_env_Peek.loc, undefined, env);
+          const start_loc$11 = Parser_env_Peek.loc(undefined, env);
           token$4(env, /* T_DEBUGGER */ 57);
-          const loc$10 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+          const loc$10 = Parser_env_Peek.semicolon_loc(undefined, env);
           const end_loc$8 = loc$10 !== undefined ? loc$10 : start_loc$11;
           semicolon(env);
           return [
@@ -14117,7 +14117,7 @@ function statement(env) {
         case /* T_EOF */ 105 :
           error_unexpected(env);
           return [
-            Curry._2(Parser_env_Peek.loc, undefined, env),
+            Parser_env_Peek.loc(undefined, env),
             /* Empty */ 0
           ];
         default:
@@ -14127,9 +14127,9 @@ function statement(env) {
       exit = 2;
     }
     if (exit === 2) {
-      if (Curry._2(Parser_env_Peek.is_identifier, undefined, env)) {
+      if (Parser_env_Peek.is_identifier(undefined, env)) {
         const expr$1 = Curry._1(Parse.expression, env);
-        const match$12 = Curry._2(Parser_env_Peek.token, undefined, env);
+        const match$12 = Parser_env_Peek.token(undefined, env);
         const label$4 = expr$1[1];
         if (!/* tag */ (typeof label$4 !== "object" && typeof label$4 !== "function") && label$4.TAG === /* Identifier */ 18 && /* tag */ typeof match$12 !== "object" && typeof match$12 !== "function" && match$12 === /* T_COLON */ 77) {
           const label$5 = label$4._0;
@@ -14160,7 +14160,7 @@ function statement(env) {
             }
           ];
         }
-        const loc$12 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env);
+        const loc$12 = Parser_env_Peek.semicolon_loc(undefined, env);
         const end_loc$9 = loc$12 !== undefined ? loc$12 : expr$1[0];
         semicolon(env);
         return [
@@ -14210,26 +14210,26 @@ function statement(env) {
 
 function module_item(env) {
   const decorators = decorator_list(env);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (!/* tag */ (typeof match !== "object" && typeof match !== "function")) {
     return statement_list_item(decorators, env);
   }
   switch (match) {
     case /* T_EXPORT */ 47 :
       const env$1 = with_in_export(true, with_strict(true, env));
-      const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env$1);
+      const start_loc = Parser_env_Peek.loc(undefined, env$1);
       token$4(env$1, /* T_EXPORT */ 47);
-      const match$1 = Curry._2(Parser_env_Peek.token, undefined, env$1);
+      const match$1 = Parser_env_Peek.token(undefined, env$1);
       let exit = 0;
       if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
         switch (match$1) {
           case /* T_DEFAULT */ 34 :
             token$4(env$1, /* T_DEFAULT */ 34);
             record_export(env$1, [
-              btwn(start_loc, Curry._2(Parser_env_Peek.loc, undefined, env$1)),
+              btwn(start_loc, Parser_env_Peek.loc(undefined, env$1)),
               "default"
             ]);
-            const match$2 = Curry._2(Parser_env_Peek.token, undefined, env$1);
+            const match$2 = Parser_env_Peek.token(undefined, env$1);
             let match$3;
             let exit$1 = 0;
             if (/* tag */ typeof match$2 !== "object" && typeof match$2 !== "function" && match$2 === /* T_FUNCTION */ 13) {
@@ -14245,7 +14245,7 @@ function module_item(env) {
               exit$1 = 3;
             }
             if (exit$1 === 3) {
-              if (Curry._2(Parser_env_Peek.is_class, undefined, env$1)) {
+              if (Parser_env_Peek.is_class(undefined, env$1)) {
                 const _class = class_declaration(env$1, decorators);
                 match$3 = [
                   _class[0],
@@ -14256,7 +14256,7 @@ function module_item(env) {
                 ];
               } else {
                 const expr = Curry._1(Parse.assignment, env$1);
-                const loc = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env$1);
+                const loc = Parser_env_Peek.semicolon_loc(undefined, env$1);
                 const end_loc = loc !== undefined ? loc : expr[0];
                 semicolon(env$1);
                 match$3 = [
@@ -14322,7 +14322,7 @@ function module_item(env) {
               }
             ];
           case /* T_TYPE */ 59 :
-            if (Caml_obj.caml_notequal(Curry._2(Parser_env_Peek.token, 1, env$1), /* T_LCURLY */ 1)) {
+            if (Caml_obj.caml_notequal(Parser_env_Peek.token(1, env$1), /* T_LCURLY */ 1)) {
               if (!env$1.parse_options.types) {
                 error$1(env$1, /* UnexpectedTypeExport */ 9);
               }
@@ -14375,17 +14375,17 @@ function module_item(env) {
             exit = 2;
             break;
           case /* T_MULT */ 97 :
-            const loc$1 = Curry._2(Parser_env_Peek.loc, undefined, env$1);
+            const loc$1 = Parser_env_Peek.loc(undefined, env$1);
             token$4(env$1, /* T_MULT */ 97);
             const parse_export_star_as = env$1.parse_options.esproposal_export_star_as;
-            const local_name = Curry._2(Parser_env_Peek.value, undefined, env$1) === "as" ? (contextual(env$1, "as"), parse_export_star_as ? Curry._2(Parse.identifier, undefined, env$1) : (error$1(env$1, /* UnexpectedTypeDeclaration */ 7), undefined)) : undefined;
+            const local_name = Parser_env_Peek.value(undefined, env$1) === "as" ? (contextual(env$1, "as"), parse_export_star_as ? Curry._2(Parse.identifier, undefined, env$1) : (error$1(env$1, /* UnexpectedTypeDeclaration */ 7), undefined)) : undefined;
             const specifiers = {
               TAG: /* ExportBatchSpecifier */ 1,
               _0: loc$1,
               _1: local_name
             };
             const source$1 = export_source(env$1);
-            const loc$2 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env$1);
+            const loc$2 = Parser_env_Peek.semicolon_loc(undefined, env$1);
             const end_loc$3 = loc$2 !== undefined ? loc$2 : source$1[0];
             const source$2 = source$1;
             semicolon(env$1);
@@ -14410,7 +14410,7 @@ function module_item(env) {
       }
       switch (exit) {
         case 1 :
-          const match$6 = Curry._2(Parser_env_Peek.token, undefined, env$1);
+          const match$6 = Parser_env_Peek.token(undefined, env$1);
           let exportKind;
           if (/* tag */ typeof match$6 !== "object" && typeof match$6 !== "function" && match$6 === /* T_TYPE */ 59) {
             token$3(env$1);
@@ -14424,12 +14424,12 @@ function module_item(env) {
             TAG: /* ExportSpecifiers */ 0,
             _0: match$7[0]
           };
-          const end_loc$4 = Curry._2(Parser_env_Peek.loc, undefined, env$1);
+          const end_loc$4 = Parser_env_Peek.loc(undefined, env$1);
           token$4(env$1, /* T_RCURLY */ 2);
-          const source$3 = Curry._2(Parser_env_Peek.value, undefined, env$1) === "from" ? export_source(env$1) : (Stdlib__List.iter((function (param) {
+          const source$3 = Parser_env_Peek.value(undefined, env$1) === "from" ? export_source(env$1) : (Stdlib__List.iter((function (param) {
               return error_at(env$1, param);
             }), match$7[1]), undefined);
-          const loc$3 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env$1);
+          const loc$3 = Parser_env_Peek.semicolon_loc(undefined, env$1);
           const end_loc$5 = loc$3 !== undefined ? loc$3 : (
               source$3 !== undefined ? source$3[0] : end_loc$4
             );
@@ -14535,9 +14535,9 @@ function module_item(env) {
     case /* T_IMPORT */ 48 :
       error_on_decorators(env)(decorators);
       const env$2 = with_strict(true, env);
-      const start_loc$1 = Curry._2(Parser_env_Peek.loc, undefined, env$2);
+      const start_loc$1 = Parser_env_Peek.loc(undefined, env$2);
       token$4(env$2, /* T_IMPORT */ 48);
-      const match$9 = Curry._2(Parser_env_Peek.token, undefined, env$2);
+      const match$9 = Parser_env_Peek.token(undefined, env$2);
       let match$10;
       if (/* tag */ typeof match$9 !== "object" && typeof match$9 !== "function") {
         switch (match$9) {
@@ -14574,8 +14574,8 @@ function module_item(env) {
       }
       const type_ident = match$10[1];
       const importKind = match$10[0];
-      const match$11 = Curry._2(Parser_env_Peek.token, undefined, env$2);
-      const match$12 = Curry._2(Parser_env_Peek.is_identifier, undefined, env$2);
+      const match$11 = Parser_env_Peek.token(undefined, env$2);
+      const match$12 = Parser_env_Peek.is_identifier(undefined, env$2);
       let exit$2 = 0;
       let exit$3 = 0;
       if (/* tag */ typeof match$11 !== "object" && typeof match$11 !== "function") {
@@ -14615,7 +14615,7 @@ function module_item(env) {
             str_loc,
             source_1
           ];
-          const loc$5 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env$2);
+          const loc$5 = Parser_env_Peek.semicolon_loc(undefined, env$2);
           const end_loc$6 = loc$5 !== undefined ? loc$5 : str_loc;
           semicolon(env$2);
           return [
@@ -14640,7 +14640,7 @@ function module_item(env) {
         } else {
           const specifiers$2 = named_or_namespace_specifier(env$2);
           const source$5 = source(env$2);
-          const loc$6 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env$2);
+          const loc$6 = Parser_env_Peek.semicolon_loc(undefined, env$2);
           const end_loc$7 = loc$6 !== undefined ? loc$6 : source$5[0];
           semicolon(env$2);
           return [
@@ -14657,8 +14657,8 @@ function module_item(env) {
         }
       }
       if (exit$2 === 1) {
-        const match$14 = Curry._2(Parser_env_Peek.token, undefined, env$2);
-        const match$15 = Curry._2(Parser_env_Peek.value, undefined, env$2);
+        const match$14 = Parser_env_Peek.token(undefined, env$2);
+        const match$15 = Parser_env_Peek.value(undefined, env$2);
         let match$16;
         let exit$4 = 0;
         if (type_ident !== undefined && /* tag */ typeof match$14 !== "object" && typeof match$14 !== "function") {
@@ -14700,7 +14700,7 @@ function module_item(env) {
             }
           ];
         }
-        const match$17 = Curry._2(Parser_env_Peek.token, undefined, env$2);
+        const match$17 = Parser_env_Peek.token(undefined, env$2);
         let additional_specifiers;
         if (/* tag */ typeof match$17 !== "object" && typeof match$17 !== "function" && match$17 === /* T_COMMA */ 8) {
           token$4(env$2, /* T_COMMA */ 8);
@@ -14709,7 +14709,7 @@ function module_item(env) {
           additional_specifiers = /* [] */ 0;
         }
         const source$6 = source(env$2);
-        const loc$7 = Curry._2(Parser_env_Peek.semicolon_loc, undefined, env$2);
+        const loc$7 = Parser_env_Peek.semicolon_loc(undefined, env$2);
         const end_loc$8 = loc$7 !== undefined ? loc$7 : source$6[0];
         semicolon(env$2);
         return [
@@ -14728,7 +14728,7 @@ function module_item(env) {
         ];
       }
       case /* T_DECLARE */ 58 :
-      if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, 1, env), /* T_EXPORT */ 47)) {
+      if (Caml_obj.caml_equal(Parser_env_Peek.token(1, env), /* T_EXPORT */ 47)) {
         error_on_decorators(env)(decorators);
         return declare_export_declaration(undefined, env);
       } else {
@@ -14745,7 +14745,7 @@ function statement_list(term_fn, env) {
   let _acc = /* [] */ 0;
   while (true) {
     const acc = _acc;
-    const t = Curry._2(Parser_env_Peek.token, undefined, env);
+    const t = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof t !== "object" && typeof t !== "function" && t === /* T_EOF */ 105) {
       return Stdlib__List.rev(acc);
     }
@@ -14766,7 +14766,7 @@ function statement_list$1(_env, term_fn, item_fn, _param) {
     const env = _env;
     const stmts = param[1];
     const string_tokens = param[0];
-    const t = Curry._2(Parser_env_Peek.token, undefined, env);
+    const t = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof t !== "object" && typeof t !== "function" && t === /* T_EOF */ 105) {
       return [
         env,
@@ -14781,8 +14781,8 @@ function statement_list$1(_env, term_fn, item_fn, _param) {
         stmts
       ];
     }
-    const string_token_0 = Curry._2(Parser_env_Peek.loc, undefined, env);
-    const string_token_1 = Curry._2(Parser_env_Peek.token, undefined, env);
+    const string_token_0 = Parser_env_Peek.loc(undefined, env);
+    const string_token_1 = Parser_env_Peek.token(undefined, env);
     const string_token = [
       string_token_0,
       string_token_1
@@ -14888,7 +14888,7 @@ function module_body(term_fn, env) {
   let _acc = /* [] */ 0;
   while (true) {
     const acc = _acc;
-    const t = Curry._2(Parser_env_Peek.token, undefined, env);
+    const t = Parser_env_Peek.token(undefined, env);
     if (/* tag */ typeof t !== "object" && typeof t !== "function" && t === /* T_EOF */ 105) {
       return Stdlib__List.rev(acc);
     }
@@ -14915,9 +14915,9 @@ function module_body_with_directives(env, term_fn) {
 }
 
 function identifier$2(restricted_error, env) {
-  const loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  const name = Curry._2(Parser_env_Peek.value, undefined, env);
-  const t = Curry._2(Parser_env_Peek.token, undefined, env);
+  const loc = Parser_env_Peek.loc(undefined, env);
+  const name = Parser_env_Peek.value(undefined, env);
+  const t = Parser_env_Peek.token(undefined, env);
   let exit = 0;
   if (/* tag */ typeof t !== "object" && typeof t !== "function" && t === /* T_LET */ 26) {
     if (env.in_strict_mode) {
@@ -14990,7 +14990,7 @@ function program(env) {
   const stmts = module_body_with_directives(env, (function (param) {
     return false;
   }));
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_EOF */ 105);
   const loc = stmts ? btwn(Stdlib__List.hd(stmts)[0], Stdlib__List.hd(Stdlib__List.rev(stmts))[0]) : end_loc;
   const comments = Stdlib__List.rev(env.comments.contents);
@@ -15003,7 +15003,7 @@ function program(env) {
 
 function expression$1(env) {
   const expr = Curry._1(assignment, env);
-  const match = Curry._2(Parser_env_Peek.token, undefined, env);
+  const match = Parser_env_Peek.token(undefined, env);
   if (/* tag */ typeof match !== "object" && typeof match !== "function" && match === /* T_COMMA */ 8) {
     return sequence(env, {
       hd: expr,
@@ -15019,11 +15019,11 @@ function identifier_with_type(env, restricted_error) {
   const id = match[1];
   const loc = match[0];
   let match$1;
-  if (Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_PLING */ 76)) {
+  if (Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_PLING */ 76)) {
     if (!env.parse_options.types) {
       error$1(env, /* UnexpectedTypeAnnotation */ 6);
     }
-    const loc$1 = btwn(loc, Curry._2(Parser_env_Peek.loc, undefined, env));
+    const loc$1 = btwn(loc, Parser_env_Peek.loc(undefined, env));
     token$4(env, /* T_PLING */ 76);
     match$1 = [
       loc$1,
@@ -15041,7 +15041,7 @@ function identifier_with_type(env, restricted_error) {
   }
   const id$1 = match$1[1];
   const loc$2 = match$1[0];
-  if (!Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_COLON */ 77)) {
+  if (!Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_COLON */ 77)) {
     return [
       loc$2,
       id$1
@@ -15061,13 +15061,13 @@ function identifier_with_type(env, restricted_error) {
 }
 
 function block_body(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LCURLY */ 1);
   const term_fn = function (t) {
     return Caml_obj.caml_equal(t, /* T_RCURLY */ 2);
   };
   const body = Curry._2(statement_list, term_fn, env);
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RCURLY */ 2);
   return [
     btwn(start_loc, end_loc),
@@ -15078,13 +15078,13 @@ function block_body(env) {
 }
 
 function function_block_body(env) {
-  const start_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const start_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_LCURLY */ 1);
   const term_fn = function (t) {
     return Caml_obj.caml_equal(t, /* T_RCURLY */ 2);
   };
   const match = statement_list_with_directives(term_fn, env);
-  const end_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const end_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RCURLY */ 2);
   return [
     btwn(start_loc, end_loc),
@@ -15096,8 +15096,8 @@ function function_block_body(env) {
 }
 
 function predicate(env) {
-  const checks_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
-  if (!(Caml_obj.caml_equal(Curry._2(Parser_env_Peek.token, undefined, env), /* T_IDENTIFIER */ 0) && Curry._2(Parser_env_Peek.value, undefined, env) === "checks")) {
+  const checks_loc = Parser_env_Peek.loc(undefined, env);
+  if (!(Caml_obj.caml_equal(Parser_env_Peek.token(undefined, env), /* T_IDENTIFIER */ 0) && Parser_env_Peek.value(undefined, env) === "checks")) {
     return;
   }
   token$4(env, /* T_IDENTIFIER */ 0);
@@ -15108,7 +15108,7 @@ function predicate(env) {
     ];
   }
   const exp = Curry._1(Parse.expression, env);
-  const rparen_loc = Curry._2(Parser_env_Peek.loc, undefined, env);
+  const rparen_loc = Parser_env_Peek.loc(undefined, env);
   token$4(env, /* T_RPAREN */ 4);
   const loc = btwn(checks_loc, rparen_loc);
   return [

--- a/jscomp/test/dist/ocaml_parsetree_test.js
+++ b/jscomp/test/dist/ocaml_parsetree_test.js
@@ -1596,7 +1596,7 @@ function get_pos_info(pos) {
 }
 
 function print_loc(ppf, loc) {
-  Curry._1(Misc_Color.setup, color.contents);
+  Misc_Color.setup(color.contents);
   const match = get_pos_info(loc.loc_start);
   const startchar = match[2];
   const file = match[0];
@@ -1713,7 +1713,7 @@ function print_loc(ppf, loc) {
 }
 
 function print$1(ppf, loc) {
-  Curry._1(Misc_Color.setup, color.contents);
+  Misc_Color.setup(color.contents);
   if (loc.loc_start.pos_fname === "//toplevel//" && highlight_locations(ppf, {
       hd: loc,
       tl: /* [] */ 0
@@ -1762,7 +1762,7 @@ const error_prefix = "Error";
 
 function print_error(ppf, loc) {
   print$1(ppf, loc);
-  Curry._1(Misc_Color.setup, color.contents);
+  Misc_Color.setup(color.contents);
   Curry._1(Stdlib__Format.fprintf(ppf)({
     TAG: /* Format */ 0,
     _0: {
@@ -1799,7 +1799,7 @@ function print_error(ppf, loc) {
 
 function default_warning_printer(loc, ppf, w) {
   if (is_active(w)) {
-    Curry._1(Misc_Color.setup, color.contents);
+    Misc_Color.setup(color.contents);
     print$1(ppf, loc);
     return Curry._3(Stdlib__Format.fprintf(ppf)({
       TAG: /* Format */ 0,
@@ -1908,7 +1908,7 @@ function errorf(locOpt, subOpt, if_highlightOpt, fmt) {
   };
   const buf = Stdlib__Buffer.create(64);
   const ppf = Stdlib__Format.formatter_of_buffer(buf);
-  Curry._1(Misc_Color.set_color_tag_handling, ppf);
+  Misc_Color.set_color_tag_handling(ppf);
   if (before !== undefined) {
     Curry._1(before, ppf);
   }
@@ -3730,7 +3730,7 @@ function mkpat(d) {
 }
 
 function mkexp(d) {
-  return Curry._3(Ast_helper_Exp.mk, symbol_rloc(), undefined, d);
+  return Ast_helper_Exp.mk(symbol_rloc(), undefined, d);
 }
 
 function mkmty(d) {
@@ -3758,11 +3758,11 @@ function mkcty(d) {
 }
 
 function mkctf(attrs, docs, d) {
-  return Curry._4(Ast_helper_Ctf.mk, symbol_rloc(), attrs, docs, d);
+  return Ast_helper_Ctf.mk(symbol_rloc(), attrs, docs, d);
 }
 
 function mkcf(attrs, docs, d) {
-  return Curry._4(Ast_helper_Cf.mk, symbol_rloc(), attrs, docs, d);
+  return Ast_helper_Cf.mk(symbol_rloc(), attrs, docs, d);
 }
 
 function mkoption(d) {
@@ -3812,7 +3812,7 @@ function reloc_exp(x) {
 
 function mkoperator(name, pos) {
   const loc = rhs_loc(pos);
-  return Curry._3(Ast_helper_Exp.mk, loc, undefined, {
+  return Ast_helper_Exp.mk(loc, undefined, {
     TAG: /* Pexp_ident */ 0,
     _0: {
       txt: {
@@ -3835,7 +3835,7 @@ function mkpatvar(name, pos) {
 }
 
 function ghexp(d) {
-  return Curry._3(Ast_helper_Exp.mk, symbol_gloc(), undefined, d);
+  return Ast_helper_Exp.mk(symbol_gloc(), undefined, d);
 }
 
 function ghpat(d) {
@@ -3875,7 +3875,7 @@ function neg_float_string(f) {
 }
 
 function mkexp_cons(consloc, args, loc) {
-  return Curry._3(Ast_helper_Exp.mk, loc, undefined, {
+  return Ast_helper_Exp.mk(loc, undefined, {
     TAG: /* Pexp_construct */ 9,
     _0: {
       txt: {
@@ -3913,7 +3913,7 @@ function mktailexp(nilloc, param) {
       loc_end: loc_loc_end,
       loc_ghost: true
     };
-    const arg = Curry._3(Ast_helper_Exp.mk, loc, undefined, {
+    const arg = Ast_helper_Exp.mk(loc, undefined, {
       TAG: /* Pexp_tuple */ 8,
       _0: {
         hd: e1,
@@ -3944,7 +3944,7 @@ function mktailexp(nilloc, param) {
     txt: nil_txt,
     loc: loc$1
   };
-  return Curry._3(Ast_helper_Exp.mk, loc$1, undefined, {
+  return Ast_helper_Exp.mk(loc$1, undefined, {
     TAG: /* Pexp_construct */ 9,
     _0: nil,
     _1: undefined
@@ -5732,7 +5732,7 @@ const yyact = [
     const _2 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
     return Stdlib.$at({
       hd: _2,
-      tl: Curry._1(Ast_helper_Cf.text, get_text(Stdlib__Parsing.rhs_start_pos(2)))
+      tl: Ast_helper_Cf.text(get_text(Stdlib__Parsing.rhs_start_pos(2)))
     }, _1);
   }),
   (function (__caml_parser_env) {
@@ -6103,7 +6103,7 @@ const yyact = [
     const _2 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
     return Stdlib.$at({
       hd: _2,
-      tl: Curry._1(Ast_helper_Ctf.text, get_text(Stdlib__Parsing.rhs_start_pos(2)))
+      tl: Ast_helper_Ctf.text(get_text(Stdlib__Parsing.rhs_start_pos(2)))
     }, _1);
   }),
   (function (__caml_parser_env) {
@@ -7160,7 +7160,7 @@ const yyact = [
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 1);
     const _2 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
-    return Curry._2(Ast_helper_Exp.attr, _1, _2);
+    return Ast_helper_Exp.attr(_1, _2);
   }),
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
@@ -7949,13 +7949,13 @@ const yyact = [
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 2);
     const _3 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
-    return Curry._3(Ast_helper_Exp.$$case, _1, undefined, _3);
+    return Ast_helper_Exp.$$case(_1, undefined, _3);
   }),
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 4);
     const _3 = Stdlib__Parsing.peek_val(__caml_parser_env, 2);
     const _5 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
-    return Curry._3(Ast_helper_Exp.$$case, _1, _3, _5);
+    return Ast_helper_Exp.$$case(_1, _3, _5);
   }),
   (function (__caml_parser_env) {
     return Stdlib__Parsing.peek_val(__caml_parser_env, 0);

--- a/jscomp/test/dist/ocaml_re_test.js
+++ b/jscomp/test/dist/ocaml_re_test.js
@@ -1490,9 +1490,9 @@ function category(re, c) {
   if (c === -1) {
     return Re_automata_Category.inexistant;
   } else if (c === re.lnl) {
-    return Curry._2(Re_automata_Category.$plus$plus, Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.lastnewline, Re_automata_Category.newline), Re_automata_Category.not_letter);
+    return Re_automata_Category.$plus$plus(Re_automata_Category.$plus$plus(Re_automata_Category.lastnewline, Re_automata_Category.newline), Re_automata_Category.not_letter);
   } else {
-    return Curry._1(Re_automata_Category.from_char, Caml_bytes.get(re.col_repr, c));
+    return Re_automata_Category.from_char(Caml_bytes.get(re.col_repr, c));
   }
 }
 
@@ -1622,7 +1622,7 @@ function find_initial_state(re, cat) {
   catch (raw_exn){
     const exn = Caml_js_exceptions.internalToOCamlException(raw_exn);
     if (exn.MEL_EXN_ID === Stdlib.Not_found) {
-      const st = find_state(re, Curry._2(Re_automata_State.create, cat, re.initial));
+      const st = find_state(re, Re_automata_State.create(cat, re.initial));
       re.initial_states = {
         hd: [
           cat,
@@ -2263,7 +2263,7 @@ function translate(ids, kind, _ign_group, ign_case, _greedy, pos, cache, c, _s) 
     if (/* tag */ typeof s !== "object" && typeof s !== "function") {
       switch (s) {
         case /* Beg_of_line */ 0 :
-          const c$1 = Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.inexistant, Re_automata_Category.newline);
+          const c$1 = Re_automata_Category.$plus$plus(Re_automata_Category.inexistant, Re_automata_Category.newline);
           return [
             mk_expr(ids, {
               TAG: /* After */ 7,
@@ -2272,7 +2272,7 @@ function translate(ids, kind, _ign_group, ign_case, _greedy, pos, cache, c, _s) 
             kind
           ];
         case /* End_of_line */ 1 :
-          const c$2 = Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.inexistant, Re_automata_Category.newline);
+          const c$2 = Re_automata_Category.$plus$plus(Re_automata_Category.inexistant, Re_automata_Category.newline);
           return [
             mk_expr(ids, {
               TAG: /* Before */ 6,
@@ -2281,8 +2281,8 @@ function translate(ids, kind, _ign_group, ign_case, _greedy, pos, cache, c, _s) 
             kind
           ];
         case /* Beg_of_word */ 2 :
-          const c$3 = Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.inexistant, Re_automata_Category.not_letter);
-          const c$4 = Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.inexistant, Re_automata_Category.letter);
+          const c$3 = Re_automata_Category.$plus$plus(Re_automata_Category.inexistant, Re_automata_Category.not_letter);
+          const c$4 = Re_automata_Category.$plus$plus(Re_automata_Category.inexistant, Re_automata_Category.letter);
           return [
             seq$1(ids, "First", mk_expr(ids, {
               TAG: /* After */ 7,
@@ -2294,8 +2294,8 @@ function translate(ids, kind, _ign_group, ign_case, _greedy, pos, cache, c, _s) 
             kind
           ];
         case /* End_of_word */ 3 :
-          const c$5 = Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.inexistant, Re_automata_Category.letter);
-          const c$6 = Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.inexistant, Re_automata_Category.not_letter);
+          const c$5 = Re_automata_Category.$plus$plus(Re_automata_Category.inexistant, Re_automata_Category.letter);
+          const c$6 = Re_automata_Category.$plus$plus(Re_automata_Category.inexistant, Re_automata_Category.not_letter);
           return [
             seq$1(ids, "First", mk_expr(ids, {
               TAG: /* After */ 7,
@@ -2346,7 +2346,7 @@ function translate(ids, kind, _ign_group, ign_case, _greedy, pos, cache, c, _s) 
             kind
           ];
         case /* Last_end_of_line */ 7 :
-          const c$7 = Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.inexistant, Re_automata_Category.lastnewline);
+          const c$7 = Re_automata_Category.$plus$plus(Re_automata_Category.inexistant, Re_automata_Category.lastnewline);
           return [
             mk_expr(ids, {
               TAG: /* Before */ 6,
@@ -3190,14 +3190,14 @@ function exec_internal(name, posOpt, lenOpt, groups, re, s) {
     pos: pos,
     last: last
   };
-  const initial_cat = pos === 0 ? Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.search_boundary, Re_automata_Category.inexistant) : Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.search_boundary, category(re, get_color(re, s, pos - 1 | 0)));
+  const initial_cat = pos === 0 ? Re_automata_Category.$plus$plus(Re_automata_Category.search_boundary, Re_automata_Category.inexistant) : Re_automata_Category.$plus$plus(Re_automata_Category.search_boundary, category(re, get_color(re, s, pos - 1 | 0)));
   const initial_state = find_initial_state(re, initial_cat);
   const st = scan_str(info, s, initial_state, groups);
   let res;
   if (st.idx === -3 || partial) {
     res = status(st.desc);
   } else {
-    const final_cat = last === slen ? Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.search_boundary, Re_automata_Category.inexistant) : Curry._2(Re_automata_Category.$plus$plus, Re_automata_Category.search_boundary, category(re, get_color(re, s, last)));
+    const final_cat = last === slen ? Re_automata_Category.$plus$plus(Re_automata_Category.search_boundary, Re_automata_Category.inexistant) : Re_automata_Category.$plus$plus(Re_automata_Category.search_boundary, category(re, get_color(re, s, last)));
     const match = $$final(info, st, final_cat);
     if (groups) {
       Caml_array.set(info.positions, match[0], last + 1 | 0);

--- a/jscomp/test/dist/ocaml_typedtree_test.js
+++ b/jscomp/test/dist/ocaml_typedtree_test.js
@@ -1874,7 +1874,7 @@ function get_pos_info(pos) {
 }
 
 function print_loc(ppf, loc) {
-  Curry._1(Misc_Color.setup, color.contents);
+  Misc_Color.setup(color.contents);
   const match = get_pos_info(loc.loc_start);
   const startchar = match[2];
   const file = match[0];
@@ -1991,7 +1991,7 @@ function print_loc(ppf, loc) {
 }
 
 function print$1(ppf, loc) {
-  Curry._1(Misc_Color.setup, color.contents);
+  Misc_Color.setup(color.contents);
   if (loc.loc_start.pos_fname === "//toplevel//" && highlight_locations(ppf, {
       hd: loc,
       tl: /* [] */ 0
@@ -2040,7 +2040,7 @@ const error_prefix = "Error";
 
 function print_error(ppf, loc) {
   print$1(ppf, loc);
-  Curry._1(Misc_Color.setup, color.contents);
+  Misc_Color.setup(color.contents);
   Curry._1(Stdlib__Format.fprintf(ppf)({
     TAG: /* Format */ 0,
     _0: {
@@ -2077,7 +2077,7 @@ function print_error(ppf, loc) {
 
 function default_warning_printer(loc, ppf, w) {
   if (is_active(w)) {
-    Curry._1(Misc_Color.setup, color.contents);
+    Misc_Color.setup(color.contents);
     print$1(ppf, loc);
     return Curry._3(Stdlib__Format.fprintf(ppf)({
       TAG: /* Format */ 0,
@@ -2186,7 +2186,7 @@ function errorf(locOpt, subOpt, if_highlightOpt, fmt) {
   };
   const buf = Stdlib__Buffer.create(64);
   const ppf = Stdlib__Format.formatter_of_buffer(buf);
-  Curry._1(Misc_Color.set_color_tag_handling, ppf);
+  Misc_Color.set_color_tag_handling(ppf);
   if (before !== undefined) {
     Curry._1(before, ppf);
   }
@@ -9542,20 +9542,20 @@ function map_field(sub, param) {
   const attrs = Curry._2(sub.attributes, sub, param.pctf_attributes);
   switch (desc.TAG) {
     case /* Pctf_inherit */ 0 :
-      return Curry._3(Ast_helper_Ctf.inherit_, loc, attrs, Curry._2(sub.class_type, sub, desc._0));
+      return Ast_helper_Ctf.inherit_(loc, attrs, Curry._2(sub.class_type, sub, desc._0));
     case /* Pctf_val */ 1 :
       const match = desc._0;
-      return Curry._6(Ast_helper_Ctf.val_, loc, attrs, match[0], match[1], match[2], Curry._2(sub.typ, sub, match[3]));
+      return Ast_helper_Ctf.val_(loc, attrs, match[0], match[1], match[2], Curry._2(sub.typ, sub, match[3]));
     case /* Pctf_method */ 2 :
       const match$1 = desc._0;
-      return Curry._6(Ast_helper_Ctf.method_, loc, attrs, match$1[0], match$1[1], match$1[2], Curry._2(sub.typ, sub, match$1[3]));
+      return Ast_helper_Ctf.method_(loc, attrs, match$1[0], match$1[1], match$1[2], Curry._2(sub.typ, sub, match$1[3]));
     case /* Pctf_constraint */ 3 :
       const match$2 = desc._0;
-      return Curry._4(Ast_helper_Ctf.constraint_, loc, attrs, Curry._2(sub.typ, sub, match$2[0]), Curry._2(sub.typ, sub, match$2[1]));
+      return Ast_helper_Ctf.constraint_(loc, attrs, Curry._2(sub.typ, sub, match$2[0]), Curry._2(sub.typ, sub, match$2[1]));
     case /* Pctf_attribute */ 4 :
-      return Curry._2(Ast_helper_Ctf.attribute, loc, Curry._2(sub.attribute, sub, desc._0));
+      return Ast_helper_Ctf.attribute(loc, Curry._2(sub.attribute, sub, desc._0));
     case /* Pctf_extension */ 5 :
-      return Curry._3(Ast_helper_Ctf.extension, loc, attrs, Curry._2(sub.extension, sub, desc._0));
+      return Ast_helper_Ctf.extension(loc, attrs, Curry._2(sub.extension, sub, desc._0));
   }
 }
 
@@ -9810,86 +9810,86 @@ function map$5(sub, param) {
   const attrs = Curry._2(sub.attributes, sub, param.pexp_attributes);
   switch (desc.TAG) {
     case /* Pexp_ident */ 0 :
-      return Curry._3(Ast_helper_Exp.ident, loc, attrs, map_loc(sub, desc._0));
+      return Ast_helper_Exp.ident(loc, attrs, map_loc(sub, desc._0));
     case /* Pexp_constant */ 1 :
-      return Curry._3(Ast_helper_Exp.constant, loc, attrs, desc._0);
+      return Ast_helper_Exp.constant(loc, attrs, desc._0);
     case /* Pexp_let */ 2 :
-      return Curry._5(Ast_helper_Exp.let_, loc, attrs, desc._0, Stdlib__List.map(Curry._1(sub.value_binding, sub), desc._1), Curry._2(sub.expr, sub, desc._2));
+      return Ast_helper_Exp.let_(loc, attrs, desc._0, Stdlib__List.map(Curry._1(sub.value_binding, sub), desc._1), Curry._2(sub.expr, sub, desc._2));
     case /* Pexp_function */ 3 :
-      return Curry._3(Ast_helper_Exp.function_, loc, attrs, Curry._2(sub.cases, sub, desc._0));
+      return Ast_helper_Exp.function_(loc, attrs, Curry._2(sub.cases, sub, desc._0));
     case /* Pexp_fun */ 4 :
-      return Curry._6(Ast_helper_Exp.fun_, loc, attrs, desc._0, map_opt(Curry._1(sub.expr, sub), desc._1), Curry._2(sub.pat, sub, desc._2), Curry._2(sub.expr, sub, desc._3));
+      return Ast_helper_Exp.fun_(loc, attrs, desc._0, map_opt(Curry._1(sub.expr, sub), desc._1), Curry._2(sub.pat, sub, desc._2), Curry._2(sub.expr, sub, desc._3));
     case /* Pexp_apply */ 5 :
       const partial_arg = Curry._1(sub.expr, sub);
-      return Curry._4(Ast_helper_Exp.apply, loc, attrs, Curry._2(sub.expr, sub, desc._0), Stdlib__List.map((function (param) {
+      return Ast_helper_Exp.apply(loc, attrs, Curry._2(sub.expr, sub, desc._0), Stdlib__List.map((function (param) {
         return map_snd(partial_arg, param);
       }), desc._1));
     case /* Pexp_match */ 6 :
-      return Curry._4(Ast_helper_Exp.match_, loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.cases, sub, desc._1));
+      return Ast_helper_Exp.match_(loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.cases, sub, desc._1));
     case /* Pexp_try */ 7 :
-      return Curry._4(Ast_helper_Exp.try_, loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.cases, sub, desc._1));
+      return Ast_helper_Exp.try_(loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.cases, sub, desc._1));
     case /* Pexp_tuple */ 8 :
-      return Curry._3(Ast_helper_Exp.tuple, loc, attrs, Stdlib__List.map(Curry._1(sub.expr, sub), desc._0));
+      return Ast_helper_Exp.tuple(loc, attrs, Stdlib__List.map(Curry._1(sub.expr, sub), desc._0));
     case /* Pexp_construct */ 9 :
-      return Curry._4(Ast_helper_Exp.construct, loc, attrs, map_loc(sub, desc._0), map_opt(Curry._1(sub.expr, sub), desc._1));
+      return Ast_helper_Exp.construct(loc, attrs, map_loc(sub, desc._0), map_opt(Curry._1(sub.expr, sub), desc._1));
     case /* Pexp_variant */ 10 :
-      return Curry._4(Ast_helper_Exp.variant, loc, attrs, desc._0, map_opt(Curry._1(sub.expr, sub), desc._1));
+      return Ast_helper_Exp.variant(loc, attrs, desc._0, map_opt(Curry._1(sub.expr, sub), desc._1));
     case /* Pexp_record */ 11 :
       const partial_arg$1 = Curry._1(sub.expr, sub);
-      return Curry._4(Ast_helper_Exp.record, loc, attrs, Stdlib__List.map((function (param) {
+      return Ast_helper_Exp.record(loc, attrs, Stdlib__List.map((function (param) {
         return map_tuple((function (param) {
           return map_loc(sub, param);
         }), partial_arg$1, param);
       }), desc._0), map_opt(Curry._1(sub.expr, sub), desc._1));
     case /* Pexp_field */ 12 :
-      return Curry._4(Ast_helper_Exp.field, loc, attrs, Curry._2(sub.expr, sub, desc._0), map_loc(sub, desc._1));
+      return Ast_helper_Exp.field(loc, attrs, Curry._2(sub.expr, sub, desc._0), map_loc(sub, desc._1));
     case /* Pexp_setfield */ 13 :
-      return Curry._5(Ast_helper_Exp.setfield, loc, attrs, Curry._2(sub.expr, sub, desc._0), map_loc(sub, desc._1), Curry._2(sub.expr, sub, desc._2));
+      return Ast_helper_Exp.setfield(loc, attrs, Curry._2(sub.expr, sub, desc._0), map_loc(sub, desc._1), Curry._2(sub.expr, sub, desc._2));
     case /* Pexp_array */ 14 :
-      return Curry._3(Ast_helper_Exp.array, loc, attrs, Stdlib__List.map(Curry._1(sub.expr, sub), desc._0));
+      return Ast_helper_Exp.array(loc, attrs, Stdlib__List.map(Curry._1(sub.expr, sub), desc._0));
     case /* Pexp_ifthenelse */ 15 :
-      return Curry._5(Ast_helper_Exp.ifthenelse, loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.expr, sub, desc._1), map_opt(Curry._1(sub.expr, sub), desc._2));
+      return Ast_helper_Exp.ifthenelse(loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.expr, sub, desc._1), map_opt(Curry._1(sub.expr, sub), desc._2));
     case /* Pexp_sequence */ 16 :
-      return Curry._4(Ast_helper_Exp.sequence, loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.expr, sub, desc._1));
+      return Ast_helper_Exp.sequence(loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.expr, sub, desc._1));
     case /* Pexp_while */ 17 :
-      return Curry._4(Ast_helper_Exp.while_, loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.expr, sub, desc._1));
+      return Ast_helper_Exp.while_(loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.expr, sub, desc._1));
     case /* Pexp_for */ 18 :
-      return Curry._7(Ast_helper_Exp.for_, loc, attrs, Curry._2(sub.pat, sub, desc._0), Curry._2(sub.expr, sub, desc._1), Curry._2(sub.expr, sub, desc._2), desc._3, Curry._2(sub.expr, sub, desc._4));
+      return Ast_helper_Exp.for_(loc, attrs, Curry._2(sub.pat, sub, desc._0), Curry._2(sub.expr, sub, desc._1), Curry._2(sub.expr, sub, desc._2), desc._3, Curry._2(sub.expr, sub, desc._4));
     case /* Pexp_constraint */ 19 :
-      return Curry._4(Ast_helper_Exp.constraint_, loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.typ, sub, desc._1));
+      return Ast_helper_Exp.constraint_(loc, attrs, Curry._2(sub.expr, sub, desc._0), Curry._2(sub.typ, sub, desc._1));
     case /* Pexp_coerce */ 20 :
-      return Curry._5(Ast_helper_Exp.coerce, loc, attrs, Curry._2(sub.expr, sub, desc._0), map_opt(Curry._1(sub.typ, sub), desc._1), Curry._2(sub.typ, sub, desc._2));
+      return Ast_helper_Exp.coerce(loc, attrs, Curry._2(sub.expr, sub, desc._0), map_opt(Curry._1(sub.typ, sub), desc._1), Curry._2(sub.typ, sub, desc._2));
     case /* Pexp_send */ 21 :
-      return Curry._4(Ast_helper_Exp.send, loc, attrs, Curry._2(sub.expr, sub, desc._0), desc._1);
+      return Ast_helper_Exp.send(loc, attrs, Curry._2(sub.expr, sub, desc._0), desc._1);
     case /* Pexp_new */ 22 :
-      return Curry._3(Ast_helper_Exp.new_, loc, attrs, map_loc(sub, desc._0));
+      return Ast_helper_Exp.new_(loc, attrs, map_loc(sub, desc._0));
     case /* Pexp_setinstvar */ 23 :
-      return Curry._4(Ast_helper_Exp.setinstvar, loc, attrs, map_loc(sub, desc._0), Curry._2(sub.expr, sub, desc._1));
+      return Ast_helper_Exp.setinstvar(loc, attrs, map_loc(sub, desc._0), Curry._2(sub.expr, sub, desc._1));
     case /* Pexp_override */ 24 :
       const partial_arg$2 = Curry._1(sub.expr, sub);
-      return Curry._3(Ast_helper_Exp.override, loc, attrs, Stdlib__List.map((function (param) {
+      return Ast_helper_Exp.override(loc, attrs, Stdlib__List.map((function (param) {
         return map_tuple((function (param) {
           return map_loc(sub, param);
         }), partial_arg$2, param);
       }), desc._0));
     case /* Pexp_letmodule */ 25 :
-      return Curry._5(Ast_helper_Exp.letmodule, loc, attrs, map_loc(sub, desc._0), Curry._2(sub.module_expr, sub, desc._1), Curry._2(sub.expr, sub, desc._2));
+      return Ast_helper_Exp.letmodule(loc, attrs, map_loc(sub, desc._0), Curry._2(sub.module_expr, sub, desc._1), Curry._2(sub.expr, sub, desc._2));
     case /* Pexp_assert */ 26 :
-      return Curry._3(Ast_helper_Exp.assert_, loc, attrs, Curry._2(sub.expr, sub, desc._0));
+      return Ast_helper_Exp.assert_(loc, attrs, Curry._2(sub.expr, sub, desc._0));
     case /* Pexp_lazy */ 27 :
-      return Curry._3(Ast_helper_Exp.lazy_, loc, attrs, Curry._2(sub.expr, sub, desc._0));
+      return Ast_helper_Exp.lazy_(loc, attrs, Curry._2(sub.expr, sub, desc._0));
     case /* Pexp_poly */ 28 :
-      return Curry._4(Ast_helper_Exp.poly, loc, attrs, Curry._2(sub.expr, sub, desc._0), map_opt(Curry._1(sub.typ, sub), desc._1));
+      return Ast_helper_Exp.poly(loc, attrs, Curry._2(sub.expr, sub, desc._0), map_opt(Curry._1(sub.typ, sub), desc._1));
     case /* Pexp_object */ 29 :
-      return Curry._3(Ast_helper_Exp.object_, loc, attrs, Curry._2(sub.class_structure, sub, desc._0));
+      return Ast_helper_Exp.object_(loc, attrs, Curry._2(sub.class_structure, sub, desc._0));
     case /* Pexp_newtype */ 30 :
-      return Curry._4(Ast_helper_Exp.newtype, loc, attrs, desc._0, Curry._2(sub.expr, sub, desc._1));
+      return Ast_helper_Exp.newtype(loc, attrs, desc._0, Curry._2(sub.expr, sub, desc._1));
     case /* Pexp_pack */ 31 :
-      return Curry._3(Ast_helper_Exp.pack, loc, attrs, Curry._2(sub.module_expr, sub, desc._0));
+      return Ast_helper_Exp.pack(loc, attrs, Curry._2(sub.module_expr, sub, desc._0));
     case /* Pexp_open */ 32 :
-      return Curry._5(Ast_helper_Exp.open_, loc, attrs, desc._0, map_loc(sub, desc._1), Curry._2(sub.expr, sub, desc._2));
+      return Ast_helper_Exp.open_(loc, attrs, desc._0, map_loc(sub, desc._1), Curry._2(sub.expr, sub, desc._2));
     case /* Pexp_extension */ 33 :
-      return Curry._3(Ast_helper_Exp.extension, loc, attrs, Curry._2(sub.extension, sub, desc._0));
+      return Ast_helper_Exp.extension(loc, attrs, Curry._2(sub.extension, sub, desc._0));
   }
 }
 
@@ -9987,22 +9987,22 @@ function map_field$1(sub, param) {
   const attrs = Curry._2(sub.attributes, sub, param.pcf_attributes);
   switch (desc.TAG) {
     case /* Pcf_inherit */ 0 :
-      return Curry._5(Ast_helper_Cf.inherit_, loc, attrs, desc._0, Curry._2(sub.class_expr, sub, desc._1), desc._2);
+      return Ast_helper_Cf.inherit_(loc, attrs, desc._0, Curry._2(sub.class_expr, sub, desc._1), desc._2);
     case /* Pcf_val */ 1 :
       const match = desc._0;
-      return Curry._5(Ast_helper_Cf.val_, loc, attrs, map_loc(sub, match[0]), match[1], map_kind(sub, match[2]));
+      return Ast_helper_Cf.val_(loc, attrs, map_loc(sub, match[0]), match[1], map_kind(sub, match[2]));
     case /* Pcf_method */ 2 :
       const match$1 = desc._0;
-      return Curry._5(Ast_helper_Cf.method_, loc, attrs, map_loc(sub, match$1[0]), match$1[1], map_kind(sub, match$1[2]));
+      return Ast_helper_Cf.method_(loc, attrs, map_loc(sub, match$1[0]), match$1[1], map_kind(sub, match$1[2]));
     case /* Pcf_constraint */ 3 :
       const match$2 = desc._0;
-      return Curry._4(Ast_helper_Cf.constraint_, loc, attrs, Curry._2(sub.typ, sub, match$2[0]), Curry._2(sub.typ, sub, match$2[1]));
+      return Ast_helper_Cf.constraint_(loc, attrs, Curry._2(sub.typ, sub, match$2[0]), Curry._2(sub.typ, sub, match$2[1]));
     case /* Pcf_initializer */ 4 :
-      return Curry._3(Ast_helper_Cf.initializer_, loc, attrs, Curry._2(sub.expr, sub, desc._0));
+      return Ast_helper_Cf.initializer_(loc, attrs, Curry._2(sub.expr, sub, desc._0));
     case /* Pcf_attribute */ 5 :
-      return Curry._2(Ast_helper_Cf.attribute, loc, Curry._2(sub.attribute, sub, desc._0));
+      return Ast_helper_Cf.attribute(loc, Curry._2(sub.attribute, sub, desc._0));
     case /* Pcf_extension */ 6 :
-      return Curry._3(Ast_helper_Cf.extension, loc, attrs, Curry._2(sub.extension, sub, desc._0));
+      return Ast_helper_Cf.extension(loc, attrs, Curry._2(sub.extension, sub, desc._0));
   }
 }
 
@@ -15807,7 +15807,7 @@ function mkpat(d) {
 }
 
 function mkexp(d) {
-  return Curry._3(Ast_helper_Exp.mk, symbol_rloc(), undefined, d);
+  return Ast_helper_Exp.mk(symbol_rloc(), undefined, d);
 }
 
 function mkmty(d) {
@@ -15835,11 +15835,11 @@ function mkcty(d) {
 }
 
 function mkctf(attrs, docs, d) {
-  return Curry._4(Ast_helper_Ctf.mk, symbol_rloc(), attrs, docs, d);
+  return Ast_helper_Ctf.mk(symbol_rloc(), attrs, docs, d);
 }
 
 function mkcf(attrs, docs, d) {
-  return Curry._4(Ast_helper_Cf.mk, symbol_rloc(), attrs, docs, d);
+  return Ast_helper_Cf.mk(symbol_rloc(), attrs, docs, d);
 }
 
 function mkoption(d) {
@@ -15889,7 +15889,7 @@ function reloc_exp(x) {
 
 function mkoperator(name, pos) {
   const loc = rhs_loc(pos);
-  return Curry._3(Ast_helper_Exp.mk, loc, undefined, {
+  return Ast_helper_Exp.mk(loc, undefined, {
     TAG: /* Pexp_ident */ 0,
     _0: {
       txt: {
@@ -15912,7 +15912,7 @@ function mkpatvar(name, pos) {
 }
 
 function ghexp(d) {
-  return Curry._3(Ast_helper_Exp.mk, symbol_gloc(), undefined, d);
+  return Ast_helper_Exp.mk(symbol_gloc(), undefined, d);
 }
 
 function ghpat(d) {
@@ -15952,7 +15952,7 @@ function neg_float_string(f) {
 }
 
 function mkexp_cons(consloc, args, loc) {
-  return Curry._3(Ast_helper_Exp.mk, loc, undefined, {
+  return Ast_helper_Exp.mk(loc, undefined, {
     TAG: /* Pexp_construct */ 9,
     _0: {
       txt: {
@@ -15990,7 +15990,7 @@ function mktailexp(nilloc, param) {
       loc_end: loc_loc_end,
       loc_ghost: true
     };
-    const arg = Curry._3(Ast_helper_Exp.mk, loc, undefined, {
+    const arg = Ast_helper_Exp.mk(loc, undefined, {
       TAG: /* Pexp_tuple */ 8,
       _0: {
         hd: e1,
@@ -16021,7 +16021,7 @@ function mktailexp(nilloc, param) {
     txt: nil_txt,
     loc: loc$1
   };
-  return Curry._3(Ast_helper_Exp.mk, loc$1, undefined, {
+  return Ast_helper_Exp.mk(loc$1, undefined, {
     TAG: /* Pexp_construct */ 9,
     _0: nil,
     _1: undefined
@@ -17809,7 +17809,7 @@ const yyact = [
     const _2 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
     return Stdlib.$at({
       hd: _2,
-      tl: Curry._1(Ast_helper_Cf.text, get_text(Stdlib__Parsing.rhs_start_pos(2)))
+      tl: Ast_helper_Cf.text(get_text(Stdlib__Parsing.rhs_start_pos(2)))
     }, _1);
   }),
   (function (__caml_parser_env) {
@@ -18180,7 +18180,7 @@ const yyact = [
     const _2 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
     return Stdlib.$at({
       hd: _2,
-      tl: Curry._1(Ast_helper_Ctf.text, get_text(Stdlib__Parsing.rhs_start_pos(2)))
+      tl: Ast_helper_Ctf.text(get_text(Stdlib__Parsing.rhs_start_pos(2)))
     }, _1);
   }),
   (function (__caml_parser_env) {
@@ -19237,7 +19237,7 @@ const yyact = [
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 1);
     const _2 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
-    return Curry._2(Ast_helper_Exp.attr, _1, _2);
+    return Ast_helper_Exp.attr(_1, _2);
   }),
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
@@ -20026,13 +20026,13 @@ const yyact = [
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 2);
     const _3 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
-    return Curry._3(Ast_helper_Exp.$$case, _1, undefined, _3);
+    return Ast_helper_Exp.$$case(_1, undefined, _3);
   }),
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 4);
     const _3 = Stdlib__Parsing.peek_val(__caml_parser_env, 2);
     const _5 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
-    return Curry._3(Ast_helper_Exp.$$case, _1, _3, _5);
+    return Ast_helper_Exp.$$case(_1, _3, _5);
   }),
   (function (__caml_parser_env) {
     return Stdlib__Parsing.peek_val(__caml_parser_env, 0);
@@ -27538,7 +27538,7 @@ function leave_class_type(c) {
   };
 }
 
-const ClearEnv = Curry._1(TypedtreeMap_MakeMap, {
+const ClearEnv = TypedtreeMap_MakeMap({
   enter_structure: enter_structure,
   enter_value_description: enter_value_description,
   enter_type_declaration: enter_type_declaration,
@@ -29332,7 +29332,7 @@ function generalize_expansive(env, var_level, _ty) {
         }
         match._2.contents = /* Mnil */ 0;
         return Stdlib__List.iter2((function (v, t) {
-          if (Curry._2(Types_Variance.mem, /* May_weak */ 2, v)) {
+          if (Types_Variance.mem(/* May_weak */ 2)(v)) {
             return generalize_contravariant(env)(var_level, t);
           } else {
             return generalize_expansive(env, var_level, t);
@@ -31157,7 +31157,7 @@ function occur_univar(env, ty) {
           try {
             const td = find_type_full(match._0, env)[0];
             return Stdlib__List.iter2((function (t, v) {
-              if (Curry._2(Types_Variance.mem, /* May_pos */ 0, v) || Curry._2(Types_Variance.mem, /* May_neg */ 1, v)) {
+              if (Types_Variance.mem(/* May_pos */ 0)(v) || Types_Variance.mem(/* May_neg */ 1)(v)) {
                 return occur_rec(bound, t);
               }
               
@@ -31261,7 +31261,7 @@ function univars_escape(env, univar_pairs, vl, ty) {
           try {
             const td = find_type_full(match._0, env)[0];
             return Stdlib__List.iter2((function (t, v) {
-              if (Curry._2(Types_Variance.mem, /* May_pos */ 0, v) || Curry._2(Types_Variance.mem, /* May_neg */ 1, v)) {
+              if (Types_Variance.mem(/* May_pos */ 0)(v) || Types_Variance.mem(/* May_neg */ 1)(v)) {
                 return occur(t);
               }
               
@@ -31834,7 +31834,7 @@ function mcomp(type_pairs, env, _t1, _t2) {
                       if (same(p1, p2)) {
                         let inj;
                         try {
-                          inj = Stdlib__List.map(Curry._1(Types_Variance.mem, /* Inj */ 3), find_type_full(p1, env)[0].type_variance);
+                          inj = Stdlib__List.map(Types_Variance.mem(/* Inj */ 3), find_type_full(p1, env)[0].type_variance);
                         }
                         catch (raw_exn$1){
                           const exn$1 = Caml_js_exceptions.internalToOCamlException(raw_exn$1);
@@ -33682,7 +33682,7 @@ function unify3(env, t1, t1$p, t2, t2$p) {
                   } else {
                     let inj;
                     try {
-                      inj = Stdlib__List.map(Curry._1(Types_Variance.mem, /* Inj */ 3), find_type_full(p1, env.contents)[0].type_variance);
+                      inj = Stdlib__List.map(Types_Variance.mem(/* Inj */ 3), find_type_full(p1, env.contents)[0].type_variance);
                     }
                     catch (raw_exn){
                       const exn = Caml_js_exceptions.internalToOCamlException(raw_exn);
@@ -37227,7 +37227,7 @@ function build_subtype(env, visited, loops, posi, level, t) {
             warn.contents = true;
           }
           const tl$p = Stdlib__List.map2((function (v, t) {
-            const match = Curry._1(Types_Variance.get_upper, v);
+            const match = Types_Variance.get_upper(v);
             const co = match[0];
             if (match[1]) {
               if (co) {
@@ -38258,7 +38258,7 @@ function subtype_rec(env, _trace, _t1, _t2, _cstrs) {
                 return Stdlib__List.fold_left2((function (cstrs, v, param) {
                   const t2 = param[1];
                   const t1 = param[0];
-                  const match = Curry._1(Types_Variance.get_upper, v);
+                  const match = Types_Variance.get_upper(v);
                   const cn = match[1];
                   if (match[0]) {
                     if (cn) {
@@ -46356,7 +46356,7 @@ function tree_of_type_decl(id, decl) {
       );
     const vari = Stdlib__List.map2((function (ty, v) {
       if (abstr || !is_Tvar(repr(ty))) {
-        return Curry._1(Types_Variance.get_upper, v);
+        return Types_Variance.get_upper(v);
       } else {
         return [
           true,
@@ -46755,8 +46755,8 @@ function tree_of_class_param(param, variance) {
 function class_variance(param) {
   return Stdlib__List.map((function (v) {
     return [
-      Curry._2(Types_Variance.mem, /* May_pos */ 0, v),
-      Curry._2(Types_Variance.mem, /* May_neg */ 1, v)
+      Types_Variance.mem(/* May_pos */ 0)(v),
+      Types_Variance.mem(/* May_neg */ 1)(v)
     ];
   }), param);
 }
@@ -50345,10 +50345,10 @@ function type_declarations$1(equalityOpt, env, name, decl1, id, decl2) {
   if (Stdlib__List.for_all2((function (ty, param) {
       const v2 = param[1];
       const v1 = param[0];
-      const match = Curry._1(Types_Variance.get_upper, v1);
+      const match = Types_Variance.get_upper(v1);
       const cn1 = match[1];
       const co1 = match[0];
-      const match$1 = Curry._1(Types_Variance.get_upper, v2);
+      const match$1 = Types_Variance.get_upper(v2);
       const cn2 = match$1[1];
       const co2 = match$1[0];
       if (!(
@@ -50358,8 +50358,8 @@ function type_declarations$1(equalityOpt, env, name, decl1, id, decl2) {
         )) {
         return false;
       }
-      const match$2 = Curry._1(Types_Variance.get_lower, v1);
-      const match$3 = Curry._1(Types_Variance.get_lower, v2);
+      const match$2 = Types_Variance.get_lower(v1);
+      const match$3 = Types_Variance.get_lower(v2);
       return abstr ? (
           (!match$3[0] || match$2[0]) && (!match$3[1] || match$2[1]) && (!match$3[2] || match$2[2]) ? (
               match$3[3] ? match$2[3] : true
@@ -66157,7 +66157,7 @@ const self_coercion = {
 function wrap_unpacks(sexp, unpacks) {
   return Stdlib__List.fold_left((function (sexp, param) {
     const name = param[0];
-    return Curry._5(Ast_helper_Exp.letmodule, sexp.pexp_loc, undefined, name, unpack$1(param[1], undefined, Curry._3(Ast_helper_Exp.ident, name.loc, undefined, {
+    return Ast_helper_Exp.letmodule(sexp.pexp_loc, undefined, name, unpack$1(param[1], undefined, Ast_helper_Exp.ident(name.loc, undefined, {
       txt: {
         TAG: /* Lident */ 0,
         _0: name.txt
@@ -66636,7 +66636,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
                   TAG: /* Pexp_match */ 6,
                   _0: match$6.pvb_expr,
                   _1: {
-                    hd: Curry._3(Ast_helper_Exp.$$case, spat, undefined, lid._2),
+                    hd: Ast_helper_Exp.$$case(spat, undefined, lid._2),
                     tl: /* [] */ 0
                   }
                 },
@@ -66705,7 +66705,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
             });
         }
         const default_loc = $$default.pexp_loc;
-        const scases_0 = Curry._3(Ast_helper_Exp.$$case, construct(default_loc, undefined, {
+        const scases_0 = Ast_helper_Exp.$$case(construct(default_loc, undefined, {
           txt: {
             TAG: /* Ldot */ 1,
             _0: {
@@ -66718,7 +66718,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
         }, $$var$1(default_loc, undefined, {
           txt: "*sth*",
           loc: none
-        })), undefined, Curry._3(Ast_helper_Exp.ident, default_loc, undefined, {
+        })), undefined, Ast_helper_Exp.ident(default_loc, undefined, {
           txt: {
             TAG: /* Lident */ 0,
             _0: "*sth*"
@@ -66726,7 +66726,7 @@ function type_expect_(in_function, env, sexp, ty_expected) {
           loc: none
         }));
         const scases_1 = {
-          hd: Curry._3(Ast_helper_Exp.$$case, construct(default_loc, undefined, {
+          hd: Ast_helper_Exp.$$case(construct(default_loc, undefined, {
             txt: {
               TAG: /* Ldot */ 1,
               _0: {
@@ -66743,17 +66743,17 @@ function type_expect_(in_function, env, sexp, ty_expected) {
           hd: scases_0,
           tl: scases_1
         };
-        const smatch = Curry._4(Ast_helper_Exp.match_, loc, undefined, Curry._3(Ast_helper_Exp.ident, loc, undefined, {
+        const smatch = Ast_helper_Exp.match_(loc, undefined, Ast_helper_Exp.ident(loc, undefined, {
           txt: {
             TAG: /* Lident */ 0,
             _0: "*opt*"
           },
           loc: none
         }), scases);
-        const sfun = Curry._6(Ast_helper_Exp.fun_, loc, undefined, l, undefined, $$var$1(loc, undefined, {
+        const sfun = Ast_helper_Exp.fun_(loc, undefined, l, undefined, $$var$1(loc, undefined, {
           txt: "*opt*",
           loc: none
-        }), Curry._5(Ast_helper_Exp.let_, loc, {
+        }), Ast_helper_Exp.let_(loc, {
           hd: [
             {
               txt: "#default",
@@ -73398,10 +73398,10 @@ function compute_variance(env, visited, vari, ty) {
       const vari = _vari;
       const ty$1 = repr(ty);
       const vari$p = get_variance(ty$1, visited);
-      if (Curry._2(Types_Variance.subset, vari, vari$p)) {
+      if (Types_Variance.subset(vari, vari$p)) {
         return;
       }
-      const vari$1 = Curry._2(Types_Variance.union, vari, vari$p);
+      const vari$1 = Types_Variance.union(vari, vari$p);
       visited.contents = Curry._3(add$4, ty$1, vari$1, visited.contents);
       const compute_same = function (param) {
         return compute_variance_rec(vari$1, param);
@@ -73412,8 +73412,8 @@ function compute_variance(env, visited, vari, ty) {
       }
       switch (tl.TAG) {
         case /* Tarrow */ 1 :
-          const v = Curry._1(Types_Variance.conjugate, vari$1);
-          const v1 = Curry._2(Types_Variance.mem, /* May_pos */ 0, v) || Curry._2(Types_Variance.mem, /* May_neg */ 1, v) ? Curry._3(Types_Variance.set, /* May_weak */ 2, true, v) : v;
+          const v = Types_Variance.conjugate(vari$1);
+          const v1 = Types_Variance.mem(/* May_pos */ 0)(v) || Types_Variance.mem(/* May_neg */ 1)(v) ? Types_Variance.set(/* May_weak */ 2, true, v) : v;
           compute_variance_rec(v1, tl._1);
           _ty = tl._2;
           _vari = vari$1;
@@ -73428,15 +73428,15 @@ function compute_variance(env, visited, vari, ty) {
           try {
             const decl = find_type_full(tl._0, env)[0];
             return Stdlib__List.iter2((function (ty, v) {
-              const strict = Curry._2(Types_Variance.mem, /* Inv */ 6, vari$1) && Curry._2(Types_Variance.mem, /* Inj */ 3, v) || (Curry._2(Types_Variance.mem, /* Pos */ 4, vari$1) || Curry._2(Types_Variance.mem, /* Neg */ 5, vari$1)) && Curry._2(Types_Variance.mem, /* Inv */ 6, v);
+              const strict = Types_Variance.mem(/* Inv */ 6)(vari$1) && Types_Variance.mem(/* Inj */ 3)(v) || (Types_Variance.mem(/* Pos */ 4)(vari$1) || Types_Variance.mem(/* Neg */ 5)(vari$1)) && Types_Variance.mem(/* Inv */ 6)(v);
               if (strict) {
                 return compute_variance_rec(Types_Variance.full, ty);
               }
-              const p1 = Curry._2(Types_Variance.inter, v, vari$1);
-              const n1 = Curry._2(Types_Variance.inter, v, Curry._1(Types_Variance.conjugate, vari$1));
-              const v1 = Curry._2(Types_Variance.union, Curry._2(Types_Variance.inter, Types_Variance.covariant, Curry._2(Types_Variance.union, p1, Curry._1(Types_Variance.conjugate, p1))), Curry._2(Types_Variance.inter, Curry._1(Types_Variance.conjugate, Types_Variance.covariant), Curry._2(Types_Variance.union, n1, Curry._1(Types_Variance.conjugate, n1))));
-              const weak = Curry._2(Types_Variance.mem, /* May_weak */ 2, vari$1) && (Curry._2(Types_Variance.mem, /* May_pos */ 0, v) || Curry._2(Types_Variance.mem, /* May_neg */ 1, v)) || (Curry._2(Types_Variance.mem, /* May_pos */ 0, vari$1) || Curry._2(Types_Variance.mem, /* May_neg */ 1, vari$1)) && Curry._2(Types_Variance.mem, /* May_weak */ 2, v);
-              const v2 = Curry._3(Types_Variance.set, /* May_weak */ 2, weak, v1);
+              const p1 = Types_Variance.inter(v, vari$1);
+              const n1 = Types_Variance.inter(v, Types_Variance.conjugate(vari$1));
+              const v1 = Types_Variance.union(Types_Variance.inter(Types_Variance.covariant, Types_Variance.union(p1, Types_Variance.conjugate(p1))), Types_Variance.inter(Types_Variance.conjugate(Types_Variance.covariant), Types_Variance.union(n1, Types_Variance.conjugate(n1))));
+              const weak = Types_Variance.mem(/* May_weak */ 2)(vari$1) && (Types_Variance.mem(/* May_pos */ 0)(v) || Types_Variance.mem(/* May_neg */ 1)(v)) || (Types_Variance.mem(/* May_pos */ 0)(vari$1) || Types_Variance.mem(/* May_neg */ 1)(vari$1)) && Types_Variance.mem(/* May_weak */ 2)(v);
+              const v2 = Types_Variance.set(/* May_weak */ 2, weak, v1);
               compute_variance_rec(v2, ty);
             }), tl$1, decl.type_variance);
           }
@@ -73470,7 +73470,7 @@ function compute_variance(env, visited, vari, ty) {
               }
             }
             const upper = Stdlib__List.fold_left((function (s, f) {
-              return Curry._3(Types_Variance.set, f, true, s);
+              return Types_Variance.set(f, true, s);
             }), Types_Variance.$$null, {
               hd: /* May_pos */ 0,
               tl: {
@@ -73481,7 +73481,7 @@ function compute_variance(env, visited, vari, ty) {
                 }
               }
             });
-            const v = Curry._2(Types_Variance.inter, vari$1, upper);
+            const v = Types_Variance.inter(vari$1, upper);
             Stdlib__List.iter((function (param) {
               return compute_variance_rec(v, param);
             }), match._1);
@@ -73496,7 +73496,7 @@ function compute_variance(env, visited, vari, ty) {
           _vari = vari$1;
           continue;
         case /* Tpackage */ 11 :
-          const v$1 = Curry._2(Types_Variance.mem, /* Pos */ 4, vari$1) || Curry._2(Types_Variance.mem, /* Neg */ 5, vari$1) ? Types_Variance.full : Types_Variance.may_inv;
+          const v$1 = Types_Variance.mem(/* Pos */ 4)(vari$1) || Types_Variance.mem(/* Neg */ 5)(vari$1) ? Types_Variance.full : Types_Variance.may_inv;
           return Stdlib__List.iter((function (param) {
             return compute_variance_rec(v$1, param);
           }), tl._2);
@@ -73509,7 +73509,7 @@ function compute_variance(env, visited, vari, ty) {
 }
 
 function make(p, n, i) {
-  return Curry._3(Types_Variance.set, /* May_pos */ 0, p, Curry._3(Types_Variance.set, /* May_neg */ 1, n, Curry._3(Types_Variance.set, /* May_weak */ 2, n, Curry._3(Types_Variance.set, /* Inj */ 3, i, Types_Variance.$$null))));
+  return Types_Variance.set(/* May_pos */ 0, p, Types_Variance.set(/* May_neg */ 1, n, Types_Variance.set(/* May_weak */ 2, n, Types_Variance.set(/* Inj */ 3, i, Types_Variance.$$null))));
 }
 
 function compute_variance_type(env, check, param, decl, tyl) {
@@ -73549,10 +73549,10 @@ function compute_variance_type(env, check, param, decl, tyl) {
       const c = param[0];
       pos.contents = pos.contents + 1 | 0;
       const $$var = get_variance(ty, tvl);
-      const match = Curry._1(Types_Variance.get_upper, $$var);
+      const match = Types_Variance.get_upper($$var);
       const cn = match[1];
       const co = match[0];
-      const ij = Curry._2(Types_Variance.mem, /* Inj */ 3, $$var);
+      const ij = Types_Variance.mem(/* Inj */ 3)($$var);
       if (!(is_Tvar(ty) && (co && !c || cn && !n || !ij && i))) {
         return;
       }
@@ -73593,7 +73593,7 @@ function compute_variance_type(env, check, param, decl, tyl) {
         }
         const v = param[0] ? (
             param[1] ? Types_Variance.full : Types_Variance.covariant
-          ) : Curry._1(Types_Variance.conjugate, Types_Variance.covariant);
+          ) : Types_Variance.conjugate(Types_Variance.covariant);
         compute_variance(env, tvl2, v, ty);
       }), params, required);
       const visited = {
@@ -73616,16 +73616,16 @@ function compute_variance_type(env, check, param, decl, tyl) {
               hd: t,
               tl: /* [] */ 0
             })) {
-            return Curry._2(Types_Variance.union, vt, v);
+            return Types_Variance.union(vt, v);
           } else {
             return v;
           }
         }), tvl2.contents, Types_Variance.$$null);
         backtrack(snap);
-        const match = Curry._1(Types_Variance.get_upper, v1);
+        const match = Types_Variance.get_upper(v1);
         const n1 = match[1];
         const c1 = match[0];
-        const match$1 = Curry._1(Types_Variance.get_lower, v2);
+        const match$1 = Types_Variance.get_lower(v2);
         const n2 = match$1[1];
         const c2 = match$1[0];
         if (!(c1 && !c2 || n1 && !n2)) {
@@ -73676,18 +73676,18 @@ function compute_variance_type(env, check, param, decl, tyl) {
     const n = match[1];
     const p = match[0];
     const i = concr || param[2] && tr === /* Private */ 0;
-    const v$1 = Curry._2(Types_Variance.union, v, make(p, n, i));
+    const v$1 = Types_Variance.union(v, make(p, n, i));
     const v$2 = concr ? (
-        Curry._2(Types_Variance.mem, /* Pos */ 4, v$1) && Curry._2(Types_Variance.mem, /* Neg */ 5, v$1) ? Types_Variance.full : (
-            is_Tvar(ty) ? v$1 : Curry._2(Types_Variance.union, v$1, p ? (
+        Types_Variance.mem(/* Pos */ 4)(v$1) && Types_Variance.mem(/* Neg */ 5)(v$1) ? Types_Variance.full : (
+            is_Tvar(ty) ? v$1 : Types_Variance.union(v$1, p ? (
                   n ? Types_Variance.full : Types_Variance.covariant
-                ) : Curry._1(Types_Variance.conjugate, Types_Variance.covariant))
+                ) : Types_Variance.conjugate(Types_Variance.covariant))
           )
       ) : v$1;
     if (Caml_obj.caml_equal(decl.type_kind, /* Type_abstract */ 0) && tr === /* Public */ 1) {
       return v$2;
     } else {
-      return Curry._3(Types_Variance.set, /* May_weak */ 2, Curry._2(Types_Variance.mem, /* May_neg */ 1, v$2), v$2);
+      return Types_Variance.set(/* May_weak */ 2, Types_Variance.mem(/* May_neg */ 1)(v$2), v$2);
     }
   }), params, required);
 }
@@ -73874,7 +73874,7 @@ function compute_variance_decl(env, check, decl, rloc) {
       return Stdlib__List.map2(Types_Variance.union, param, param$1);
     }), match.hd, match.tl);
     return Stdlib__List.map((function (v) {
-      if (Curry._2(Types_Variance.mem, /* Pos */ 4, v) && Curry._2(Types_Variance.mem, /* Neg */ 5, v)) {
+      if (Types_Variance.mem(/* Pos */ 4)(v) && Types_Variance.mem(/* Neg */ 5)(v)) {
         return Types_Variance.full;
       } else {
         return v;
@@ -75065,7 +75065,7 @@ function transl_type_extension(check_open, env, loc, styext) {
       });
   }
   const type_variance = Stdlib__List.map((function (v) {
-    const match = Curry._1(Types_Variance.get_upper, v);
+    const match = Types_Variance.get_upper(v);
     return [
       !match[1],
       !match[0],
@@ -77572,7 +77572,7 @@ function type_constraint(val_env, sty, sty$p, loc) {
 }
 
 function make_method(loc, cl_num, expr) {
-  return Curry._6(Ast_helper_Exp.fun_, expr.pexp_loc, undefined, "", undefined, alias$1(loc, undefined, $$var$1(loc, undefined, {
+  return Ast_helper_Exp.fun_(expr.pexp_loc, undefined, "", undefined, alias$1(loc, undefined, $$var$1(loc, undefined, {
     txt: "self-*",
     loc: loc
   }), {
@@ -78329,7 +78329,7 @@ function class_structure(cl_num, $$final, val_env, met_env, loc, param) {
         const ovf$2 = sty._0;
         const match$10 = expr$1.pexp_desc;
         let expr$2;
-        expr$2 = match$10.TAG === /* Pexp_poly */ 28 ? expr$1 : Curry._4(Ast_helper_Exp.poly, expr$1.pexp_loc, undefined, expr$1, undefined);
+        expr$2 = match$10.TAG === /* Pexp_poly */ 28 ? expr$1 : Ast_helper_Exp.poly(expr$1.pexp_loc, undefined, expr$1, undefined);
         if (Curry._2(mem$2, lab$1.txt, local_meths)) {
           throw new Caml_js_exceptions.MelangeError($$Error$9, {
               MEL_EXN_ID: $$Error$9,
@@ -78856,7 +78856,7 @@ function class_expr(cl_num, val_env, met_env, _scl) {
         const l = cl_str._0;
         if ($$default !== undefined) {
           const loc = $$default.pexp_loc;
-          const scases_0 = Curry._3(Ast_helper_Exp.$$case, construct(loc, undefined, {
+          const scases_0 = Ast_helper_Exp.$$case(construct(loc, undefined, {
             txt: {
               TAG: /* Ldot */ 1,
               _0: {
@@ -78869,7 +78869,7 @@ function class_expr(cl_num, val_env, met_env, _scl) {
           }, $$var$1(loc, undefined, {
             txt: "*sth*",
             loc: none
-          })), undefined, Curry._3(Ast_helper_Exp.ident, loc, undefined, {
+          })), undefined, Ast_helper_Exp.ident(loc, undefined, {
             txt: {
               TAG: /* Lident */ 0,
               _0: "*sth*"
@@ -78877,7 +78877,7 @@ function class_expr(cl_num, val_env, met_env, _scl) {
             loc: none
           }));
           const scases_1 = {
-            hd: Curry._3(Ast_helper_Exp.$$case, construct(loc, undefined, {
+            hd: Ast_helper_Exp.$$case(construct(loc, undefined, {
               txt: {
                 TAG: /* Ldot */ 1,
                 _0: {
@@ -78894,7 +78894,7 @@ function class_expr(cl_num, val_env, met_env, _scl) {
             hd: scases_0,
             tl: scases_1
           };
-          const smatch = Curry._4(Ast_helper_Exp.match_, loc, undefined, Curry._3(Ast_helper_Exp.ident, loc, undefined, {
+          const smatch = Ast_helper_Exp.match_(loc, undefined, Ast_helper_Exp.ident(loc, undefined, {
             txt: {
               TAG: /* Lident */ 0,
               _0: "*opt*"
@@ -82074,7 +82074,7 @@ function merge_constraint(initial_env, loc, sg, constr) {
                         let p = !match[1];
                         let n = !match[0];
                         let i = false;
-                        return Curry._3(Types_Variance.set, /* May_pos */ 0, p, Curry._3(Types_Variance.set, /* May_neg */ 1, n, Curry._3(Types_Variance.set, /* May_weak */ 2, n, Curry._3(Types_Variance.set, /* Inj */ 3, i, Types_Variance.$$null))));
+                        return Types_Variance.set(/* May_pos */ 0, p, Types_Variance.set(/* May_neg */ 1, n, Types_Variance.set(/* May_weak */ 2, n, Types_Variance.set(/* Inj */ 3, i, Types_Variance.$$null))));
                       }), sdecl.ptype_params);
                       const decl_row_type_loc = sdecl.ptype_loc;
                       const decl_row = {

--- a/jscomp/test/dist/parser_api.js
+++ b/jscomp/test/dist/parser_api.js
@@ -3528,7 +3528,7 @@ function get_pos_info(pos) {
 }
 
 function print_loc(ppf, loc) {
-  Curry._1(Misc_Color.setup, color.contents);
+  Misc_Color.setup(color.contents);
   const match = get_pos_info(loc.loc_start);
   const startchar = match[2];
   const file = match[0];
@@ -3645,7 +3645,7 @@ function print_loc(ppf, loc) {
 }
 
 function print$1(ppf, loc) {
-  Curry._1(Misc_Color.setup, color.contents);
+  Misc_Color.setup(color.contents);
   if (loc.loc_start.pos_fname === "//toplevel//" && highlight_locations(ppf, {
       hd: loc,
       tl: /* [] */ 0
@@ -3693,7 +3693,7 @@ function print$1(ppf, loc) {
 const error_prefix = "Error";
 
 function print_error_prefix(ppf, param) {
-  Curry._1(Misc_Color.setup, color.contents);
+  Misc_Color.setup(color.contents);
   Curry._1(Stdlib__Format.fprintf(ppf)({
     TAG: /* Format */ 0,
     _0: {
@@ -3739,7 +3739,7 @@ function print_error_cur_file(ppf, param) {
 
 function default_warning_printer(loc, ppf, w) {
   if (is_active(w)) {
-    Curry._1(Misc_Color.setup, color.contents);
+    Misc_Color.setup(color.contents);
     print$1(ppf, loc);
     return Curry._3(Stdlib__Format.fprintf(ppf)({
       TAG: /* Format */ 0,
@@ -3822,7 +3822,7 @@ function mknoloc(txt) {
 function pp_ksprintf(before, k, fmt) {
   const buf = Stdlib__Buffer.create(64);
   const ppf = Stdlib__Format.formatter_of_buffer(buf);
-  Curry._1(Misc_Color.set_color_tag_handling, ppf);
+  Misc_Color.set_color_tag_handling(ppf);
   if (before !== undefined) {
     Curry._1(before, ppf);
   }
@@ -6794,7 +6794,7 @@ function mkpat(d) {
 }
 
 function mkexp(d) {
-  return Curry._3(Ast_helper_Exp.mk, symbol_rloc(), undefined, d);
+  return Ast_helper_Exp.mk(symbol_rloc(), undefined, d);
 }
 
 function mkmty(d) {
@@ -6822,11 +6822,11 @@ function mkcty(d) {
 }
 
 function mkctf(attrs, docs, d) {
-  return Curry._4(Ast_helper_Ctf.mk, symbol_rloc(), attrs, docs, d);
+  return Ast_helper_Ctf.mk(symbol_rloc(), attrs, docs, d);
 }
 
 function mkcf(attrs, docs, d) {
-  return Curry._4(Ast_helper_Cf.mk, symbol_rloc(), attrs, docs, d);
+  return Ast_helper_Cf.mk(symbol_rloc(), attrs, docs, d);
 }
 
 function mkoption(d) {
@@ -6876,7 +6876,7 @@ function reloc_exp(x) {
 
 function mkoperator(name, pos) {
   const loc = rhs_loc(pos);
-  return Curry._3(Ast_helper_Exp.mk, loc, undefined, {
+  return Ast_helper_Exp.mk(loc, undefined, {
     TAG: /* Pexp_ident */ 0,
     _0: {
       txt: {
@@ -6899,7 +6899,7 @@ function mkpatvar(name, pos) {
 }
 
 function ghexp(d) {
-  return Curry._3(Ast_helper_Exp.mk, symbol_gloc(), undefined, d);
+  return Ast_helper_Exp.mk(symbol_gloc(), undefined, d);
 }
 
 function ghpat(d) {
@@ -6939,7 +6939,7 @@ function neg_float_string(f) {
 }
 
 function mkexp_cons(consloc, args, loc) {
-  return Curry._3(Ast_helper_Exp.mk, loc, undefined, {
+  return Ast_helper_Exp.mk(loc, undefined, {
     TAG: /* Pexp_construct */ 9,
     _0: {
       txt: {
@@ -6977,7 +6977,7 @@ function mktailexp(nilloc, param) {
       loc_end: loc_loc_end,
       loc_ghost: true
     };
-    const arg = Curry._3(Ast_helper_Exp.mk, loc, undefined, {
+    const arg = Ast_helper_Exp.mk(loc, undefined, {
       TAG: /* Pexp_tuple */ 8,
       _0: {
         hd: e1,
@@ -7008,7 +7008,7 @@ function mktailexp(nilloc, param) {
     txt: nil_txt,
     loc: loc$1
   };
-  return Curry._3(Ast_helper_Exp.mk, loc$1, undefined, {
+  return Ast_helper_Exp.mk(loc$1, undefined, {
     TAG: /* Pexp_construct */ 9,
     _0: nil,
     _1: undefined
@@ -8796,7 +8796,7 @@ const yyact = [
     const _2 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
     return Stdlib.$at({
       hd: _2,
-      tl: Curry._1(Ast_helper_Cf.text, get_text(Stdlib__Parsing.rhs_start_pos(2)))
+      tl: Ast_helper_Cf.text(get_text(Stdlib__Parsing.rhs_start_pos(2)))
     }, _1);
   }),
   (function (__caml_parser_env) {
@@ -9167,7 +9167,7 @@ const yyact = [
     const _2 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
     return Stdlib.$at({
       hd: _2,
-      tl: Curry._1(Ast_helper_Ctf.text, get_text(Stdlib__Parsing.rhs_start_pos(2)))
+      tl: Ast_helper_Ctf.text(get_text(Stdlib__Parsing.rhs_start_pos(2)))
     }, _1);
   }),
   (function (__caml_parser_env) {
@@ -10224,7 +10224,7 @@ const yyact = [
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 1);
     const _2 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
-    return Curry._2(Ast_helper_Exp.attr, _1, _2);
+    return Ast_helper_Exp.attr(_1, _2);
   }),
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
@@ -11013,13 +11013,13 @@ const yyact = [
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 2);
     const _3 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
-    return Curry._3(Ast_helper_Exp.$$case, _1, undefined, _3);
+    return Ast_helper_Exp.$$case(_1, undefined, _3);
   }),
   (function (__caml_parser_env) {
     const _1 = Stdlib__Parsing.peek_val(__caml_parser_env, 4);
     const _3 = Stdlib__Parsing.peek_val(__caml_parser_env, 2);
     const _5 = Stdlib__Parsing.peek_val(__caml_parser_env, 0);
-    return Curry._3(Ast_helper_Exp.$$case, _1, _3, _5);
+    return Ast_helper_Exp.$$case(_1, _3, _5);
   }),
   (function (__caml_parser_env) {
     return Stdlib__Parsing.peek_val(__caml_parser_env, 0);

--- a/node_modules/melange/dynarray.js
+++ b/node_modules/melange/dynarray.js
@@ -560,7 +560,7 @@ function make$1(n, x) {
     negative_length_requested("make", n);
   }
   const dummy = global_dummy._0;
-  const arr = Curry._3(Dummy_Array.make, n, x, dummy);
+  const arr = Dummy_Array.make(n, x, dummy);
   return {
     length: n,
     arr: arr,
@@ -573,7 +573,7 @@ function init$1(n, f) {
     negative_length_requested("init", n);
   }
   const dummy = global_dummy._0;
-  const arr = Curry._3(Dummy_Array.init, n, f, dummy);
+  const arr = Dummy_Array.init(n, f, dummy);
   return {
     length: n,
     arr: arr,
@@ -586,7 +586,7 @@ function get(a, i) {
   if (v === a.dummy) {
     return unexpected_empty_element("get", i, a.length);
   } else {
-    return Curry._1(Dummy_unsafe_get, v);
+    return Dummy_unsafe_get(v);
   }
 }
 
@@ -596,7 +596,7 @@ function set(a, i, x) {
   if (i >= length) {
     return index_out_of_bounds("set", i, length);
   } else {
-    return Caml_array.set(arr, i, Curry._1(Dummy_of_val, x));
+    return Caml_array.set(arr, i, Dummy_of_val(x));
   }
 }
 
@@ -615,7 +615,7 @@ function copy(param) {
   if (length > capacity) {
     invalid_length(length, capacity);
   }
-  const arr$1 = Curry._2(Dummy_Array.prefix, arr, length);
+  const arr$1 = Dummy_Array.prefix(arr, length);
   return {
     length: length,
     arr: arr$1,
@@ -638,7 +638,7 @@ function get_last(a) {
   if (v === a.dummy) {
     return missing_element(i, length);
   } else {
-    return Curry._1(Dummy_unsafe_get, v);
+    return Dummy_unsafe_get(v);
   }
 }
 
@@ -654,7 +654,7 @@ function find_last(a) {
   }
   const i = length - 1 | 0;
   const v = arr[i];
-  return Caml_option.some(v === a.dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+  return Caml_option.some(v === a.dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
 }
 
 function pop_last(a) {
@@ -672,8 +672,8 @@ function pop_last(a) {
   }
   const last = length - 1 | 0;
   const v = arr[last];
-  const v$1 = v === dummy ? missing_element(last, length) : Curry._1(Dummy_unsafe_get, v);
-  arr[last] = Curry._1(Dummy_of_dummy, dummy);
+  const v$1 = v === dummy ? missing_element(last, length) : Dummy_unsafe_get(v);
+  arr[last] = Dummy_of_dummy(dummy);
   a.length = last;
   return v$1;
 }
@@ -697,7 +697,7 @@ function remove_last(a) {
   const last = a.length - 1 | 0;
   if (last >= 0) {
     a.length = last;
-    return Caml_array.set(a.arr, last, Curry._1(Dummy_of_dummy, a.dummy));
+    return Caml_array.set(a.arr, last, Dummy_of_dummy(a.dummy));
   }
   
 }
@@ -712,7 +712,7 @@ function truncate(a, n) {
     return;
   } else {
     a.length = n;
-    return Stdlib__Array.fill(arr, n, length - n | 0, Curry._1(Dummy_of_dummy, a.dummy));
+    return Stdlib__Array.fill(arr, n, length - n | 0, Dummy_of_dummy(a.dummy));
   }
 }
 
@@ -752,7 +752,7 @@ function ensure_capacity(a, capacity_request) {
         ]
       });
   }
-  const new_arr = Curry._4(Dummy_Array.extend, arr, a.length, a.dummy, new_capacity);
+  const new_arr = Dummy_Array.extend(arr, a.length, a.dummy, new_capacity);
   a.arr = new_arr;
   if (0 > capacity_request) {
     throw new Caml_js_exceptions.MelangeError("Assert_failure", {
@@ -785,7 +785,7 @@ function fit_capacity(a) {
   if (a.arr.length === a.length) {
     return;
   } else {
-    a.arr = Curry._2(Dummy_Array.prefix, a.arr, a.length);
+    a.arr = Dummy_Array.prefix(a.arr, a.length);
     return;
   }
 }
@@ -798,10 +798,10 @@ function set_capacity(a, n) {
   const cur_capacity = arr.length;
   if (n < cur_capacity) {
     a.length = a.length < n ? a.length : n;
-    a.arr = Curry._2(Dummy_Array.prefix, arr, n);
+    a.arr = Dummy_Array.prefix(arr, n);
     return;
   } else if (n > cur_capacity) {
-    a.arr = Curry._4(Dummy_Array.extend, arr, a.length, a.dummy, n);
+    a.arr = Dummy_Array.extend(arr, a.length, a.dummy, n);
     return;
   } else {
     return;
@@ -816,14 +816,14 @@ function reset(a) {
 function add_last(a, x) {
   const length = a.length;
   const arr = a.arr;
-  if (length >= arr.length ? false : (a.length = length + 1 | 0, arr[length] = Curry._1(Dummy_of_val, x), true)) {
+  if (length >= arr.length ? false : (a.length = length + 1 | 0, arr[length] = Dummy_of_val(x), true)) {
     return;
   }
   while (true) {
     ensure_extra_capacity(a, 1);
     const length$1 = a.length;
     const arr$1 = a.arr;
-    if (length$1 >= arr$1.length ? false : (a.length = length$1 + 1 | 0, arr$1[length$1] = Curry._1(Dummy_of_val, x), true)) {
+    if (length$1 >= arr$1.length ? false : (a.length = length$1 + 1 | 0, arr$1[length$1] = Dummy_of_val(x), true)) {
       return;
     }
     continue;
@@ -863,7 +863,7 @@ function blit_assume_room(src, src_pos, src_length, dst, dst_pos, dst_length, bl
     dst.length = dst_pos + blit_length | 0;
   }
   try {
-    return Curry._7(Dummy_Array.blit, src_arr, src.dummy, src_pos, dst_arr, dst.dummy, dst_pos, blit_length);
+    return Dummy_Array.blit(src_arr, src.dummy, src_pos, dst_arr, dst.dummy, dst_pos, blit_length);
   }
   catch (raw_i){
     const i = Caml_js_exceptions.internalToOCamlException(raw_i);
@@ -984,7 +984,7 @@ function append_array_if_room(a, b) {
     return false;
   } else {
     a.length = length_a + length_b | 0;
-    Curry._5(Dummy_Array.blit_array, b, 0, arr, length_a, length_b);
+    Dummy_Array.blit_array(b, 0, arr, length_a, length_b);
     return true;
   }
 }
@@ -1039,7 +1039,7 @@ function iter_(fname, f, a) {
   }
   for (let i = 0; i < length; ++i) {
     const v = arr[i];
-    Curry._1(f, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+    Curry._1(f, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
   }
   check_same_length(fname, a, length);
 }
@@ -1058,7 +1058,7 @@ function iteri(f, a) {
   }
   for (let i = 0; i < length; ++i) {
     const v = arr[i];
-    Curry._2(f, i, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+    Curry._2(f, i, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
   }
   check_same_length("iteri", a, length);
 }
@@ -1073,7 +1073,7 @@ function rev_iter(f, a) {
   }
   for (let i = length - 1 | 0; i >= 0; --i) {
     const v = arr[i];
-    Curry._1(f, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+    Curry._1(f, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
   }
   check_same_length("rev_iter", a, length);
 }
@@ -1088,7 +1088,7 @@ function rev_iteri(f, a) {
   }
   for (let i = length - 1 | 0; i >= 0; --i) {
     const v = arr[i];
-    Curry._2(f, i, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+    Curry._2(f, i, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
   }
   check_same_length("rev_iteri", a, length);
 }
@@ -1101,10 +1101,10 @@ function map(f, a) {
   if (length > capacity) {
     invalid_length(length, capacity);
   }
-  const arr_out = Caml_array.make(length, Curry._1(Dummy_of_dummy, dummy));
+  const arr_out = Caml_array.make(length, Dummy_of_dummy(dummy));
   for (let i = 0; i < length; ++i) {
     const v = arr_in[i];
-    arr_out[i] = Curry._1(Dummy_of_val, Curry._1(f, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v)));
+    arr_out[i] = Dummy_of_val(Curry._1(f, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v)));
   }
   const res = {
     length: length,
@@ -1123,10 +1123,10 @@ function mapi(f, a) {
   if (length > capacity) {
     invalid_length(length, capacity);
   }
-  const arr_out = Caml_array.make(length, Curry._1(Dummy_of_dummy, dummy));
+  const arr_out = Caml_array.make(length, Dummy_of_dummy(dummy));
   for (let i = 0; i < length; ++i) {
     const v = arr_in[i];
-    arr_out[i] = Curry._1(Dummy_of_val, Curry._2(f, i, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v)));
+    arr_out[i] = Dummy_of_val(Curry._2(f, i, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v)));
   }
   const res = {
     length: length,
@@ -1148,7 +1148,7 @@ function fold_left(f, acc, a) {
   let r = acc;
   for (let i = 0; i < length; ++i) {
     const v = arr[i];
-    const v$1 = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+    const v$1 = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
     r = Curry._2(f, r, v$1);
   }
   check_same_length("fold_left", a, length);
@@ -1166,7 +1166,7 @@ function fold_right(f, a, acc) {
   let r = acc;
   for (let i = length - 1 | 0; i >= 0; --i) {
     const v = arr[i];
-    const v$1 = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+    const v$1 = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
     r = Curry._2(f, v$1, r);
   }
   check_same_length("fold_right", a, length);
@@ -1187,7 +1187,7 @@ function exists(p, a) {
         return false;
       }
       const v = arr[i];
-      if (Curry._1(p, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v))) {
+      if (Curry._1(p, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v))) {
         return true;
       }
       _i = i + 1 | 0;
@@ -1213,7 +1213,7 @@ function for_all(p, a) {
         return true;
       }
       const v = arr[i];
-      if (!Curry._1(p, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v))) {
+      if (!Curry._1(p, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v))) {
         return false;
       }
       _i = i + 1 | 0;
@@ -1249,7 +1249,7 @@ function exists2(p, a1, a2) {
       }
       const v = arr1[i];
       const v$1 = arr2[i];
-      if (Curry._2(p, v === dummy1 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), v$1 === dummy2 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v$1))) {
+      if (Curry._2(p, v === dummy1 ? missing_element(i, length) : Dummy_unsafe_get(v), v$1 === dummy2 ? missing_element(i, length) : Dummy_unsafe_get(v$1))) {
         return true;
       }
       _i = i + 1 | 0;
@@ -1286,7 +1286,7 @@ function for_all2(p, a1, a2) {
       }
       const v = arr1[i];
       const v$1 = arr2[i];
-      if (!Curry._2(p, v === dummy1 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), v$1 === dummy2 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v$1))) {
+      if (!Curry._2(p, v === dummy1 ? missing_element(i, length) : Dummy_unsafe_get(v), v$1 === dummy2 ? missing_element(i, length) : Dummy_unsafe_get(v$1))) {
         return false;
       }
       _i = i + 1 | 0;
@@ -1337,7 +1337,7 @@ function mem(x, a) {
         return false;
       }
       const v = arr[i];
-      if (Caml_obj.caml_equal(v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), x)) {
+      if (Caml_obj.caml_equal(v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v), x)) {
         return true;
       }
       _i = i + 1 | 0;
@@ -1365,7 +1365,7 @@ function memq(x, a) {
       }
       const v = arr[i];
       if ((
-          v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v)
+          v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v)
         ) === x) {
         return true;
       }
@@ -1393,7 +1393,7 @@ function find_opt(p, a) {
         return;
       }
       const v = arr[i];
-      const x = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+      const x = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
       if (Curry._1(p, x)) {
         return Caml_option.some(x);
       }
@@ -1421,7 +1421,7 @@ function find_index(p, a) {
         return;
       }
       const v = arr[i];
-      const x = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+      const x = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
       if (Curry._1(p, x)) {
         return i;
       }
@@ -1449,7 +1449,7 @@ function find_map(p, a) {
         return;
       }
       const v = arr[i];
-      const r = Curry._1(p, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+      const r = Curry._1(p, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
       if (r !== undefined) {
         return r;
       }
@@ -1477,7 +1477,7 @@ function find_mapi(p, a) {
         return;
       }
       const v = arr[i];
-      const r = Curry._2(p, i, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+      const r = Curry._2(p, i, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
       if (r !== undefined) {
         return r;
       }
@@ -1516,7 +1516,7 @@ function equal(eq, a1, a2) {
       }
       const v = arr1[i];
       const v$1 = arr2[i];
-      if (!Curry._2(eq, v === dum1 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), v$1 === dum2 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v$1))) {
+      if (!Curry._2(eq, v === dum1 ? missing_element(i, length) : Dummy_unsafe_get(v), v$1 === dum2 ? missing_element(i, length) : Dummy_unsafe_get(v$1))) {
         return false;
       }
       _i = i + 1 | 0;
@@ -1555,7 +1555,7 @@ function compare(cmp, a1, a2) {
       }
       const v = arr1[i];
       const v$1 = arr2[i];
-      const c = Curry._2(cmp, v === dum1 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), v$1 === dum2 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v$1));
+      const c = Curry._2(cmp, v === dum1 ? missing_element(i, length) : Dummy_unsafe_get(v), v$1 === dum2 ? missing_element(i, length) : Dummy_unsafe_get(v$1));
       if (c !== 0) {
         return c;
       }
@@ -1572,7 +1572,7 @@ function compare(cmp, a1, a2) {
 function of_array(a) {
   const length = a.length;
   const dummy = global_dummy._0;
-  const arr = Curry._2(Dummy_Array.copy_from_array, a, dummy);
+  const arr = Dummy_Array.copy_from_array(a, dummy);
   return {
     length: length,
     arr: arr,
@@ -1593,7 +1593,7 @@ function to_array(a) {
     if (v === dummy) {
       return missing_element(i, length);
     } else {
-      return Curry._1(Dummy_unsafe_get, v);
+      return Dummy_unsafe_get(v);
     }
   }));
   check_same_length("to_array", a, length);
@@ -1604,7 +1604,7 @@ function of_list(li) {
   const a = Stdlib__Array.of_list(li);
   const length = a.length;
   const dummy = global_dummy._0;
-  const arr = Curry._2(Dummy_Array.unsafe_nocopy_from_array, a, dummy);
+  const arr = Dummy_Array.unsafe_nocopy_from_array(a, dummy);
   return {
     length: length,
     arr: arr,
@@ -1624,7 +1624,7 @@ function to_list(a) {
   for (let i = length - 1 | 0; i >= 0; --i) {
     const v = arr[i];
     l = {
-      hd: v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v),
+      hd: v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v),
       tl: l
     };
   }
@@ -1652,7 +1652,7 @@ function to_seq(a) {
       return /* Nil */ 0;
     }
     const v = arr[i];
-    const v$1 = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+    const v$1 = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
     const partial_arg = i + 1 | 0;
     return {
       TAG: /* Cons */ 0,
@@ -1701,7 +1701,7 @@ function to_seq_rev(a) {
       return /* Nil */ 0;
     }
     const v = arr[i];
-    const v$1 = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+    const v$1 = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
     const partial_arg = i - 1 | 0;
     return {
       TAG: /* Cons */ 0,
@@ -1758,15 +1758,15 @@ function unsafe_to_iarray(capacity, f) {
   if (length > capacity$2) {
     invalid_length(length, capacity$2);
   }
-  const values = length === capacity$1 ? arr : Curry._2(Dummy_Array.prefix, arr, length);
+  const values = length === capacity$1 ? arr : Dummy_Array.prefix(arr, length);
   let tmp;
   try {
-    tmp = Curry._2(Dummy_Array.unsafe_nocopy_to_array, values, a.dummy);
+    tmp = Dummy_Array.unsafe_nocopy_to_array(values, a.dummy);
   }
   catch (raw_i){
     const i = Caml_js_exceptions.internalToOCamlException(raw_i);
     if (i.MEL_EXN_ID === Dummy_Array.Dummy_found) {
-      tmp = Curry._2(missing_element, i._1, length);
+      tmp = missing_element(i._1, length);
     } else {
       throw i;
     }

--- a/node_modules/melange/dynarray.mjs
+++ b/node_modules/melange/dynarray.mjs
@@ -559,7 +559,7 @@ function make$1(n, x) {
     negative_length_requested("make", n);
   }
   const dummy = global_dummy._0;
-  const arr = Curry._3(Dummy_Array.make, n, x, dummy);
+  const arr = Dummy_Array.make(n, x, dummy);
   return {
     length: n,
     arr: arr,
@@ -572,7 +572,7 @@ function init$1(n, f) {
     negative_length_requested("init", n);
   }
   const dummy = global_dummy._0;
-  const arr = Curry._3(Dummy_Array.init, n, f, dummy);
+  const arr = Dummy_Array.init(n, f, dummy);
   return {
     length: n,
     arr: arr,
@@ -585,7 +585,7 @@ function get(a, i) {
   if (v === a.dummy) {
     return unexpected_empty_element("get", i, a.length);
   } else {
-    return Curry._1(Dummy_unsafe_get, v);
+    return Dummy_unsafe_get(v);
   }
 }
 
@@ -595,7 +595,7 @@ function set(a, i, x) {
   if (i >= length) {
     return index_out_of_bounds("set", i, length);
   } else {
-    return Caml_array.set(arr, i, Curry._1(Dummy_of_val, x));
+    return Caml_array.set(arr, i, Dummy_of_val(x));
   }
 }
 
@@ -614,7 +614,7 @@ function copy(param) {
   if (length > capacity) {
     invalid_length(length, capacity);
   }
-  const arr$1 = Curry._2(Dummy_Array.prefix, arr, length);
+  const arr$1 = Dummy_Array.prefix(arr, length);
   return {
     length: length,
     arr: arr$1,
@@ -637,7 +637,7 @@ function get_last(a) {
   if (v === a.dummy) {
     return missing_element(i, length);
   } else {
-    return Curry._1(Dummy_unsafe_get, v);
+    return Dummy_unsafe_get(v);
   }
 }
 
@@ -653,7 +653,7 @@ function find_last(a) {
   }
   const i = length - 1 | 0;
   const v = arr[i];
-  return Caml_option.some(v === a.dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+  return Caml_option.some(v === a.dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
 }
 
 function pop_last(a) {
@@ -671,8 +671,8 @@ function pop_last(a) {
   }
   const last = length - 1 | 0;
   const v = arr[last];
-  const v$1 = v === dummy ? missing_element(last, length) : Curry._1(Dummy_unsafe_get, v);
-  arr[last] = Curry._1(Dummy_of_dummy, dummy);
+  const v$1 = v === dummy ? missing_element(last, length) : Dummy_unsafe_get(v);
+  arr[last] = Dummy_of_dummy(dummy);
   a.length = last;
   return v$1;
 }
@@ -696,7 +696,7 @@ function remove_last(a) {
   const last = a.length - 1 | 0;
   if (last >= 0) {
     a.length = last;
-    return Caml_array.set(a.arr, last, Curry._1(Dummy_of_dummy, a.dummy));
+    return Caml_array.set(a.arr, last, Dummy_of_dummy(a.dummy));
   }
   
 }
@@ -711,7 +711,7 @@ function truncate(a, n) {
     return;
   } else {
     a.length = n;
-    return Stdlib__Array.fill(arr, n, length - n | 0, Curry._1(Dummy_of_dummy, a.dummy));
+    return Stdlib__Array.fill(arr, n, length - n | 0, Dummy_of_dummy(a.dummy));
   }
 }
 
@@ -751,7 +751,7 @@ function ensure_capacity(a, capacity_request) {
         ]
       });
   }
-  const new_arr = Curry._4(Dummy_Array.extend, arr, a.length, a.dummy, new_capacity);
+  const new_arr = Dummy_Array.extend(arr, a.length, a.dummy, new_capacity);
   a.arr = new_arr;
   if (0 > capacity_request) {
     throw new Caml_js_exceptions.MelangeError("Assert_failure", {
@@ -784,7 +784,7 @@ function fit_capacity(a) {
   if (a.arr.length === a.length) {
     return;
   } else {
-    a.arr = Curry._2(Dummy_Array.prefix, a.arr, a.length);
+    a.arr = Dummy_Array.prefix(a.arr, a.length);
     return;
   }
 }
@@ -797,10 +797,10 @@ function set_capacity(a, n) {
   const cur_capacity = arr.length;
   if (n < cur_capacity) {
     a.length = a.length < n ? a.length : n;
-    a.arr = Curry._2(Dummy_Array.prefix, arr, n);
+    a.arr = Dummy_Array.prefix(arr, n);
     return;
   } else if (n > cur_capacity) {
-    a.arr = Curry._4(Dummy_Array.extend, arr, a.length, a.dummy, n);
+    a.arr = Dummy_Array.extend(arr, a.length, a.dummy, n);
     return;
   } else {
     return;
@@ -815,14 +815,14 @@ function reset(a) {
 function add_last(a, x) {
   const length = a.length;
   const arr = a.arr;
-  if (length >= arr.length ? false : (a.length = length + 1 | 0, arr[length] = Curry._1(Dummy_of_val, x), true)) {
+  if (length >= arr.length ? false : (a.length = length + 1 | 0, arr[length] = Dummy_of_val(x), true)) {
     return;
   }
   while (true) {
     ensure_extra_capacity(a, 1);
     const length$1 = a.length;
     const arr$1 = a.arr;
-    if (length$1 >= arr$1.length ? false : (a.length = length$1 + 1 | 0, arr$1[length$1] = Curry._1(Dummy_of_val, x), true)) {
+    if (length$1 >= arr$1.length ? false : (a.length = length$1 + 1 | 0, arr$1[length$1] = Dummy_of_val(x), true)) {
       return;
     }
     continue;
@@ -862,7 +862,7 @@ function blit_assume_room(src, src_pos, src_length, dst, dst_pos, dst_length, bl
     dst.length = dst_pos + blit_length | 0;
   }
   try {
-    return Curry._7(Dummy_Array.blit, src_arr, src.dummy, src_pos, dst_arr, dst.dummy, dst_pos, blit_length);
+    return Dummy_Array.blit(src_arr, src.dummy, src_pos, dst_arr, dst.dummy, dst_pos, blit_length);
   }
   catch (raw_i){
     const i = Caml_js_exceptions.internalToOCamlException(raw_i);
@@ -983,7 +983,7 @@ function append_array_if_room(a, b) {
     return false;
   } else {
     a.length = length_a + length_b | 0;
-    Curry._5(Dummy_Array.blit_array, b, 0, arr, length_a, length_b);
+    Dummy_Array.blit_array(b, 0, arr, length_a, length_b);
     return true;
   }
 }
@@ -1038,7 +1038,7 @@ function iter_(fname, f, a) {
   }
   for (let i = 0; i < length; ++i) {
     const v = arr[i];
-    Curry._1(f, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+    Curry._1(f, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
   }
   check_same_length(fname, a, length);
 }
@@ -1057,7 +1057,7 @@ function iteri(f, a) {
   }
   for (let i = 0; i < length; ++i) {
     const v = arr[i];
-    Curry._2(f, i, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+    Curry._2(f, i, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
   }
   check_same_length("iteri", a, length);
 }
@@ -1072,7 +1072,7 @@ function rev_iter(f, a) {
   }
   for (let i = length - 1 | 0; i >= 0; --i) {
     const v = arr[i];
-    Curry._1(f, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+    Curry._1(f, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
   }
   check_same_length("rev_iter", a, length);
 }
@@ -1087,7 +1087,7 @@ function rev_iteri(f, a) {
   }
   for (let i = length - 1 | 0; i >= 0; --i) {
     const v = arr[i];
-    Curry._2(f, i, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+    Curry._2(f, i, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
   }
   check_same_length("rev_iteri", a, length);
 }
@@ -1100,10 +1100,10 @@ function map(f, a) {
   if (length > capacity) {
     invalid_length(length, capacity);
   }
-  const arr_out = Caml_array.make(length, Curry._1(Dummy_of_dummy, dummy));
+  const arr_out = Caml_array.make(length, Dummy_of_dummy(dummy));
   for (let i = 0; i < length; ++i) {
     const v = arr_in[i];
-    arr_out[i] = Curry._1(Dummy_of_val, Curry._1(f, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v)));
+    arr_out[i] = Dummy_of_val(Curry._1(f, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v)));
   }
   const res = {
     length: length,
@@ -1122,10 +1122,10 @@ function mapi(f, a) {
   if (length > capacity) {
     invalid_length(length, capacity);
   }
-  const arr_out = Caml_array.make(length, Curry._1(Dummy_of_dummy, dummy));
+  const arr_out = Caml_array.make(length, Dummy_of_dummy(dummy));
   for (let i = 0; i < length; ++i) {
     const v = arr_in[i];
-    arr_out[i] = Curry._1(Dummy_of_val, Curry._2(f, i, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v)));
+    arr_out[i] = Dummy_of_val(Curry._2(f, i, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v)));
   }
   const res = {
     length: length,
@@ -1147,7 +1147,7 @@ function fold_left(f, acc, a) {
   let r = acc;
   for (let i = 0; i < length; ++i) {
     const v = arr[i];
-    const v$1 = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+    const v$1 = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
     r = Curry._2(f, r, v$1);
   }
   check_same_length("fold_left", a, length);
@@ -1165,7 +1165,7 @@ function fold_right(f, a, acc) {
   let r = acc;
   for (let i = length - 1 | 0; i >= 0; --i) {
     const v = arr[i];
-    const v$1 = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+    const v$1 = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
     r = Curry._2(f, v$1, r);
   }
   check_same_length("fold_right", a, length);
@@ -1186,7 +1186,7 @@ function exists(p, a) {
         return false;
       }
       const v = arr[i];
-      if (Curry._1(p, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v))) {
+      if (Curry._1(p, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v))) {
         return true;
       }
       _i = i + 1 | 0;
@@ -1212,7 +1212,7 @@ function for_all(p, a) {
         return true;
       }
       const v = arr[i];
-      if (!Curry._1(p, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v))) {
+      if (!Curry._1(p, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v))) {
         return false;
       }
       _i = i + 1 | 0;
@@ -1248,7 +1248,7 @@ function exists2(p, a1, a2) {
       }
       const v = arr1[i];
       const v$1 = arr2[i];
-      if (Curry._2(p, v === dummy1 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), v$1 === dummy2 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v$1))) {
+      if (Curry._2(p, v === dummy1 ? missing_element(i, length) : Dummy_unsafe_get(v), v$1 === dummy2 ? missing_element(i, length) : Dummy_unsafe_get(v$1))) {
         return true;
       }
       _i = i + 1 | 0;
@@ -1285,7 +1285,7 @@ function for_all2(p, a1, a2) {
       }
       const v = arr1[i];
       const v$1 = arr2[i];
-      if (!Curry._2(p, v === dummy1 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), v$1 === dummy2 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v$1))) {
+      if (!Curry._2(p, v === dummy1 ? missing_element(i, length) : Dummy_unsafe_get(v), v$1 === dummy2 ? missing_element(i, length) : Dummy_unsafe_get(v$1))) {
         return false;
       }
       _i = i + 1 | 0;
@@ -1336,7 +1336,7 @@ function mem(x, a) {
         return false;
       }
       const v = arr[i];
-      if (Caml_obj.caml_equal(v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), x)) {
+      if (Caml_obj.caml_equal(v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v), x)) {
         return true;
       }
       _i = i + 1 | 0;
@@ -1364,7 +1364,7 @@ function memq(x, a) {
       }
       const v = arr[i];
       if ((
-          v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v)
+          v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v)
         ) === x) {
         return true;
       }
@@ -1392,7 +1392,7 @@ function find_opt(p, a) {
         return;
       }
       const v = arr[i];
-      const x = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+      const x = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
       if (Curry._1(p, x)) {
         return Caml_option.some(x);
       }
@@ -1420,7 +1420,7 @@ function find_index(p, a) {
         return;
       }
       const v = arr[i];
-      const x = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+      const x = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
       if (Curry._1(p, x)) {
         return i;
       }
@@ -1448,7 +1448,7 @@ function find_map(p, a) {
         return;
       }
       const v = arr[i];
-      const r = Curry._1(p, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+      const r = Curry._1(p, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
       if (r !== undefined) {
         return r;
       }
@@ -1476,7 +1476,7 @@ function find_mapi(p, a) {
         return;
       }
       const v = arr[i];
-      const r = Curry._2(p, i, v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v));
+      const r = Curry._2(p, i, v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v));
       if (r !== undefined) {
         return r;
       }
@@ -1515,7 +1515,7 @@ function equal(eq, a1, a2) {
       }
       const v = arr1[i];
       const v$1 = arr2[i];
-      if (!Curry._2(eq, v === dum1 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), v$1 === dum2 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v$1))) {
+      if (!Curry._2(eq, v === dum1 ? missing_element(i, length) : Dummy_unsafe_get(v), v$1 === dum2 ? missing_element(i, length) : Dummy_unsafe_get(v$1))) {
         return false;
       }
       _i = i + 1 | 0;
@@ -1554,7 +1554,7 @@ function compare(cmp, a1, a2) {
       }
       const v = arr1[i];
       const v$1 = arr2[i];
-      const c = Curry._2(cmp, v === dum1 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v), v$1 === dum2 ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v$1));
+      const c = Curry._2(cmp, v === dum1 ? missing_element(i, length) : Dummy_unsafe_get(v), v$1 === dum2 ? missing_element(i, length) : Dummy_unsafe_get(v$1));
       if (c !== 0) {
         return c;
       }
@@ -1571,7 +1571,7 @@ function compare(cmp, a1, a2) {
 function of_array(a) {
   const length = a.length;
   const dummy = global_dummy._0;
-  const arr = Curry._2(Dummy_Array.copy_from_array, a, dummy);
+  const arr = Dummy_Array.copy_from_array(a, dummy);
   return {
     length: length,
     arr: arr,
@@ -1592,7 +1592,7 @@ function to_array(a) {
     if (v === dummy) {
       return missing_element(i, length);
     } else {
-      return Curry._1(Dummy_unsafe_get, v);
+      return Dummy_unsafe_get(v);
     }
   }));
   check_same_length("to_array", a, length);
@@ -1603,7 +1603,7 @@ function of_list(li) {
   const a = Stdlib__Array.of_list(li);
   const length = a.length;
   const dummy = global_dummy._0;
-  const arr = Curry._2(Dummy_Array.unsafe_nocopy_from_array, a, dummy);
+  const arr = Dummy_Array.unsafe_nocopy_from_array(a, dummy);
   return {
     length: length,
     arr: arr,
@@ -1623,7 +1623,7 @@ function to_list(a) {
   for (let i = length - 1 | 0; i >= 0; --i) {
     const v = arr[i];
     l = {
-      hd: v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v),
+      hd: v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v),
       tl: l
     };
   }
@@ -1651,7 +1651,7 @@ function to_seq(a) {
       return /* Nil */ 0;
     }
     const v = arr[i];
-    const v$1 = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+    const v$1 = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
     const partial_arg = i + 1 | 0;
     return {
       TAG: /* Cons */ 0,
@@ -1700,7 +1700,7 @@ function to_seq_rev(a) {
       return /* Nil */ 0;
     }
     const v = arr[i];
-    const v$1 = v === dummy ? missing_element(i, length) : Curry._1(Dummy_unsafe_get, v);
+    const v$1 = v === dummy ? missing_element(i, length) : Dummy_unsafe_get(v);
     const partial_arg = i - 1 | 0;
     return {
       TAG: /* Cons */ 0,
@@ -1757,15 +1757,15 @@ function unsafe_to_iarray(capacity, f) {
   if (length > capacity$2) {
     invalid_length(length, capacity$2);
   }
-  const values = length === capacity$1 ? arr : Curry._2(Dummy_Array.prefix, arr, length);
+  const values = length === capacity$1 ? arr : Dummy_Array.prefix(arr, length);
   let tmp;
   try {
-    tmp = Curry._2(Dummy_Array.unsafe_nocopy_to_array, values, a.dummy);
+    tmp = Dummy_Array.unsafe_nocopy_to_array(values, a.dummy);
   }
   catch (raw_i){
     const i = Caml_js_exceptions.internalToOCamlException(raw_i);
     if (i.MEL_EXN_ID === Dummy_Array.Dummy_found) {
-      tmp = Curry._2(missing_element, i._1, length);
+      tmp = missing_element(i._1, length);
     } else {
       throw i;
     }


### PR DESCRIPTION
## Summary

- record arity metadata for function-valued fields in immutable local module blocks
- follow nested immutable module-field paths during arity analysis, allowing existing alpha conversion to emit direct calls for known local module fields
- avoid flattening function or nested-module fields in alias removal so function bodies are not duplicated
- add a regression test for functions that perform effects before returning another function

Promoted JS output is intentionally omitted from this PR.

## Verification

- `dune build @install`
- `dune build @melange-runtime-tests`
- `node _build/default/jscomp/test/dist/jscomp/test/arity_deopt_test.js`