### PR TITLE
Unify C-call lowering and effects

### DIFF
--- a/jscomp/core/lam_analysis.ml
+++ b/jscomp/core/lam_analysis.ml
@@ -44,18 +44,20 @@ let rec no_side_effects (lam : Lam.t) : bool =
       &&
       match primitive with
       | Pccall ccall -> (
-          match (Lam_ccall.effects ccall, args) with
-          | No_side_effects, _ -> true
-          | ( Depends_on_arguments Open_descriptor_in,
-              [ Lconst (Const_int { i = 0l; _ }) ] ) ->
-              true
-          | ( Depends_on_arguments Open_descriptor_out,
-              [ Lconst (Const_int { i = 1l | 2l; _ }) ] ) ->
-              true
+          match (Lam_ccall.behavior ccall, args) with
+          | (Builtin (_, No_side_effects) | External No_side_effects), _ -> true
+          | Conditional conditional, [ Lconst (Const_int { i; _ }) ] -> (
+              match Lam_ccall.resolve_conditional conditional i with
+              | Some _ -> true
+              | None -> false)
           (* we can not mark it pure
              only when we guarantee this exception is caught...
           *)
-          | (May_have_side_effects | Depends_on_arguments _), _ -> false)
+          | ( ( Builtin (_, May_have_side_effects)
+              | External May_have_side_effects ),
+              _ )
+          | Conditional _, _ ->
+              false)
       | Pmodint | Pdivint | Pdivint64 | Pmodint64 -> (
           match args with
           | [ _; Lconst cst ] -> not_zero_constant cst

--- a/jscomp/core/lam_ccall.ml
+++ b/jscomp/core/lam_ccall.ml
@@ -77,28 +77,21 @@ type builtin =
   | Nativeint of nativeint_operation
 
 type conditional = Open_descriptor_in | Open_descriptor_out
-type lowering = Builtin of builtin | Conditional of conditional | External
+type effects = No_side_effects | May_have_side_effects
 
-type effects =
-  | No_side_effects
-  | May_have_side_effects
-  | Depends_on_arguments of conditional
+type behavior =
+  | Builtin of builtin * effects
+  | Conditional of conditional
+  | External of effects
 
 type result_kind = Unknown | Boolean
+type t = { prim_name : string; behavior : behavior; result_kind : result_kind }
 
-type t = {
-  prim_name : string;
-  lowering : lowering;
-  effects : effects;
-  result_kind : result_kind;
-}
+let make ?(result_kind = Unknown) prim_name behavior =
+  { prim_name; behavior; result_kind }
 
-let make ?(effects = May_have_side_effects) ?(result_kind = Unknown) prim_name
-    lowering =
-  { prim_name; lowering; effects; result_kind }
-
-let builtin ?effects ?result_kind prim_name builtin =
-  make ?effects ?result_kind prim_name (Builtin builtin)
+let builtin ?(effects = May_have_side_effects) ?result_kind prim_name builtin =
+  make ?result_kind prim_name (Builtin (builtin, effects))
 
 let runtime ?effects ?result_kind prim_name runtime_module runtime_name =
   builtin ?effects ?result_kind prim_name
@@ -106,6 +99,18 @@ let runtime ?effects ?result_kind prim_name runtime_module runtime_name =
 
 let runtime_primitive ?effects ?result_kind prim_name runtime_module =
   runtime ?effects ?result_kind prim_name runtime_module Primitive_name
+
+let conditional prim_name conditional = make prim_name (Conditional conditional)
+
+let external_call ?(effects = May_have_side_effects) prim_name =
+  make prim_name (External effects)
+
+let resolve_conditional conditional argument =
+  match (conditional, argument) with
+  | Open_descriptor_in, 0l -> Some (Io, "stdin")
+  | Open_descriptor_out, 1l -> Some (Io, "stdout")
+  | Open_descriptor_out, 2l -> Some (Io, "stderr")
+  | (Open_descriptor_in | Open_descriptor_out), _ -> None
 
 let boolean_builtin ?effects prim_name lowering =
   builtin ?effects ~result_kind:Boolean prim_name lowering
@@ -291,12 +296,8 @@ let of_name prim_name =
       builtin ~effects:No_side_effects prim_name (Nativeint Nativeint_lsr)
   | "nativeint_mul" ->
       builtin ~effects:No_side_effects prim_name (Nativeint Nativeint_mul)
-  | "caml_ml_open_descriptor_in" ->
-      make ~effects:(Depends_on_arguments Open_descriptor_in) prim_name
-        (Conditional Open_descriptor_in)
-  | "caml_ml_open_descriptor_out" ->
-      make ~effects:(Depends_on_arguments Open_descriptor_out) prim_name
-        (Conditional Open_descriptor_out)
+  | "caml_ml_open_descriptor_in" -> conditional prim_name Open_descriptor_in
+  | "caml_ml_open_descriptor_out" -> conditional prim_name Open_descriptor_out
   | "caml_register_named_value" ->
       (* Registering with the C runtime does not make sense in Melange. Keep
          the call effectful so its arguments are still evaluated, then lower
@@ -304,22 +305,23 @@ let of_name prim_name =
       builtin ~effects:May_have_side_effects prim_name Unit
   | "caml_sys_get_config" ->
       (* Should be fine to eliminate when unused. *)
-      make ~effects:No_side_effects prim_name External
+      external_call ~effects:No_side_effects prim_name
   | _ ->
       (* "caml_alloc_dummy"; *)
       (* TODO: "caml_alloc_dummy_float". *)
-      make prim_name External
+      external_call prim_name
 
 let name t = t.prim_name
-let lowering t = t.lowering
-let effects t = t.effects
+let behavior t = t.behavior
 let result_kind t = t.result_kind
 
 let returns_boolean t =
   match t.result_kind with Boolean -> true | Unknown -> false
 
 let is_relocatable t =
-  match t.lowering with Builtin _ -> true | Conditional _ | External -> false
+  match t.behavior with
+  | Builtin _ -> true
+  | Conditional _ | External _ -> false
 
 let equal left right = String.equal left.prim_name right.prim_name
 let int_compare = of_name "caml_int_compare"

--- a/jscomp/core/lam_ccall.mli
+++ b/jscomp/core/lam_ccall.mli
@@ -77,12 +77,12 @@ type builtin =
   | Nativeint of nativeint_operation
 
 type conditional = Open_descriptor_in | Open_descriptor_out
-type lowering = Builtin of builtin | Conditional of conditional | External
+type effects = No_side_effects | May_have_side_effects
 
-type effects =
-  | No_side_effects
-  | May_have_side_effects
-  | Depends_on_arguments of conditional
+type behavior =
+  | Builtin of builtin * effects
+  | Conditional of conditional
+  | External of effects
 
 type result_kind = Unknown | Boolean
 
@@ -94,8 +94,12 @@ val of_name : string -> t
     classification. *)
 
 val name : t -> string
-val lowering : t -> lowering
-val effects : t -> effects
+val behavior : t -> behavior
+
+val resolve_conditional :
+  conditional -> int32 -> (runtime_module * string) option
+(** Select the shared lowering/effect case for a constant argument. *)
+
 val result_kind : t -> result_kind
 val returns_boolean : t -> bool
 val is_relocatable : t -> bool

--- a/jscomp/core/lam_dispatch_primitive.ml
+++ b/jscomp/core/lam_dispatch_primitive.ml
@@ -25,21 +25,10 @@
 open Import
 module E = Js_exp_make
 
-(* not exhaustive *)
-let args_const_unbox_approx_int_zero (args : J.expression list) =
+let constant_int_argument (args : J.expression list) =
   match args with
-  | [ { expression_desc = Number (Int { i = 0l; _ }); _ } ] -> true
-  | _ -> false
-
-let args_const_unbox_approx_int_one (args : J.expression list) =
-  match args with
-  | [ { expression_desc = Number (Int { i = 1l; _ }); _ } ] -> true
-  | _ -> false
-
-let args_const_unbox_approx_int_two (args : J.expression list) =
-  match args with
-  | [ { expression_desc = Number (Int { i = 2l; _ }); _ } ] -> true
-  | _ -> false
+  | [ { expression_desc = Number (Int { i; _ }); _ } ] -> Some i
+  | _ -> None
 
 let runtime_module = function
   | Lam_ccall.Bytes -> Js_runtime_modules.bytes
@@ -166,8 +155,8 @@ let translate loc (ccall : Lam_ccall.t) (args : J.expression list) :
     Location.prerr_warning loc (Mel_unimplemented_primitive prim_name);
     E.resolve_and_apply prim_name args
   in
-  match Lam_ccall.lowering ccall with
-  | Builtin builtin -> (
+  match Lam_ccall.behavior ccall with
+  | Builtin (builtin, _) -> (
       match builtin with
       | Float_add -> (
           match args with
@@ -298,17 +287,14 @@ let translate loc (ccall : Lam_ccall.t) (args : J.expression list) :
           | [ number; behavior ] -> E.seq number behavior (* TODO *)
           | _ -> assert false)
       | Nativeint operation -> nativeint_operation operation args)
-  | Conditional Open_descriptor_in ->
-      if args_const_unbox_approx_int_zero args then
-        E.runtime_ref Js_runtime_modules.io "stdin"
-      else fallback ()
-  | Conditional Open_descriptor_out ->
-      if args_const_unbox_approx_int_one args then
-        E.runtime_ref Js_runtime_modules.io "stdout"
-      else if args_const_unbox_approx_int_two args then
-        E.runtime_ref Js_runtime_modules.io "stderr"
-      else fallback ()
-  | External -> fallback ()
+  | Conditional conditional -> (
+      match constant_int_argument args with
+      | Some argument -> (
+          match Lam_ccall.resolve_conditional conditional argument with
+          | Some (runtime, name) -> E.runtime_ref (runtime_module runtime) name
+          | None -> fallback ())
+      | None -> fallback ())
+  | External _ -> fallback ()
 (*we dont use [throw] here, since [throw] is an statement
   so we wrap in IIFE
   TODO: we might provoide a hook for user to provide polyfill.

--- a/test/unit-tests/test_lam_ccall.ml
+++ b/test/unit-tests/test_lam_ccall.ml
@@ -3,15 +3,10 @@ module Lam_ccall = Melangelib.Lam_ccall
 let register_named_value_is_effectful () =
   let ccall = Lam_ccall.of_name "caml_register_named_value" in
   Alcotest.(check bool)
-    "the registration call may have side effects" true
-    (match Lam_ccall.effects ccall with
-    | May_have_side_effects -> true
-    | No_side_effects | Depends_on_arguments _ -> false);
-  Alcotest.(check bool)
-    "the unsupported registration itself lowers to unit" true
-    (match Lam_ccall.lowering ccall with
-    | Builtin Unit -> true
-    | Builtin _ | Conditional _ | External -> false)
+    "the unsupported registration is an effectful unit builtin" true
+    (match Lam_ccall.behavior ccall with
+    | Builtin (Unit, May_have_side_effects) -> true
+    | Builtin _ | Conditional _ | External _ -> false)
 
 let result_kinds () =
   let check expected prim_name =
@@ -57,9 +52,35 @@ let result_kinds () =
     ]
     ~f:(check false)
 
+let behaviors () =
+  let check message prim_name predicate =
+    Alcotest.(check bool)
+      message true
+      (predicate (Lam_ccall.behavior (Lam_ccall.of_name prim_name)))
+  in
+  check "pure builtin" "caml_string_repeat" (function
+    | Builtin (String_repeat, No_side_effects) -> true
+    | Builtin _ | Conditional _ | External _ -> false);
+  check "conditional behavior" "caml_ml_open_descriptor_in" (function
+    | Conditional Open_descriptor_in -> true
+    | Builtin _ | Conditional Open_descriptor_out | External _ -> false);
+  check "pure external" "caml_sys_get_config" (function
+    | External No_side_effects -> true
+    | Builtin _ | Conditional _ | External May_have_side_effects -> false);
+  Alcotest.(check bool)
+    "conditional resolution" true
+    (match
+       ( Lam_ccall.resolve_conditional Open_descriptor_in 0l,
+         Lam_ccall.resolve_conditional Open_descriptor_out 2l,
+         Lam_ccall.resolve_conditional Open_descriptor_in 1l )
+     with
+    | Some (Io, "stdin"), Some (Io, "stderr"), None -> true
+    | _ -> false)
+
 let suite =
   [
     Alcotest.test_case "register_named_value is effectful" `Quick
       register_named_value_is_effectful;
     Alcotest.test_case "result kinds" `Quick result_kinds;
+    Alcotest.test_case "behaviors" `Quick behaviors;
   ]


### PR DESCRIPTION
Represents lowering and effects as one behavior and shares conditional descriptor selection.

Stacked on #1830.