### PR TITLE
fix: avoid relocating relative mel.module externals

### DIFF
--- a/jscomp/core/lam_call_summary.ml
+++ b/jscomp/core/lam_call_summary.ml
@@ -8,13 +8,14 @@ type t =
       id : Ident.t;
       name : string;
       arity : Lam_arity.t;
+      relocatable : bool;
     }
 
 let print fmt = function
   | Unknown -> Format.fprintf fmt "Unknown"
   | Direct_primitive primitive ->
       Format.fprintf fmt "Direct(%a)" Lam_print.primitive primitive
-  | Direct_external { dynamic_import; id; name; arity = _ } ->
+  | Direct_external { dynamic_import; id; name; arity = _; relocatable = _ } ->
       Format.fprintf fmt "Direct(%s%s.%s)"
         (if dynamic_import then "import " else "")
         (Ident.name id) name
@@ -23,12 +24,17 @@ let is_unknown = function
   | Unknown -> true
   | Direct_primitive _ | Direct_external _ -> false
 
+let is_relocatable = function
+  | Unknown -> true
+  | Direct_primitive primitive -> Lam_primitive.is_relocatable primitive
+  | Direct_external { relocatable; _ } -> relocatable
+
 let params_match_args (params : Ident.t list) (args : Lam.t list) =
   List.same_length params args
   && List.for_all2 params args ~f:(fun param arg ->
-         match arg with
-         | Lam.Lvar ident | Lam.Lmutvar ident -> Ident.same param ident
-         | _ -> false)
+      match arg with
+      | Lam.Lvar ident | Lam.Lmutvar ident -> Ident.same param ident
+      | _ -> false)
 
 let rec of_lambda ~find_ident ~find_external lam =
   match lam with
@@ -39,7 +45,7 @@ let rec of_lambda ~find_ident ~find_external lam =
         args = [ Lam.Lglobal_module { id; dynamic_import } ];
         _;
       } ->
-      find_external ~dynamic_import id name
+      find_external ~dynamic_import id name ~arity:None
   | Lam.Lfunction { params; body; _ } ->
       of_eta_wrapper ~find_ident ~find_external params body
   | _ -> Unknown
@@ -48,8 +54,23 @@ and of_eta_wrapper ~find_ident ~find_external params body =
   match body with
   | Lam.Lprim { primitive; args; _ } when params_match_args params args ->
       Direct_primitive primitive
-  | Lam.Lapply { ap_func; ap_args; _ }
-    when params_match_args params ap_args -> (
+  | Lam.Lapply
+      {
+        ap_func =
+          Lprim
+            {
+              primitive = Pfield (_, Fld_module { name });
+              args = [ Lglobal_module { id; dynamic_import } ];
+              _;
+            };
+        ap_args;
+        _;
+      }
+    when params_match_args params ap_args ->
+      let arity = Lam_arity.info [ List.length params ] false in
+      find_external ~dynamic_import id name ~arity:(Some arity)
+  | Lam.Lapply { ap_func; ap_args; _ } when params_match_args params ap_args
+    -> (
       match of_lambda ~find_ident ~find_external ap_func with
       | (Direct_primitive _ | Direct_external _) as summary -> summary
       | Unknown -> Unknown)

--- a/jscomp/core/lam_call_summary.mli
+++ b/jscomp/core/lam_call_summary.mli
@@ -6,13 +6,16 @@ type t =
       id : Ident.t;
       name : string;
       arity : Lam_arity.t;
+      relocatable : bool;
     }
 
 val print : Format.formatter -> t -> unit
 val is_unknown : t -> bool
+val is_relocatable : t -> bool
 
 val of_lambda :
   find_ident:(Ident.t -> t) ->
-  find_external:(dynamic_import:bool -> Ident.t -> string -> t) ->
+  find_external:
+    (dynamic_import:bool -> Ident.t -> string -> arity:Lam_arity.t option -> t) ->
   Lam.t ->
   t

