### PR TITLE
Unify cross-module value summaries

### DIFF
--- a/jscomp/core/js_cmj_format.ml
+++ b/jscomp/core/js_cmj_format.ml
@@ -24,30 +24,33 @@
 
 open Import
 
-type arity = Single of Lam_arity.t | Submodule of arity array
+type value_summary =
+  | Leaf of { arity : Lam_arity.t; call_summary : Lam_call_summary.t }
+  | Submodule of value_summary array
 
-type nested_call_summary =
-  | Call_summary of Lam_call_summary.t
-  | Call_summary_submodule of nested_call_summary array
+let unknown_value_summary =
+  Leaf { arity = Lam_arity.na; call_summary = Lam_call_summary.Unknown }
+
+let rec value_summary_at_path summary path =
+  match (path, summary) with
+  | [], summary -> Some summary
+  | i :: rest, Submodule summaries -> (
+      match summaries.(i) with
+      | summary -> value_summary_at_path summary rest
+      | exception _ -> None)
+  | _ :: _, Leaf _ -> None
 
 (* TODO: add a magic number *)
 type cmj_value = {
-  arity : arity;
+  value_summary : value_summary;
   persistent_closed_lambda : (Lam.t * Lam_var_stats.t Ident.Map.t) option;
       (** Either constant or closed functor *)
-  call_summary : Lam_call_summary.t;
-  nested_call_summary : nested_call_summary;
 }
-
-let single_na = Single Lam_arity.na
-let call_summary_unknown = Call_summary Lam_call_summary.Unknown
 
 type keyed_cmj_value = {
   name : string;
-  arity : arity;
+  value_summary : value_summary;
   persistent_closed_lambda : (Lam.t * Lam_var_stats.t Ident.Map.t) option;
-  call_summary : Lam_call_summary.t;
-  nested_call_summary : nested_call_summary;
 }
 
 type t = {
@@ -77,10 +80,8 @@ let make ~(values : cmj_value String.Map.t) ~effect_ ~package_spec ~case
       to_sorted_array_with_f_seq values ~f:(fun k (v : cmj_value) ->
           {
             name = k;
-            arity = v.arity;
+            value_summary = v.value_summary;
             persistent_closed_lambda = v.persistent_closed_lambda;
-            call_summary = v.call_summary;
-            nested_call_summary = v.nested_call_summary;
           });
     pure = effect_ = None;
     package_spec;
@@ -123,10 +124,8 @@ let keyComp (a : string) b = String.compare a b.name
 let not_found key =
   {
     name = key;
-    arity = single_na;
+    value_summary = unknown_value_summary;
     persistent_closed_lambda = None;
-    call_summary = Lam_call_summary.Unknown;
-    nested_call_summary = call_summary_unknown;
   }
 
 let get_result midVal =

--- a/jscomp/core/js_cmj_format.mli
+++ b/jscomp/core/js_cmj_format.mli
@@ -46,26 +46,20 @@ open Import
     ]}
 *)
 
-type arity = Single of Lam_arity.t | Submodule of arity array
-
-type nested_call_summary =
-  | Call_summary of Lam_call_summary.t
-  | Call_summary_submodule of nested_call_summary array
+type value_summary =
+  | Leaf of { arity : Lam_arity.t; call_summary : Lam_call_summary.t }
+  | Submodule of value_summary array
 
 type cmj_value = {
-  arity : arity;
+  value_summary : value_summary;
   persistent_closed_lambda : (Lam.t * Lam_var_stats.t Ident.Map.t) option;
       (* Either constant or closed functor *)
-  call_summary : Lam_call_summary.t;
-  nested_call_summary : nested_call_summary;
 }
 
 type keyed_cmj_value = {
   name : string;
-  arity : arity;
+  value_summary : value_summary;
   persistent_closed_lambda : (Lam.t * Lam_var_stats.t Ident.Map.t) option;
-  call_summary : Lam_call_summary.t;
-  nested_call_summary : nested_call_summary;
 }
 
 type t = {
@@ -85,8 +79,8 @@ val make :
   t
 
 val query_by_name : t -> string -> keyed_cmj_value
-val single_na : arity
-val call_summary_unknown : nested_call_summary
+val unknown_value_summary : value_summary
+val value_summary_at_path : value_summary -> int list -> value_summary option
 val from_file : string -> t
 
 (* Note writing the file if its content is not changed *)

--- a/jscomp/core/lam_arity_analysis.ml
+++ b/jscomp/core/lam_arity_analysis.ml
@@ -45,16 +45,6 @@ let rec field_element (meta : Lam_stats.t) (lam : Lam.t) (i : int) =
       | _ | (exception _) -> Lam_id_kind.Element.NA)
   | _ -> Lam_id_kind.Element.NA
 
