### PR TITLE
Add a versioned CMJ header

### DIFF
--- a/jscomp/core/js_cmj_format.ml
+++ b/jscomp/core/js_cmj_format.ml
@@ -107,26 +107,25 @@ let from_file name : t =
 (* This may cause some build system always rebuild
    maybe should not be turned on by default *)
 let to_file =
-  let for_sure_not_changed name header digest =
+  let for_sure_not_changed name digest =
     match Sys.file_exists name with
     | true ->
         Io.with_file_in name ~f:(fun ic ->
-            match really_input_string ic marshal_header_size with
-            | holder ->
-                String.equal holder header
-                && Digest.equal (Digest.channel ic (-1)) digest
+            match
+              let actual_magic = really_input_string ic magic_number_size in
+              String.equal actual_magic magic_number
+              && Digest.equal (Digest.input ic) digest
+              && Digest.equal (Digest.channel ic (-1)) digest
+            with
+            | unchanged -> unchanged
             | exception End_of_file -> false)
     | false -> false
   in
   fun name (v : t) ->
     let s = Marshal.to_string v [] in
     let cur_digest = Digest.string s in
-    let header = magic_number ^ cur_digest in
-    if not (for_sure_not_changed name header cur_digest) then
-      Misc.output_to_file_via_temporary ~mode:[ Open_binary ] name
-        (fun _temp_name oc ->
-          output_string oc header;
-          output_string oc s)
+    if not (for_sure_not_changed name cur_digest) then
+      Io.write_filev_atomic name [ magic_number; cur_digest; s ]
 
 let keyComp (a : string) b = String.compare a b.name
 

--- a/jscomp/core/js_cmj_format.ml
+++ b/jscomp/core/js_cmj_format.ml
@@ -26,7 +26,6 @@ open Import
 
 type arity = Single of Lam_arity.t | Submodule of Lam_arity.t array
 
-(* TODO: add a magic number *)
 type cmj_value = {
   arity : arity;
   persistent_closed_lambda : (Lam.t * Lam_var_stats.t Ident.Map.t) option;
@@ -81,12 +80,27 @@ let make ~(values : cmj_value String.Map.t) ~effect_ ~package_spec ~case
   }
 
 (* Serialization .. *)
-let marshal_header_size = 16
+(* Increment the suffix whenever the marshalled representation of [t] changes. *)
+let magic_number = "MelangeCMJ001"
+let magic_number_size = String.length magic_number
+let digest_size = 16
+let marshal_header_size = magic_number_size + digest_size
+let invalid_format name = Mel_exception.error (Cmj_invalid_format name)
 
 let from_file name : t =
   let s = Io.read_file name in
-  let _digest = Digest.substring s 0 marshal_header_size in
-  Marshal.from_string s marshal_header_size
+  let size = String.length s in
+  if size < marshal_header_size then invalid_format name;
+  let actual_magic = String.sub s ~pos:0 ~len:magic_number_size in
+  if not (String.equal actual_magic magic_number) then invalid_format name;
+  let expected_digest = String.sub s ~pos:magic_number_size ~len:digest_size in
+  let actual_digest =
+    Digest.substring s marshal_header_size (size - marshal_header_size)
+  in
+  if not (String.equal expected_digest actual_digest) then invalid_format name;
+  match Marshal.from_string s marshal_header_size with
+  | cmj -> cmj
+  | exception (Failure _ | Invalid_argument _) -> invalid_format name
 
 (* This may cause some build system always rebuild
    maybe should not be turned on by default *)
@@ -106,7 +120,7 @@ let to_file =
   fun name (v : t) ->
     let s = Marshal.to_string v [] in
     let cur_digest = Digest.string s in
-    let header = cur_digest in
+    let header = magic_number ^ cur_digest in
     if not (for_sure_not_changed name header) then
       Io.write_filev name [ header; s ]
 