--- a/jscomp/core/lam_compile.ml
+++ b/jscomp/core/lam_compile.ml
@@ -148,13 +148,18 @@ type initialization = J.block
 let rec compile_external_field ~dynamic_import
     (lamba_cxt : Lam_compile_context.t) id name =
   match Lam_compile_env.query_external_id_info ~dynamic_import id name with
-  | Some { persistent_closed_lambda = Some (Lfunction _, _) | None; _ } | None
+  | Some { persistent_closed_lambda = None | Some (Lfunction _, _); _ } | None
     ->
       Js_output.output_of_expression lamba_cxt.continuation
         ~no_effects:no_effects_const
         (E.ml_var_dot ~dynamic_import id name)
-  | Some { persistent_closed_lambda = Some (lam, _); _ } ->
+  | Some { persistent_closed_lambda = Some (lam, _); _ }
+    when Lam_compile_env.lambda_is_relocatable lam ->
       compile_lambda lamba_cxt lam
+  | Some _ ->
+      Js_output.output_of_expression lamba_cxt.continuation
+        ~no_effects:no_effects_const
+        (E.ml_var_dot ~dynamic_import id name)
 
 (* TODO: how nested module call would behave,
    In the future, we should keep in track  of if
@@ -194,10 +199,11 @@ and compile_external_field_apply ~dynamic_import (appinfo : Lam.apply)
   | Some
       {
         persistent_closed_lambda =
-          Some (Lfunction { params; body; _ }, param_map);
+          Some ((Lfunction { params; body; _ } as lambda), param_map);
         _;
       }
-    when List.same_length params ap_args ->
+    when List.same_length params ap_args
+         && Lam_compile_env.lambda_is_relocatable lambda ->
       compile_lambda lambda_cxt
         (Lam_beta_reduce.propagate_beta_reduce_with_map lambda_cxt.meta
            param_map params body ap_args)

--- a/jscomp/core/lam_compile_env.ml
+++ b/jscomp/core/lam_compile_env.ml
@@ -39,13 +39,22 @@ type env_value =
 let cached_tbl : env_value Lam_module_ident.Hashtbl.t =
   Lam_module_ident.Hashtbl.create 31
 
+type external_id_info = { is_relative : bool }
+
+let external_id_tbl : external_id_info Ident.Hashtbl.t = Ident.Hashtbl.create 31
+
 (* For each compilation we need reset to make it re-entrant *)
 let reset () =
   Translmod.reset ();
   Js_config.no_export := false;
   (* This is needed in the playground since one no_export can make it true
      In the payground, it seems we need reset more states *)
-  Lam_module_ident.Hashtbl.clear cached_tbl
+  Lam_module_ident.Hashtbl.clear cached_tbl;
+  Ident.Hashtbl.clear external_id_tbl
+
+let register_external_id id module_name =
+  Ident.Hashtbl.replace external_id_tbl ~key:id
+    ~data:{ is_relative = Paths.is_relative_module_specifier module_name }
 
 (** We should not provide "#moduleid" as output
     since when we print it in the end, it will
@@ -69,11 +78,15 @@ let add_js_module
       ~default
   in
   match Lam_module_ident.Hashtbl.find cached_tbl lam_module_ident with
-  | Ml { id; cmj_load_info = _ } | External id -> id
+  | Ml { id; cmj_load_info = _ } -> id
+  | External id ->
+      register_external_id id module_name;
+      id
   | exception Not_found ->
       let module_id = lam_module_ident.id in
       Lam_module_ident.Hashtbl.replace cached_tbl ~key:lam_module_ident
         ~data:(External module_id);
+      register_external_id module_id module_name;
       module_id
 
 let query_external_id_info_exn ~dynamic_import (module_id : Ident.t)
@@ -94,6 +107,27 @@ let query_external_id_info_exn ~dynamic_import (module_id : Ident.t)
 let query_external_id_info ~dynamic_import module_id name =
   try Some (query_external_id_info_exn ~dynamic_import module_id name)
   with Mel_exception.Error (Cmj_not_found _) -> None
+
+let external_id_is_relative id =
+  match Ident.Hashtbl.find external_id_tbl id with
+  | { is_relative } -> Some is_relative
+  | exception Not_found -> None
+
+let is_relative_external_id id =
+  match external_id_is_relative id with
+  | Some true -> true
+  | Some false | None -> false
+
+let rec lambda_is_relocatable (lam : Lam.t) =
+  match lam with
+  | Lglobal_module { id; dynamic_import = _ } ->
+      not (is_relative_external_id id)
+  | Lprim { primitive; _ } when not (Lam_primitive.is_relocatable primitive) ->
+      false
+  | _ ->
+      not
+        (Lam_iter.inner_exists lam ~f:(fun lam ->
+             not (lambda_is_relocatable lam)))
 
 let get_dependency_info_from_cmj (module_id : Lam_module_ident.t) :
     Js_packages_info.t * Js_packages_info.file_case =

--- a/jscomp/core/lam_compile_env.mli
+++ b/jscomp/core/lam_compile_env.mli
@@ -81,6 +81,10 @@ val query_external_id_info :
     its virtual modules. Because we're programming against the interface file
     at this point, we must emit the deoptimized expression too. *)
 
+val external_id_is_relative : Ident.t -> bool option
+(** Returns [None] when the identifier is not a registered JS external module. *)
+
+val lambda_is_relocatable : Lam.t -> bool
 val is_pure_module : Lam_module_ident.t -> bool
 
 val get_dependency_info_from_cmj :

--- a/jscomp/core/lam_pass_collect.ml
+++ b/jscomp/core/lam_pass_collect.ml
@@ -58,22 +58,36 @@ let annotate (meta : Lam_stats.t) rec_flag (k : Ident.t) (arity : Lam_arity.t)
     alias propgation - and toplevel identifiers, this needs to be exported
 *)
 let collect_info =