-let rec get_cmj_arity (arity : Js_cmj_format.arity) (path : int list) :
-    Lam_arity.t =
-  match (path, arity) with
-  | [], Js_cmj_format.Single arity -> arity
-  | i :: rest, Submodule arities -> (
-      match arities.(i) with
-      | arity -> get_cmj_arity arity rest
-      | exception _ -> Lam_arity.na)
-  | [], Submodule _ | _ :: _, Js_cmj_format.Single _ -> Lam_arity.na
-
 let external_field_path (lam : Lam.t) :
     (Ident.t * bool * string * int list) option =
   let rec aux path = function
@@ -87,7 +77,10 @@ let rec get_arity (meta : Lam_stats.t) (lam : Lam.t) : Lam_arity.t =
           match
             Lam_compile_env.query_external_id_info ~dynamic_import id name
           with
-          | Some { arity; _ } -> get_cmj_arity arity path
+          | Some { value_summary; _ } -> (
+              match Js_cmj_format.value_summary_at_path value_summary path with
+              | Some (Leaf { arity; _ }) -> arity
+              | Some (Submodule _) | None -> Lam_arity.na)
           | None -> Lam_arity.na)
       | None -> (
           match field_element meta owner m with

--- a/jscomp/core/lam_compile.ml
+++ b/jscomp/core/lam_compile.ml
@@ -209,9 +209,9 @@ and compile_external_field_apply ~dynamic_import (appinfo : Lam.apply)
            param_map params body ap_args)
   | Some _ | None ->
       let arity =
-        ident_info
-        |> Option.map ~f:(fun (t : Js_cmj_format.keyed_cmj_value) -> t.arity)
-        |> Option.value ~default:Js_cmj_format.single_na
+        match ident_info with
+        | Some { value_summary = Leaf { arity; _ }; _ } -> arity
+        | Some { value_summary = Submodule _; _ } | None -> Lam_arity.na
       in
       let args_code, args =
         let dummy = ([], []) in
@@ -234,10 +234,8 @@ and compile_external_field_apply ~dynamic_import (appinfo : Lam.apply)
             E.call ~info:(call_info_of_apply_status ap_status) fn args
         | App_na -> (
             match arity with
-            | Submodule _ | Single Arity_na ->
-                E.call ~info:Js_call_info.dummy fn args
-            | Single x ->
-                apply_with_arity fn ~arity:(Lam_arity.extract_arity x) args)
+            | Arity_na -> E.call ~info:Js_call_info.dummy fn args
+            | x -> apply_with_arity fn ~arity:(Lam_arity.extract_arity x) args)
       in
       Js_output.output_of_block_and_expression lambda_cxt.continuation args_code
         expression

--- a/jscomp/core/lam_pass_collect.ml
+++ b/jscomp/core/lam_pass_collect.ml
@@ -74,14 +74,12 @@ let collect_info =
         match
           Lam_compile_env.query_external_id_info ~dynamic_import ident name
         with
-        | Some ({ arity; call_summary; _ } as _info) -> (
+        | Some { value_summary = Leaf { arity; call_summary }; _ } ->
             if not (Lam_call_summary.is_unknown call_summary) then call_summary
-            else
-              match arity with
-              | Single arity when not (Lam_arity.first_arity_na arity) ->
-                  direct_external ~dynamic_import ident name arity
-                    ~relocatable:true
-              | Single _ | Submodule _ -> Lam_call_summary.Unknown)
+            else if not (Lam_arity.first_arity_na arity) then
+              direct_external ~dynamic_import ident name arity ~relocatable:true
+            else Lam_call_summary.Unknown
+        | Some { value_summary = Submodule _; _ } -> Lam_call_summary.Unknown
         | None -> Lam_call_summary.Unknown)
   in
   let find_ident (meta : Lam_stats.t) ident =

--- a/jscomp/core/lam_pass_remove_alias.ml
+++ b/jscomp/core/lam_pass_remove_alias.ml
@@ -81,11 +81,6 @@ let simplify_alias =
     | Lam.App_na -> { ap_info with ap_status = Lam.App_infer_full }
     | Lam.App_infer_full | Lam.App_uncurry -> ap_info
   in
-  let fully_applied_external arity args =
-    match arity with
-    | Js_cmj_format.Single arity -> fully_applied arity args
-    | Js_cmj_format.Submodule _ -> false
-  in
   let direct_external_field ~dynamic_import ident name ~loc =
     Lam.prim
       ~primitive:(Pfield (0, Fld_module { name }))