--- a/jscomp/core/js_cmj_format.ml
+++ b/jscomp/core/js_cmj_format.ml
@@ -125,7 +125,7 @@ let to_file =
     let s = Marshal.to_string v [] in
     let cur_digest = Digest.string s in
     if not (for_sure_not_changed name cur_digest) then
-      Io.write_filev_atomic name [ magic_number; cur_digest; s ]
+      Io.write_filev name [ magic_number; cur_digest; s ]
 
 let keyComp (a : string) b = String.compare a b.name
 

--- a/jscomp/core/js_cmj_format.ml
+++ b/jscomp/core/js_cmj_format.ml
@@ -80,7 +80,9 @@ let make ~(values : cmj_value String.Map.t) ~effect_ ~package_spec ~case
   }
 
 (* Serialization .. *)
-(* Increment the suffix whenever the marshalled representation of [t] changes. *)
+(* Increment the suffix whenever the representation or interpretation of the
+   marshalled object graph rooted at [t] changes incompatibly. This includes
+   changes to transitively referenced types and to the OCaml Marshal format. *)
 let magic_number = "MelangeCMJ001"
 let magic_number_size = String.length magic_number
 let digest_size = 16
@@ -97,7 +99,7 @@ let from_file name : t =
   let actual_digest =
     Digest.substring s marshal_header_size (size - marshal_header_size)
   in
-  if not (String.equal expected_digest actual_digest) then invalid_format name;
+  if not (Digest.equal expected_digest actual_digest) then invalid_format name;
   match Marshal.from_string s marshal_header_size with
   | cmj -> cmj
   | exception (Failure _ | Invalid_argument _) -> invalid_format name
@@ -105,24 +107,26 @@ let from_file name : t =
 (* This may cause some build system always rebuild
    maybe should not be turned on by default *)
 let to_file =
-  let for_sure_not_changed name header =
+  let for_sure_not_changed name header digest =
     match Sys.file_exists name with
     | true ->
-        let holder =
-          Io.with_file_in_fd name ~f:(fun fd ->
-              let buf = Bytes.create marshal_header_size in
-              let _len = Unix.read fd buf 0 marshal_header_size in
-              Bytes.unsafe_to_string buf)
-        in
-        String.equal holder header
+        Io.with_file_in name ~f:(fun ic ->
+            match really_input_string ic marshal_header_size with
+            | holder ->
+                String.equal holder header
+                && Digest.equal (Digest.channel ic (-1)) digest
+            | exception End_of_file -> false)
     | false -> false
   in
   fun name (v : t) ->
     let s = Marshal.to_string v [] in
     let cur_digest = Digest.string s in
     let header = magic_number ^ cur_digest in
-    if not (for_sure_not_changed name header) then
-      Io.write_filev name [ header; s ]
+    if not (for_sure_not_changed name header cur_digest) then
+      Misc.output_to_file_via_temporary ~mode:[ Open_binary ] name
+        (fun _temp_name oc ->
+          output_string oc header;
+          output_string oc s)
 
 let keyComp (a : string) b = String.compare a b.name
 

--- a/jscomp/core/mel_exception.cppo.ml
+++ b/jscomp/core/mel_exception.cppo.ml
@@ -26,6 +26,7 @@ open Import
 
 type error =
   | Cmj_not_found of string
+  | Cmj_invalid_format of string
   | Js_not_found of string
   | Mel_duplicate_exports of string (* gpr_974 *)
   | Missing_ml_dependency of string
@@ -47,6 +48,11 @@ let report_error ppf = function
         "%s not found, it means either the module does not exist or it is a \
          namespace"
         s
+  | Cmj_invalid_format filename ->
+      Format.fprintf ppf
+        "%s has an incompatible or corrupt .cmj format; rebuild it with the \
+         current Melange compiler"
+        filename
   | Js_not_found s -> Format.fprintf ppf "%s not found, needed in script mode" s
   | Mel_duplicate_exports str ->
       Format.fprintf ppf "%s are exported as twice" str