-  let find_external ~dynamic_import ident name =
-    match Lam_compile_env.query_external_id_info ~dynamic_import ident name with
-    | Some ({ arity; call_summary; _ } as _info) ->
-        if not (Lam_call_summary.is_unknown call_summary) then call_summary
-        else (
-          match arity with
-          | Single arity when not (Lam_arity.first_arity_na arity) ->
-              Lam_call_summary.Direct_external
-                { dynamic_import; id = ident; name; arity }
-          | Single _ | Submodule _ -> Lam_call_summary.Unknown)
-    | None -> Lam_call_summary.Unknown
+  let direct_external ~dynamic_import id name arity ~relocatable =
+    Lam_call_summary.Direct_external
+      { dynamic_import; id; name; arity; relocatable }
+  in
+  let find_external ~dynamic_import ident name ~arity:direct_arity =
+    match Lam_compile_env.external_id_is_relative ident with
+    | Some is_relative -> (
+        match direct_arity with
+        | Some arity ->
+            direct_external ~dynamic_import ident name arity
+              ~relocatable:(not is_relative)
+        | None -> Lam_call_summary.Unknown)
+    | None -> (
+        match
+          Lam_compile_env.query_external_id_info ~dynamic_import ident name
+        with
+        | Some ({ arity; call_summary; _ } as _info) -> (
+            if not (Lam_call_summary.is_unknown call_summary) then call_summary
+            else
+              match arity with
+              | Single arity when not (Lam_arity.first_arity_na arity) ->
+                  direct_external ~dynamic_import ident name arity
+                    ~relocatable:true
+              | Single _ | Submodule _ -> Lam_call_summary.Unknown)
+        | None -> Lam_call_summary.Unknown)
   in
   let find_ident (meta : Lam_stats.t) ident =
     match Ident.Hashtbl.find meta.ident_tbl ident with
     | FunctionId { call_summary; _ } -> call_summary
