### PR TITLE
Optimize nested relocatable FFI summaries

### DIFF
--- a/jscomp/core/lam_pass_remove_alias.ml
+++ b/jscomp/core/lam_pass_remove_alias.ml
@@ -113,12 +113,9 @@ let simplify_alias =
         Js_cmj_format.value_summary_at_path value_summary path
     | None -> None
   in
-  let primitive_summary_is_safe_to_inline primitive =
-    Lam_primitive.is_relocatable primitive
-    &&
-    match primitive with
-    | Lam_primitive.Pccall _ | Pjs_call _ | Pjs_object_create _ -> false
-    | _ -> true
+  let primitive_summary_is_safe_to_inline = function
+    | Lam_primitive.Pccall _ -> false
+    | primitive -> Lam_primitive.is_relocatable primitive
   in
   let direct_primitive_of_value value args =
     match value with

--- a/jscomp/test/dist/inner_call.js
+++ b/jscomp/test/dist/inner_call.js
@@ -10,8 +10,18 @@ console.log(7);
 
 console.log(Inner_target.choose(8, 5));
 
+console.log(Inner_define.Ffi.imul(6, 7));
+
+console.log(Inner_define.Ffi.basename("/tmp/ffi.txt"));
+
+console.log(Inner_define.Ffi.point(1, 2));
+
 function nested_external_wrapper(x, y) {
   return Inner_define.P.fancy_add(x, y);
+}
+
+function nested_unresolved_ffi(x, y) {
+  return Inner_define.Ffi.unresolved_add(x, y);
 }
 
 function f(x) {
@@ -25,6 +35,7 @@ function f(x) {
 
 module.exports = {
   nested_external_wrapper,
+  nested_unresolved_ffi,
   f,
 }
 /*  Not a pure module */

--- a/jscomp/test/dist/inner_call.js
+++ b/jscomp/test/dist/inner_call.js
@@ -3,6 +3,7 @@
 
 const Inner_define = require("./inner_define.js");
 const Inner_target = require("./inner_target.js");
+const Path = require("path");
 
 console.log(3);
 
@@ -10,11 +11,14 @@ console.log(7);
 
 console.log(Inner_target.choose(8, 5));
 
-console.log(Inner_define.Ffi.imul(6, 7));
+console.log(Math.imul(6, 7));
 
-console.log(Inner_define.Ffi.basename("/tmp/ffi.txt"));
+console.log(Path.basename("/tmp/ffi.txt"));
 
-console.log(Inner_define.Ffi.point(1, 2));
+console.log({
+  x: 1,
+  y: 2
+});
 
 function nested_external_wrapper(x, y) {
   return Inner_define.P.fancy_add(x, y);

--- a/jscomp/test/dist/inner_define.js
+++ b/jscomp/test/dist/inner_define.js
@@ -3,6 +3,7 @@
 
 const Caml_external_polyfill = require("melange.js/caml_external_polyfill.js");
 const Inner_target = require("./inner_target.js");
+const Path = require("path");
 
 function add(x, y) {
   return x + y | 0;
@@ -28,6 +29,32 @@ const choose = Inner_target.choose;
 
 const Forward = {
   choose
+};
+
+function imul(x, y) {
+  return Math.imul(x, y);
+}
+
+function basename(path) {
+  return Path.basename(path);
+}
+
+function point(x, y) {
+  return {
+    x,
+    y
+  };
+}
+
+function unresolved_add(x, y) {
+  return Caml_external_polyfill.resolve("caml_nested_summary_unresolved_add")(x, y);
+}
+
+const Ffi = {
+  imul,
+  basename,
+  point,
+  unresolved_add
 };
 
 function f1(param) {
@@ -72,7 +99,8 @@ module.exports = {
   Deep,
   P,
   Forward,
+  Ffi,
   N0,
   N1,
 }
-/* No side effect */
+/* path Not a pure module */

--- a/jscomp/test/inner_call.ml
+++ b/jscomp/test/inner_call.ml
@@ -4,8 +4,12 @@
 let () = Js.log (Inner_define.N.add 1 2)
 let () = Js.log (Inner_define.Deep.N.add 3 4)
 let () = Js.log (Inner_define.Forward.choose 8 5)
+let () = Js.log (Inner_define.Ffi.imul 6 7)
+let () = Js.log (Inner_define.Ffi.basename "/tmp/ffi.txt")
+let () = Js.log (Inner_define.Ffi.point 1 2)
 
 let nested_external_wrapper x y = Inner_define.P.fancy_add x y
+let nested_unresolved_ffi x y = Inner_define.Ffi.unresolved_add x y
 
 
 open Inner_define

--- a/jscomp/test/inner_define.ml
+++ b/jscomp/test/inner_define.ml
@@ -17,6 +17,22 @@ module Forward = struct
   let choose x y = Inner_target.choose x y
 end
 
+type point
+
+external math_imul : int -> int -> int = "imul" [@@mel.scope "Math"]
+external path_basename : string -> string = "basename" [@@mel.module "path"]
+external make_point : x:int -> y:int -> point = "" [@@mel.obj]
+
+external unresolved_add : int -> int -> int =
+  "caml_nested_summary_unresolved_add"
+
+module Ffi = struct
+  let imul x y = math_imul x y
+  let basename path = path_basename path
+  let point x y = make_point ~x ~y
+  let unresolved_add x y = unresolved_add x y
+end
+
 module type S0 =  sig 
   val f1 : unit -> unit 
   val f2 : unit -> unit -> unit 

--- a/jscomp/test/inner_define.mli
+++ b/jscomp/test/inner_define.mli
@@ -17,6 +17,15 @@ module Forward : sig
   val choose : int -> int -> int
 end
 
+type point
+
+module Ffi : sig
+  val imul : int -> int -> int
+  val basename : string -> string
+  val point : int -> int -> point
+  val unresolved_add : int -> int -> int
+end
+
 
 
 module type S0 =  sig 


### PR DESCRIPTION
Optimizes nested relocatable JS FFI call summaries while keeping relative module paths and unresolved OCaml primitives uninlined.

Stacked on #1820.