@@ -112,21 +107,11 @@ let simplify_alias =
              (direct_apply_info ap_info))
     | Unknown | Direct_primitive _ | Direct_external _ -> None
   in
-  let rec nested_call_summary_at_path summary path =
-    match (path, summary) with
-    | [], Js_cmj_format.Call_summary summary -> summary
-    | i :: rest, Call_summary_submodule summaries -> (
-        match summaries.(i) with
-        | summary -> nested_call_summary_at_path summary rest
-        | exception _ -> Lam_call_summary.Unknown)
-    | [], Call_summary_submodule _ | _ :: _, Call_summary _ ->
-        Lam_call_summary.Unknown
-  in
-  let find_nested_external_call_summary ~dynamic_import ident name path =
+  let find_external_value_summary ~dynamic_import ident name path =
     match Lam_compile_env.query_external_id_info ~dynamic_import ident name with
-    | Some { nested_call_summary; _ } ->
-        nested_call_summary_at_path nested_call_summary path
-    | None -> Lam_call_summary.Unknown
+    | Some { value_summary; _ } ->
+        Js_cmj_format.value_summary_at_path value_summary path
+    | None -> None
   in
   let primitive_summary_is_safe_to_inline primitive =
     Lam_primitive.is_relocatable primitive
@@ -393,18 +378,28 @@ let simplify_alias =
         with
         | Some
             {
-              arity;
-              call_summary = Lam_call_summary.Direct_primitive primitive;
+              value_summary =
+                Leaf
+                  {
+                    arity;
+                    call_summary = Lam_call_summary.Direct_primitive primitive;
+                  };
               _;
             }
           when Lam_primitive.is_relocatable primitive