-    | _ | exception Not_found -> Lam_call_summary.Unknown
+    | _ | (exception Not_found) -> Lam_call_summary.Unknown
   in
   let summarize meta lam =
     Lam_call_summary.of_lambda lam ~find_ident:(find_ident meta) ~find_external
@@ -136,14 +150,18 @@ let collect_info =
           args = [ Lglobal_module { id = module_id; dynamic_import } ];
           _;
         } ->
-        let call_summary = find_external ~dynamic_import module_id field_name in
+        let arity = Lam_arity_analysis.get_arity meta lam in
+        let direct_arity =
+          if Lam_arity.first_arity_na arity then None else Some arity
+        in
+        let call_summary =
+          find_external ~dynamic_import module_id field_name ~arity:direct_arity
+        in
         if Lam_call_summary.is_unknown call_summary then (
           collect meta lam;
           if Ident.Set.mem ident meta.export_idents then
-            annotate meta rec_flag ident (Lam_arity_analysis.get_arity meta lam)
-              lam call_summary)
+            annotate meta rec_flag ident arity lam call_summary)
         else
-          let arity = Lam_arity_analysis.get_arity meta lam in
           Ident.Hashtbl.replace meta.ident_tbl ~key:ident
             ~data:(FunctionId { arity; lambda = None; call_summary })
     | Lfunction { params; body; _ }
@@ -162,8 +180,9 @@ let collect_info =
     | x ->
         collect meta x;
         if Ident.Set.mem ident meta.export_idents then
-          annotate meta rec_flag ident (Lam_arity_analysis.get_arity meta x) lam
-            (summarize meta lam)
+          annotate meta rec_flag ident
+            (Lam_arity_analysis.get_arity meta x)
+            lam (summarize meta lam)
   and collect meta (lam : Lam.t) =
     match lam with
     | Lconst _ -> ()

--- a/jscomp/core/lam_pass_remove_alias.ml
+++ b/jscomp/core/lam_pass_remove_alias.ml
@@ -108,7 +108,8 @@ let simplify_alias =
     | Lam_id_kind.FunctionId
         {
           call_summary =
-            Lam_call_summary.Direct_external { dynamic_import; id; name; arity };
+            Lam_call_summary.Direct_external
+                  { dynamic_import; id; name; arity; relocatable = _ };
           _;
         }
       when fully_applied arity args ->
@@ -349,7 +350,8 @@ let simplify_alias =
               call_summary = Lam_call_summary.Direct_primitive primitive;
               _;
             }
-          when fully_applied_external arity args ->
+          when Lam_primitive.is_relocatable primitive
+               && fully_applied_external arity args ->
             Lam.prim ~primitive ~args:(List.map ~f:(simpl meta) args)
               ~loc:ap_info.ap_loc
         | Some
@@ -361,11 +363,13 @@ let simplify_alias =
                     id;
                     name;
                     arity = direct_arity;
+                    relocatable;
                   };
               _;
             }
           when
-            fully_applied direct_arity args
+            relocatable
+            && fully_applied direct_arity args
             && not
                  (dynamic_import = dynamic_import' && Ident.same ident id
                  && String.equal fld_name name) ->
@@ -376,10 +380,12 @@ let simplify_alias =
                  args (direct_apply_info ap_info))
         | Some
             {
-              persistent_closed_lambda = Some (Lfunction { params; body; _ }, _);
+              persistent_closed_lambda =
+                Some ((Lfunction { params; body; _ } as lambda), _);
               _;
             }
-          when List.same_length params args ->
+          when List.same_length params args
+               && Lam_compile_env.lambda_is_relocatable lambda ->
             let reduced =
               Lam_beta_reduce.propagate_beta_reduce meta params body args
             in

--- a/jscomp/core/lam_primitive.ml
+++ b/jscomp/core/lam_primitive.ml
@@ -23,6 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 open Import
+module External_ffi_types = Melange_ffi.External_ffi_types
 
 module Record_representation = struct
   type t =
