### PR TITLE
Retain call summaries for immutable function elements

### DIFF
--- a/jscomp/core/lam_arity_analysis.ml
+++ b/jscomp/core/lam_arity_analysis.ml
@@ -84,7 +84,7 @@ let rec get_arity (meta : Lam_stats.t) (lam : Lam.t) : Lam_arity.t =
           | None -> Lam_arity.na)
       | None -> (
           match field_element meta owner m with
-          | Lam_id_kind.Element.Function arity -> arity
+          | Lam_id_kind.Element.Function { arity; _ } -> arity
           | SimpleForm lam -> get_arity meta lam
           | NA | ImmutableBlock _ -> Lam_arity.na))
   (* TODO: all information except Pccall is complete, we could

--- a/jscomp/core/lam_id_kind.ml
+++ b/jscomp/core/lam_id_kind.ml
@@ -37,10 +37,10 @@ module Element = struct
   type t =
     | NA
     | SimpleForm of Lam.t
-    | Function of Lam_arity.t
+    | Function of { arity : Lam_arity.t; call_summary : Lam_call_summary.t }
     | ImmutableBlock of t array
 
-  let rec of_lambda = function
+  let rec of_lambda ~summarize = function
     | ( Lam.Lvar _ | Lconst _
       | Lprim
           {
@@ -49,9 +49,14 @@ module Element = struct
             _;
           } ) as lam ->
         SimpleForm lam
-    | Lfunction { arity; _ } -> Function (Lam_arity.info [ arity ] false)
+    | Lfunction { arity; _ } as lambda ->
+        Function
+          {
+            arity = Lam_arity.info [ arity ] false;
+            call_summary = summarize lambda;
+          }
     | Lprim { primitive = Pmakeblock (_, _, Immutable); args; _ } ->
-        ImmutableBlock (Array.of_list_map args ~f:of_lambda)
+        ImmutableBlock (Array.of_list_map args ~f:(of_lambda ~summarize))
     | _ -> NA
 end
 
@@ -97,8 +102,9 @@ type t =
        mutable fields are explicit, since wen can not inline an mutable block access
 *)
 
-let of_lambda_block (xs : Lam.t list) =
-  ImmutableBlock (Array.of_list_map xs ~f:Element.of_lambda)
+let of_lambda_block ?(summarize = fun _ -> Lam_call_summary.Unknown)
+    (xs : Lam.t list) =
+  ImmutableBlock (Array.of_list_map xs ~f:(Element.of_lambda ~summarize))
 
 let print =
   let pp = Format.fprintf in

--- a/jscomp/core/lam_id_kind.mli
+++ b/jscomp/core/lam_id_kind.mli
@@ -35,7 +35,7 @@ module Element : sig
   type t =
     | NA
     | SimpleForm of Lam.t
-    | Function of Lam_arity.t
+    | Function of { arity : Lam_arity.t; call_summary : Lam_call_summary.t }
     | ImmutableBlock of t array
 end
 
@@ -75,4 +75,6 @@ type t =
         *)
 
 val print : Format.formatter -> t -> unit
-val of_lambda_block : Lam.t list -> t
+
+val of_lambda_block :
+  ?summarize:(Lam.t -> Lam_call_summary.t) -> Lam.t list -> t

--- a/jscomp/core/lam_pass_collect.ml
+++ b/jscomp/core/lam_pass_collect.ml
@@ -98,7 +98,7 @@ let collect_info =
     (* *)
     | Lprim { primitive = Pmakeblock (_, _, Immutable); args = ls; _ } ->
         Ident.Hashtbl.replace meta.ident_tbl ~key:ident
-          ~data:(Lam_id_kind.of_lambda_block ls);
+          ~data:(Lam_id_kind.of_lambda_block ~summarize:(summarize meta) ls);
         List.iter ~f:(collect meta) ls
     | Lprim { primitive = Psome | Psome_not_nest; args = [ v ]; _ } ->
         Ident.Hashtbl.replace meta.ident_tbl ~key:ident

--- a/jscomp/core/lam_stats_export.ml
+++ b/jscomp/core/lam_stats_export.ml
@@ -104,7 +104,7 @@ let values_of_export =
         Js_cmj_format.Submodule
           (Array.map elems ~f:(value_summary_of_element meta seen))
     | SimpleForm lam -> value_summary_of_lambda meta seen lam
-    | Function arity -> leaf arity Lam_call_summary.Unknown
+    | Function { arity; call_summary } -> leaf arity call_summary
     | NA -> Js_cmj_format.unknown_value_summary
   in
   fun (meta : Lam_stats.t)

--- a/jscomp/test/dist/inner_call.js
+++ b/jscomp/test/dist/inner_call.js
@@ -20,11 +20,14 @@ console.log({
   y: 2
 });
 
-console.log(Inner_define.PackedFfi.functions.imul(7, 8));
+console.log(Math.imul(7, 8));
 
-console.log(Inner_define.PackedFfi.functions.basename("/tmp/packed-ffi.txt"));
+console.log(Path.basename("/tmp/packed-ffi.txt"));
 