-               && fully_applied_external arity args ->
+               && fully_applied arity args ->
             Lam.prim ~primitive
               ~args:(List.map ~f:(simpl meta) args)
               ~loc:ap_info.ap_loc
         | Some
             {
-              call_summary = Lam_call_summary.Direct_external _ as call_summary;
+              value_summary =
+                Leaf
+                  {
+                    call_summary =
+                      Lam_call_summary.Direct_external _ as call_summary;
+                    _;
+                  };
               _;
             } -> (
             match
@@ -455,20 +450,24 @@ let simplify_alias =
         match Lam_arity_analysis.external_field_path l1 with
         | Some (ident, dynamic_import, fld_name, (_ :: _ as path)) -> (
             match
-              find_nested_external_call_summary ~dynamic_import ident fld_name
-                path
+              find_external_value_summary ~dynamic_import ident fld_name path
             with
-            | Direct_primitive primitive
-              when fully_applied (Lam_arity_analysis.get_arity meta l1) ap_args
+            | Some (Leaf { arity; call_summary = Direct_primitive primitive })
+              when fully_applied arity ap_args
                    && primitive_summary_is_safe_to_inline primitive ->
                 Lam.prim ~primitive ~args:ap_args ~loc:ap_info.ap_loc
-            | Direct_external _ as call_summary -> (
+            | Some
+                (Leaf { call_summary = Direct_external _ as call_summary; _ })
+              -> (
                 match
                   direct_external_call ~source:None call_summary ap_args ap_info
                 with
                 | Some call -> simpl meta call
                 | None -> normal ())
-            | Unknown | Direct_primitive _ -> normal ())
+            | Some (Leaf { call_summary = Unknown | Direct_primitive _; _ })
+            | Some (Submodule _)
+            | None ->
+                normal ())
         | Some (_, _, _, []) | None -> normal ())
     (* Function inlining interact with other optimizations...
 

--- a/jscomp/core/lam_stats_export.ml
+++ b/jscomp/core/lam_stats_export.ml
@@ -41,30 +41,6 @@ let values_of_export =
     Lam_call_summary.Direct_external
       { dynamic_import; id; name; arity; relocatable }
   in
-  let rec arity_of_lambda (meta : Lam_stats.t) seen = function
-    | (Lam.Lvar v | Lmutvar v) as lam -> (
-        if Ident.Set.mem v seen then Js_cmj_format.single_na
-        else
-          let seen = Ident.Set.add v seen in
-          match Ident.Hashtbl.find meta.ident_tbl v with
-          | ImmutableBlock elems ->
-              Js_cmj_format.Submodule
-                (Array.map elems ~f:(arity_of_element meta seen))
-          | FunctionId { arity; _ } -> Js_cmj_format.Single arity
-          | _ | (exception Not_found) ->
-              Js_cmj_format.Single (Lam_arity_analysis.get_arity meta lam))
-    | Lam.Lprim { primitive = Pmakeblock (_, _, Immutable); args; _ } ->
-        Js_cmj_format.Submodule
-          (Array.of_list_map args ~f:(arity_of_lambda meta seen))
-    | lam -> Js_cmj_format.Single (Lam_arity_analysis.get_arity meta lam)
-  and arity_of_element (meta : Lam_stats.t) seen = function
-    | Lam_id_kind.Element.NA -> Js_cmj_format.single_na
-    | Function arity -> Js_cmj_format.Single arity
-    | ImmutableBlock elems ->
-        Js_cmj_format.Submodule
-          (Array.map elems ~f:(arity_of_element meta seen))
-    | SimpleForm lam -> arity_of_lambda meta seen lam
-  in
   let find_external_summary ~dynamic_import ident name ~arity:direct_arity =
     match Lam_compile_env.external_id_is_relative ident with
     | Some is_relative -> (
@@ -77,14 +53,12 @@ let values_of_export =
         match
           Lam_compile_env.query_external_id_info ~dynamic_import ident name
         with
-        | Some { arity; call_summary; _ } -> (
+        | Some { value_summary = Leaf { arity; call_summary }; _ } ->
             if not (Lam_call_summary.is_unknown call_summary) then call_summary
-            else
-              match arity with
-              | Single arity when not (Lam_arity.first_arity_na arity) ->
-                  direct_external ~dynamic_import ident name arity
-                    ~relocatable:true
-              | Single _ | Submodule _ -> Lam_call_summary.Unknown)
+            else if not (Lam_arity.first_arity_na arity) then
+              direct_external ~dynamic_import ident name arity ~relocatable:true
+            else Lam_call_summary.Unknown
+        | Some { value_summary = Submodule _; _ } -> Lam_call_summary.Unknown
         | None -> Lam_call_summary.Unknown)
   in
   let find_ident_summary (meta : Lam_stats.t) ident =
@@ -100,34 +74,38 @@ let values_of_export =
     if Lam_call_summary.is_relocatable call_summary then call_summary
     else Lam_call_summary.Unknown
   in
-  let nested_call_summary_of_summary summary =
-    Js_cmj_format.Call_summary
-      (if Lam_call_summary.is_relocatable summary then summary
-       else Lam_call_summary.Unknown)
+  let leaf arity call_summary =
+    Js_cmj_format.Leaf
+      {
+        arity;
+        call_summary =
+          (if Lam_call_summary.is_relocatable call_summary then call_summary
+           else Lam_call_summary.Unknown);
+      }
   in
-  let rec nested_call_summary_of_lambda (meta : Lam_stats.t) seen = function
+  let rec value_summary_of_lambda (meta : Lam_stats.t) seen = function
     | (Lam.Lvar v | Lmutvar v) as lam -> (
-        if Ident.Set.mem v seen then Js_cmj_format.call_summary_unknown
+        if Ident.Set.mem v seen then Js_cmj_format.unknown_value_summary
         else
           let seen = Ident.Set.add v seen in
           match Ident.Hashtbl.find meta.ident_tbl v with
           | ImmutableBlock elems ->
-              Js_cmj_format.Call_summary_submodule
-                (Array.map elems ~f:(nested_call_summary_of_element meta seen))
-          | FunctionId { call_summary; _ } ->
-              nested_call_summary_of_summary call_summary
+              Js_cmj_format.Submodule
+                (Array.map elems ~f:(value_summary_of_element meta seen))
+          | FunctionId { arity; call_summary; _ } -> leaf arity call_summary
           | _ | (exception Not_found) ->
-              Js_cmj_format.Call_summary (summarize meta lam))
+              leaf (Lam_arity_analysis.get_arity meta lam) (summarize meta lam))
     | Lam.Lprim { primitive = Pmakeblock (_, _, Immutable); args; _ } ->
-        Js_cmj_format.Call_summary_submodule
-          (Array.of_list_map args ~f:(nested_call_summary_of_lambda meta seen))
-    | lam -> Js_cmj_format.Call_summary (summarize meta lam)
-  and nested_call_summary_of_element (meta : Lam_stats.t) seen = function
+        Js_cmj_format.Submodule
+          (Array.of_list_map args ~f:(value_summary_of_lambda meta seen))
+    | lam -> leaf (Lam_arity_analysis.get_arity meta lam) (summarize meta lam)
+  and value_summary_of_element (meta : Lam_stats.t) seen = function
     | Lam_id_kind.Element.ImmutableBlock elems ->