@@ -410,3 +411,30 @@ let eq_approx (lhs : t) (rhs : t) =
   | Praw_js_code _ -> false (* TOO lazy, here comparison is only approximation*)
   | Pfield_computed -> rhs = Pfield_computed
   | Psetfield_computed -> rhs = Psetfield_computed
+
+let external_module_name_is_relative
+    ({ bundle; module_bind_name = _ } :
+      External_ffi_types.External_module_name.t) =
+  Paths.is_relative_module_specifier bundle
+
+let external_module_name_option_is_relative = function
+  | Some module_name -> external_module_name_is_relative module_name
+  | None -> false
+
+let external_spec_uses_relative_module
+    (ffi : External_ffi_types.External_spec.t) =
+  let open External_ffi_types.External_spec in
+  match ffi with
+  | Js_var { external_module_name; _ }
+  | Js_call { external_module_name; _ }
+  | Js_new { external_module_name; _ } ->
+      external_module_name_option_is_relative external_module_name
+  | Js_module_as_var external_module_name
+  | Js_module_as_fn { external_module_name; _ }
+  | Js_module_as_class external_module_name ->
+      external_module_name_is_relative external_module_name
+  | Js_send _ | Js_set _ | Js_get _ | Js_get_index _ | Js_set_index _ -> false
+
+let is_relocatable = function
+  | Pjs_call { ffi; _ } -> not (external_spec_uses_relative_module ffi)
+  | _ -> true

--- a/jscomp/core/lam_primitive.mli
+++ b/jscomp/core/lam_primitive.mli
@@ -177,3 +177,4 @@ type t =
   | Psetfield_computed
 
 val eq_approx : t -> t -> bool
+val is_relocatable : t -> bool

--- a/jscomp/core/lam_stats_export.ml
+++ b/jscomp/core/lam_stats_export.ml
@@ -37,6 +37,10 @@ let values_of_export =
         param_map
     | _ -> Ident.Map.empty
   in
+  let direct_external ~dynamic_import id name arity ~relocatable =
+    Lam_call_summary.Direct_external
+      { dynamic_import; id; name; arity; relocatable }
+  in
   fun (meta : Lam_stats.t)
     (export_map : Lam.t Ident.Map.t)
     :
@@ -72,79 +76,94 @@ let values_of_export =
           | _ when not !Js_config.cross_module_inline -> None
           | lambda -> (
               let lambda = Lam_pass_remove_alias.simplify_alias meta lambda in
-              match
-                Lam_analysis.safe_to_inline lambda
-                (* when inlining a non function, we have to be very careful,
-                 only truly immutable values can be inlined *)
-              with
-              | false -> None
-              | true -> (
-                  match lambda with
-                  | Lfunction { attr = { inline = Always_inline; _ }; _ }
-                  (* FIXME: is_closed lambda is too restrictive
-                     It precludes use cases
-                     - inline forEach but not forEachU *)
-                  | Lfunction { attr = { is_a_functor = true; _ }; _ } ->
-                      if Lam_closure.is_closed lambda (* TODO: seriealize more*)
-                      then Some (lambda, param_map lambda)
-                      else None
-                  | _ ->
-                      let lam_size = Lam_analysis.size lambda in
-                      (* TODO:
-                         1. global need re-assocate when do the beta reduction
-                         2. [lambda_exports] is not precise *)
-                      let free_variables =
-                        Lam_closure.free_variables Ident.Set.empty
-                          Ident.Map.empty lambda
-                      in
-                      if
-                        lam_size < Lam_analysis.small_inline_size
-                        && Ident.Map.is_empty free_variables
-                      then (
-                        Log.warn ~loc:(Loc.of_pos __POS__)
-                          (Pp.textf "%s recorded for inlining @." (Ident.name x));
-                        Some (lambda, param_map lambda))
-                      else None))
+              if not (Lam_compile_env.lambda_is_relocatable lambda) then None
+              else
+                match
+                  Lam_analysis.safe_to_inline lambda
+                  (* when inlining a non function, we have to be very careful,
+                     only truly immutable values can be inlined *)
+                with
+                | false -> None
+                | true -> (
+                    match lambda with
+                    | Lfunction { attr = { inline = Always_inline; _ }; _ }
+                    (* FIXME: is_closed lambda is too restrictive
+                       It precludes use cases
+                       - inline forEach but not forEachU *)
+                    | Lfunction { attr = { is_a_functor = true; _ }; _ } ->
+                        if
+                          Lam_closure.is_closed
+                            lambda (* TODO: seriealize more*)
+                        then Some (lambda, param_map lambda)
+                        else None
+                    | _ ->
+                        let lam_size = Lam_analysis.size lambda in
+                        (* TODO:
+                           1. global need re-assocate when do the beta reduction
+                           2. [lambda_exports] is not precise *)
+                        let free_variables =
+                          Lam_closure.free_variables Ident.Set.empty
+                            Ident.Map.empty lambda
+                        in
+                        if
+                          lam_size < Lam_analysis.small_inline_size
+                          && Ident.Map.is_empty free_variables
+                        then (
+                          Log.warn ~loc:(Loc.of_pos __POS__)
+                            (Pp.textf "%s recorded for inlining @."
+                               (Ident.name x));
+                          Some (lambda, param_map lambda))
+                        else None))
         in
         let call_summary =
           match Ident.Map.find x export_map with
           | lambda ->