--- a/jscomp/core/mel_exception.mli
+++ b/jscomp/core/mel_exception.mli
@@ -24,6 +24,7 @@
 
 type error =
   | Cmj_not_found of string
+  | Cmj_invalid_format of string
   | Js_not_found of string
   | Mel_duplicate_exports of string (* gpr_974 *)
   | Missing_ml_dependency of string

--- a/jscomp/melstd/io.ml
+++ b/jscomp/melstd/io.ml
@@ -186,3 +186,27 @@ let write_filev =
     else
       with_file_out ~binary ?perm fn ~f:(fun oc ->
           List.iter ~f:(output_string oc) data)
+
+let write_filev_atomic ?(binary = true) ?(perm = default_out_perm) fn data =
+  let temp_name, oc =
+    Filename.open_temp_file
+      ~mode:[ (if binary then Open_binary else Open_text) ]
+      ~perms:perm ~temp_dir:(Filename.dirname fn) (Filename.basename fn) ".tmp"
+  in
+  let remove_temp () =
+    match Sys.remove temp_name with () -> () | exception Sys_error _ -> ()
+  in
+  match
+    List.iter ~f:(output_string oc) data;
+    close_out oc
+  with
+  | () -> (
+      match Sys.rename temp_name fn with
+      | () -> ()
+      | exception exn ->
+          remove_temp ();
+          raise exn)
+  | exception exn ->
+      close_out_noerr oc;
+      remove_temp ();
+      raise exn

--- a/jscomp/melstd/io.ml
+++ b/jscomp/melstd/io.ml
@@ -186,27 +186,3 @@ let write_filev =
     else
       with_file_out ~binary ?perm fn ~f:(fun oc ->
           List.iter ~f:(output_string oc) data)
-
-let write_filev_atomic ?(binary = true) ?(perm = default_out_perm) fn data =
-  let temp_name, oc =
-    Filename.open_temp_file
-      ~mode:[ (if binary then Open_binary else Open_text) ]
-      ~perms:perm ~temp_dir:(Filename.dirname fn) (Filename.basename fn) ".tmp"
-  in
-  let remove_temp () =
-    match Sys.remove temp_name with () -> () | exception Sys_error _ -> ()
-  in
-  match
-    List.iter ~f:(output_string oc) data;
-    close_out oc
-  with
-  | () -> (
-      match Sys.rename temp_name fn with
-      | () -> ()
-      | exception exn ->
-          remove_temp ();
-          raise exn)
-  | exception exn ->
-      close_out_noerr oc;
-      remove_temp ();
-      raise exn