-        Js_cmj_format.Call_summary_submodule
-          (Array.map elems ~f:(nested_call_summary_of_element meta seen))
-    | SimpleForm lam -> nested_call_summary_of_lambda meta seen lam
-    | NA | Function _ -> Js_cmj_format.call_summary_unknown
+        Js_cmj_format.Submodule
+          (Array.map elems ~f:(value_summary_of_element meta seen))
+    | SimpleForm lam -> value_summary_of_lambda meta seen lam
+    | Function arity -> leaf arity Lam_call_summary.Unknown
+    | NA -> Js_cmj_format.unknown_value_summary
   in
   fun (meta : Lam_stats.t)
     (export_map : Lam.t Ident.Map.t)
@@ -135,22 +113,6 @@ let values_of_export =
     Js_cmj_format.cmj_value String.Map.t
   ->
     List.fold_left meta.exports ~init:String.Map.empty ~f:(fun acc x ->
-        let arity =
-          match Ident.Hashtbl.find meta.ident_tbl x with
-          | FunctionId { arity; _ } -> Js_cmj_format.Single arity
-          | ImmutableBlock elems ->
-              (* FIXME: field name for dumping *)
-              Submodule
-                (Array.map elems
-                   ~f:(arity_of_element meta (Ident.Set.singleton x)))
-          | _ | (exception Not_found) -> (
-              match Ident.Map.find x export_map with
-              | Lprim { primitive = Pmakeblock (_, _, Immutable); args; _ } ->
-                  Submodule
-                    (Array.of_list_map args
-                       ~f:(arity_of_lambda meta (Ident.Set.singleton x)))
-              | _ | (exception Not_found) -> Js_cmj_format.single_na)
-        in
         let persistent_closed_lambda =
           match Ident.Map.find x export_map with
           | Lconst
@@ -205,41 +167,32 @@ let values_of_export =
           | lambda -> summarize meta lambda
           | exception Not_found -> Lam_call_summary.Unknown
         in
-        let nested_call_summary =
+        let value_summary =
           match Ident.Hashtbl.find meta.ident_tbl x with
-          | FunctionId { call_summary; _ } ->
-              nested_call_summary_of_summary call_summary
+          | FunctionId { arity; _ } -> leaf arity call_summary
           | ImmutableBlock elems ->
-              Js_cmj_format.Call_summary_submodule
+              Js_cmj_format.Submodule
                 (Array.map elems
-                   ~f:
-                     (nested_call_summary_of_element meta
-                        (Ident.Set.singleton x)))
+                   ~f:(value_summary_of_element meta (Ident.Set.singleton x)))
           | _ | (exception Not_found) -> (
               match Ident.Map.find x export_map with
               | Lprim { primitive = Pmakeblock (_, _, Immutable); args; _ } ->
-                  Js_cmj_format.Call_summary_submodule
+                  Js_cmj_format.Submodule
                     (Array.of_list_map args
-                       ~f:
-                         (nested_call_summary_of_lambda meta
-                            (Ident.Set.singleton x)))
-              | lambda -> Js_cmj_format.Call_summary (summarize meta lambda)
-              | exception Not_found -> Js_cmj_format.call_summary_unknown)
+                       ~f:(value_summary_of_lambda meta (Ident.Set.singleton x)))
+              | _ -> leaf Lam_arity.na call_summary
+              | exception Not_found -> Js_cmj_format.unknown_value_summary)
         in
-        match (arity, persistent_closed_lambda, call_summary) with
-        | Single Arity_na, (None | Some (Lconst Const_module_alias, _)), summary
-        | Submodule [||], None, summary
+        match (value_summary, persistent_closed_lambda) with
+        | ( Leaf { arity = Arity_na; call_summary = summary },
+            (None | Some (Lconst Const_module_alias, _)) )
           when Lam_call_summary.is_unknown summary ->
             acc
-        | _, _, _ ->
+        | Submodule [||], None when Lam_call_summary.is_unknown call_summary ->
+            acc
+        | _, _ ->
             String.Map.add acc ~key:(Ident.name x)
-              ~data:
-                {
-                  Js_cmj_format.arity;
-                  persistent_closed_lambda;
-                  call_summary;
-                  nested_call_summary;
-                })
+              ~data:{ Js_cmj_format.value_summary; persistent_closed_lambda })
 
 (* ATTENTION: all runtime modules, if it is not hard required,
    it should be okay to not reference it *)


### PR DESCRIPTION
Unifies recursive cross-module arity and call-summary metadata into one value-summary tree.

Stacked on #1818.