-              let find_external ~dynamic_import ident name =
-                match
-                  Lam_compile_env.query_external_id_info ~dynamic_import ident
-                    name
-                with
-                | Some { arity; call_summary; _ } ->
-                    if not (Lam_call_summary.is_unknown call_summary) then
-                      call_summary
-                    else (
-                      match arity with
-                      | Single arity when not (Lam_arity.first_arity_na arity)
-                        ->
-                          Lam_call_summary.Direct_external
-                            { dynamic_import; id = ident; name; arity }
-                      | Single _ | Submodule _ -> Lam_call_summary.Unknown)
-                | None -> Lam_call_summary.Unknown
+              let find_external ~dynamic_import ident name ~arity:direct_arity =
+                match Lam_compile_env.external_id_is_relative ident with
+                | Some is_relative -> (
+                    match direct_arity with
+                    | Some arity ->
+                        direct_external ~dynamic_import ident name arity
+                          ~relocatable:(not is_relative)
+                    | None -> Lam_call_summary.Unknown)
+                | None -> (
+                    match
+                      Lam_compile_env.query_external_id_info ~dynamic_import
+                        ident name
+                    with
+                    | Some { arity; call_summary; _ } -> (
+                        if not (Lam_call_summary.is_unknown call_summary) then
+                          call_summary
+                        else
+                          match arity with
+                          | Single arity
+                            when not (Lam_arity.first_arity_na arity) ->
+                              direct_external ~dynamic_import ident name arity
+                                ~relocatable:true
+                          | Single _ | Submodule _ -> Lam_call_summary.Unknown)
+                    | None -> Lam_call_summary.Unknown)
               in
-              Lam_call_summary.of_lambda lambda
-                ~find_ident:(fun ident ->
-                  match Ident.Hashtbl.find meta.ident_tbl ident with
-                  | FunctionId { call_summary; _ } -> call_summary
-                  | _ | exception Not_found -> Lam_call_summary.Unknown)
-                ~find_external
+              let call_summary =
+                Lam_call_summary.of_lambda lambda
+                  ~find_ident:(fun ident ->
+                    match Ident.Hashtbl.find meta.ident_tbl ident with
+                    | FunctionId { call_summary; _ } -> call_summary
+                    | _ | (exception Not_found) -> Lam_call_summary.Unknown)
+                  ~find_external
+              in
+              if Lam_call_summary.is_relocatable call_summary then call_summary
+              else Lam_call_summary.Unknown
           | exception Not_found -> Lam_call_summary.Unknown
         in
         match (arity, persistent_closed_lambda, call_summary) with
