### PR TITLE
test: route String_interp via Melange_ppx wrapper

### DIFF
--- a/ppx/melange_ppx.cppo.ml
+++ b/ppx/melange_ppx.cppo.ml
@@ -48,6 +48,8 @@
 open Import
 open Ast_helper
 
+module String_interp = String_interp
+
 module External = struct
   let rule =
     let rule label =

--- a/ppx/melange_ppx.mli
+++ b/ppx/melange_ppx.mli
@@ -1,0 +1,1 @@
+module String_interp = String_interp

--- a/test/unit-tests/test_unicode.ml
+++ b/test/unit-tests/test_unicode.ml
@@ -1,5 +1,5 @@
 module Utf8_string = Melange_ffi.Utf8_string
-module String_interp = Melange_ppx__String_interp
+module String_interp = Melange_ppx.String_interp
 
 let content = function
   | String_interp.String content -> content


### PR DESCRIPTION
The unicode unit-tests reference `Melange_ppx__String_interp` directly — dune's internal wrapped-lib alias module, not part of Melange_ppx's public surface. The path works on current dune because the consumer compile rule receives every cmi in Melange_ppx's objdir via a directory glob.

Upcoming work in dune (per-module library dependency narrowing — ocaml/dune#14732, built on the ocaml/dune#14492 stack) tightens consumer compile rules to depend only on cmis dune's lib index records. The lib index records the wrapper name `Melange_ppx`, not the unexported `Melange_ppx__String_interp` mangled form. Under that mode the test fails to compile with `module String_interp is an alias for module Melange_ppx__String_interp, which is missing`.

This change switches the test to the supported wrapper path: adds a re-export `module String_interp = String_interp` in `melange_ppx.cppo.ml`, a matching declaration in `melange_ppx.mli` (currently empty), and updates the consumer to `module String_interp = Melange_ppx.String_interp`. The short name resolves through dune's auto-generated `Melange_ppx__` alias module the same way every other member of `Melange_ppx` does. The test surface is unchanged — all 45 alcotest cases (including the four unicode ones) still pass.

This is a no-op on current dune. The change is purely portability across upcoming dune narrowing modes; no Melange runtime behaviour changes.