-console.log(Inner_define.PackedFfi.functions.point(3, 4));
+console.log({
+  x: 3,
+  y: 4
+});
 
 function nested_external_wrapper(x, y) {
   return Inner_define.P.fancy_add(x, y);

--- a/jscomp/test/dist/inner_call.js
+++ b/jscomp/test/dist/inner_call.js
@@ -20,6 +20,12 @@ console.log({
   y: 2
 });
 
+console.log(Inner_define.PackedFfi.functions.imul(7, 8));
+
+console.log(Inner_define.PackedFfi.functions.basename("/tmp/packed-ffi.txt"));
+
+console.log(Inner_define.PackedFfi.functions.point(3, 4));
+
 function nested_external_wrapper(x, y) {
   return Inner_define.P.fancy_add(x, y);
 }

--- a/jscomp/test/dist/inner_define.js
+++ b/jscomp/test/dist/inner_define.js
@@ -57,6 +57,31 @@ const Ffi = {
   unresolved_add
 };
 
+function functions_imul(x, y) {
+  return Math.imul(x, y);
+}
+
+function functions_basename(path) {
+  return Path.basename(path);
+}
+
+function functions_point(x, y) {
+  return {
+    x,
+    y
+  };
+}
+
+const functions = {
+  imul: functions_imul,
+  basename: functions_basename,
+  point: functions_point
+};
+
+const PackedFfi = {
+  functions
+};
+
 function f1(param) {
   
 }
@@ -100,6 +125,7 @@ module.exports = {
   P,
   Forward,
   Ffi,
+  PackedFfi,
   N0,
   N1,
 }

--- a/jscomp/test/inner_call.ml
+++ b/jscomp/test/inner_call.ml
@@ -7,6 +7,9 @@ let () = Js.log (Inner_define.Forward.choose 8 5)
 let () = Js.log (Inner_define.Ffi.imul 6 7)
 let () = Js.log (Inner_define.Ffi.basename "/tmp/ffi.txt")
 let () = Js.log (Inner_define.Ffi.point 1 2)
+let () = Js.log (Inner_define.PackedFfi.functions.imul 7 8)
+let () = Js.log (Inner_define.PackedFfi.functions.basename "/tmp/packed-ffi.txt")
+let () = Js.log (Inner_define.PackedFfi.functions.point 3 4)
 
 let nested_external_wrapper x y = Inner_define.P.fancy_add x y
 let nested_unresolved_ffi x y = Inner_define.Ffi.unresolved_add x y

--- a/jscomp/test/inner_define.ml
+++ b/jscomp/test/inner_define.ml
@@ -19,6 +19,12 @@ end
 
 type point
 
+type ffi_functions = {
+  imul : int -> int -> int;
+  basename : string -> string;
+  point : int -> int -> point;
+}
+
 external math_imul : int -> int -> int = "imul" [@@mel.scope "Math"]
 external path_basename : string -> string = "basename" [@@mel.module "path"]
 external make_point : x:int -> y:int -> point = "" [@@mel.obj]
@@ -31,6 +37,14 @@ module Ffi = struct
   let basename path = path_basename path
   let point x y = make_point ~x ~y
   let unresolved_add x y = unresolved_add x y
+end
+
+module PackedFfi = struct
+  let functions = {
+    imul = (fun x y -> math_imul x y);
+    basename = (fun path -> path_basename path);
+    point = (fun x y -> make_point ~x ~y);
+  }
 end
 
 module type S0 =  sig 

--- a/jscomp/test/inner_define.mli
+++ b/jscomp/test/inner_define.mli
@@ -19,11 +19,21 @@ end
 
 type point
 
+type ffi_functions = {
+  imul : int -> int -> int;
+  basename : string -> string;
+  point : int -> int -> point;
+}
+
 module Ffi : sig
   val imul : int -> int -> int
   val basename : string -> string
   val point : int -> int -> point
   val unresolved_add : int -> int -> int
+end
+
+module PackedFfi : sig
+  val functions : ffi_functions
 end
 
 

--- a/test/blackbox-tests/mel-module-relative-path-inlining.t
+++ b/test/blackbox-tests/mel-module-relative-path-inlining.t
@@ -41,9 +41,12 @@ output dir
   > external value : int -> int = "value"
   > [@@mel.module "../vendor/shared.js"]
   > 
+  > type packed = { call : int -> int }
+  > 
   > let run x = value x
   > module Nested = struct
   >   let run x = value x
+  >   let packed = { call = (fun x -> value x) }
   > end
   > EOF
 
@@ -58,10 +61,12 @@ output dir
   $ cat > app/deep/main.ml <<EOF
   > let () = Js.log (Bindings.run 41)
   > let () = Js.log (Bindings.Nested.run 41)
+  > let () = Js.log (Bindings.Nested.packed.call 41)
   > EOF
 
   $ dune build @melange
 
   $ node _build/default/dist/app/deep/main.js
+  42
   42
   42


### PR DESCRIPTION
Retains call summaries for anonymous functions stored in immutable blocks, enabling nested packed FFI calls to optimize safely.

Stacked on #1823.