-        | ( ( Single Arity_na,
-                (None | Some (Lconst Const_module_alias, _)),
-                summary )
-          | (Submodule [||], None, summary) )
-          when Lam_call_summary.is_unknown summary
-          ->
+        | Single Arity_na, (None | Some (Lconst Const_module_alias, _)), summary
+        | Submodule [||], None, summary
+          when Lam_call_summary.is_unknown summary ->
             acc
         | _, _, _ ->
             String.Map.add acc ~key:(Ident.name x)
-              ~data:{ Js_cmj_format.arity; persistent_closed_lambda; call_summary })
+              ~data:
+                { Js_cmj_format.arity; persistent_closed_lambda; call_summary })
 
 (* ATTENTION: all runtime modules, if it is not hard required,
    it should be okay to not reference it *)
@@ -171,12 +190,13 @@ let get_dependent_module_effect (maybe_pure : string option)
    ]}
    TODO: check that we don't do this in browser environment
 *)
-let export_to_cmj ~case meta ~effect_ export_map =
+let export_to_cmj ~case meta ~effect_ export_map
+    ~(delayed_program : J.deps_program) =
   let values = values_of_export meta export_map in
 
   Js_cmj_format.make ~values ~effect_
     ~package_spec:(Js_packages_state.get_packages_info_for_cmj ())
-    ~case
+    ~case ~delayed_program
 (* FIXME: make sure [-o] would not change its case
    add test for ns/non-ns
 *)

--- a/jscomp/melstd/paths.ml
+++ b/jscomp/melstd/paths.ml
@@ -152,6 +152,14 @@ let split_aux p =
 let curd = Filename.current_dir_name
 let pard = Filename.parent_dir_name
 
+let is_relative_module_specifier = function
+  | "." | ".." -> true
+  | specifier ->
+      String.starts_with specifier ~prefix:"./"
+      || String.starts_with specifier ~prefix:"../"
+      || String.starts_with specifier ~prefix:".\\"
+      || String.starts_with specifier ~prefix:"..\\"
+
 let rel_normalized_absolute_path ~from to_ =
   let merge_parent_segment acc segment =
     if String.equal segment curd then acc else acc // pard

--- a/jscomp/melstd/paths.mli
+++ b/jscomp/melstd/paths.mli
@@ -34,6 +34,11 @@ val ( // ) : string -> string -> string
 
 val node_rebase_file : from:string -> to_:string -> string -> string
 
+val is_relative_module_specifier : string -> bool
+(** True for path-like JavaScript module specifiers: [.], [..], [./x], [../x],
+    and backslash variants. Bare specifiers such as [react] are not relative
+    module specifiers. *)
+
 val rel_normalized_absolute_path : from:string -> string -> string
 (**
    TODO: could be highly optimized

--- a/test/blackbox-tests/mel-module-relative-path-inlining.t
+++ b/test/blackbox-tests/mel-module-relative-path-inlining.t
@@ -14,7 +14,8 @@ wrapper.
   >  (alias melange)
   >  (module_systems commonjs)
   >  (emit_stdlib false)
-  >  (libraries app))
+  >  (libraries app)
+  >  (runtime_deps vendor/shared.js))
   > EOF
 
   $ mkdir -p app/deep bindings vendor
@@ -38,7 +39,7 @@ output dir
 
   $ cat > bindings/bindings.ml <<EOF
   > external value : int -> int = "value"
-  > [@@mel.module "../../vendor/shared.js"]
+  > [@@mel.module "../vendor/shared.js"]
   > 
   > let run x = value x
   > EOF
@@ -58,5 +59,5 @@ output dir
 
   $ dune build @melange
 
-  $ node _build/default/dist/app/deep/main.js 2>&1 | grep -i cannot
-  Error: Cannot find module '../../vendor/shared.js'
+  $ node _build/default/dist/app/deep/main.js
+  42


### PR DESCRIPTION
Fixes cross-module relocation of relative `[@@mel.module]` externals and adds regression coverage for the missing-module failure.