--- a/jscomp/melstd/io.mli
+++ b/jscomp/melstd/io.mli
@@ -31,3 +31,6 @@ val with_file_out_fd : ?perm:int -> string -> f:(Unix.file_descr -> 'a) -> 'a
 val write : Unix.file_descr -> string -> off:int -> len:int -> unit
 val write_file : ?binary:bool -> ?perm:int -> string -> string -> unit
 val write_filev : ?binary:bool -> ?perm:int -> string -> string list -> unit
+
+val write_filev_atomic :
+  ?binary:bool -> ?perm:int -> string -> string list -> unit

--- a/jscomp/melstd/io.mli
+++ b/jscomp/melstd/io.mli
@@ -31,6 +31,3 @@ val with_file_out_fd : ?perm:int -> string -> f:(Unix.file_descr -> 'a) -> 'a
 val write : Unix.file_descr -> string -> off:int -> len:int -> unit
 val write_file : ?binary:bool -> ?perm:int -> string -> string -> unit
 val write_filev : ?binary:bool -> ?perm:int -> string -> string list -> unit
-
-val write_filev_atomic :
-  ?binary:bool -> ?perm:int -> string -> string list -> unit

--- a/jscomp/melstd/io.mli
+++ b/jscomp/melstd/io.mli
@@ -22,6 +22,7 @@
 *)
 
 (* Read *)
+val with_file_in : ?binary:bool -> string -> f:(in_channel -> 'a) -> 'a
 val with_file_in_fd : string -> f:(Unix.file_descr -> 'a) -> 'a
 val read_file : ?binary:bool -> string -> string
 

--- a/test/blackbox-tests/cmj-format-version.t
+++ b/test/blackbox-tests/cmj-format-version.t
@@ -1,0 +1,32 @@
+  $ . ./setup.sh
+
+  $ cat > input.ml <<'EOF'
+  > module Nested = struct
+  >   let identity x = x
+  > end
+  > EOF
+
+  $ melc $MEL_STDLIB_FLAGS --mel-stop-after-cmj input.ml
+
+The header identifies the serialized CMJ schema.
+
+  $ dd if=input.cmj bs=1 count=13 2>/dev/null; echo
+  MelangeCMJ001
+
+Removing the versioned magic simulates an artifact written using the previous
+unversioned format. It must be rejected before unmarshalling.
+
+  $ dd if=input.cmj of=stale.cmj bs=1 skip=13 2>/dev/null
+  $ melc stale.cmj
+  File "_none_", line 1:
+  Error: stale.cmj has an incompatible or corrupt .cmj format; rebuild it with the current Melange compiler
+  [2]
+
+The digest catches damage to an otherwise version-compatible artifact.
+
+  $ cp input.cmj corrupt.cmj
+  $ printf x >> corrupt.cmj
+  $ melc corrupt.cmj
+  File "_none_", line 1:
+  Error: corrupt.cmj has an incompatible or corrupt .cmj format; rebuild it with the current Melange compiler
+  [2]

--- a/test/blackbox-tests/cmj-format-version.t
+++ b/test/blackbox-tests/cmj-format-version.t
@@ -13,6 +13,24 @@ The header identifies the serialized CMJ schema.
   $ dd if=input.cmj bs=1 count=13 2>/dev/null; echo
   MelangeCMJ001
 
+The current format remains readable.
+
+  $ melc input.cmj >/dev/null
+
+Writing the same payload preserves the existing artifact.
+
+  $ cat > check-mtime.ml <<'EOF'
+  > let filename = "input.cmj"
+  > let sentinel = 946684800.
+  > let () =
+  >   Unix.utimes filename sentinel sentinel;
+  >   if
+  >     Sys.command "melc $MEL_STDLIB_FLAGS --mel-stop-after-cmj input.ml" <> 0
+  >   then exit 1;
+  >   if (Unix.stat filename).st_mtime <> sentinel then exit 1
+  > EOF
+  $ ocaml -I +unix unix.cma check-mtime.ml
+
 Removing the versioned magic simulates an artifact written using the previous
 unversioned format. It must be rejected before unmarshalling.
 
@@ -30,3 +48,18 @@ The digest catches damage to an otherwise version-compatible artifact.
   File "_none_", line 1:
   Error: corrupt.cmj has an incompatible or corrupt .cmj format; rebuild it with the current Melange compiler
   [2]
+
+Recompiling the producer repairs a corrupt artifact rather than trusting its
+digest header.
+
+  $ printf x >> input.cmj
+  $ melc $MEL_STDLIB_FLAGS --mel-stop-after-cmj input.ml
+  $ melc input.cmj >/dev/null
+
+An interrupted write can leave only a valid header. Recompiling repairs that
+case too.
+
+  $ dd if=input.cmj of=header-only.cmj bs=1 count=29 2>/dev/null
+  $ mv header-only.cmj input.cmj
+  $ melc $MEL_STDLIB_FLAGS --mel-stop-after-cmj input.ml
+  $ melc input.cmj >/dev/null


### PR DESCRIPTION
Adds a versioned header and validates the payload digest so incompatible or corrupt `.cmj` files fail cleanly.

Related to #1756.