### PR TITLE
perf: avoid appending empty lists

### DIFF
--- a/jscomp/core/js_output.ml
+++ b/jscomp/core/js_output.ml
@@ -42,15 +42,6 @@ let make ?value ?(output_finished = False) block =
 
 let dummy = { value = None; block = []; output_finished = Dummy }
 
-let append_stmt block stmt =
-  match block with [] -> [ stmt ] | _ -> block @ [ stmt ]
-
-let append_block left right =
-  match (left, right) with
-  | [], right -> right
-  | left, [] -> left
-  | left, right -> left @ right
-
 (** This can be merged with
     {!output_of_block_and_expression} *)
 let output_of_expression (continuation : continuation) (exp : J.expression)
@@ -70,17 +61,16 @@ let output_of_block_and_expression (continuation : continuation)
   match continuation with
   | EffectCall Not_tail -> make block ~value:exp
   | EffectCall (Maybe_tail_is_return _) ->
-      make (append_stmt block (S.return_stmt exp)) ~output_finished:True
-  | Declare (kind, n) ->
-      make (append_stmt block (S.define_variable ~kind n exp))
-  | Assign n -> make (append_stmt block (S.assign n exp))
+      make (block @ [ S.return_stmt exp ]) ~output_finished:True
+  | Declare (kind, n) -> make (block @ [ S.define_variable ~kind n exp ])
+  | Assign n -> make (block @ [ S.assign n exp ])
   | NeedValue _ -> make block ~value:exp
 
 let block_with_opt_expr block (x : J.expression option) : J.block =
   match x with
   | None -> block
   | Some x when Js_analyzer.no_side_effect_expression x -> block
-  | Some x -> append_stmt block (S.exp x)
+  | Some x -> block @ [ S.exp x ]
 
 let opt_expr_with_block (x : J.expression option) block : J.block =
   match x with
@@ -146,7 +136,7 @@ let append_output (x : t) (y : t) : t =
       let block1 = unnest_block block1 in
       let block2 = unnest_block block2 in
       let block2 = opt_expr_with_block opt_e1 block2 in
-      make (append_block block1 block2) ?value:opt_e2 ~output_finished
+      make (List.append block1 block2) ?value:opt_e2 ~output_finished
 
 (* Fold right is more efficient *)
 let concat (xs : t list) : t =

--- a/jscomp/melstd/list.ml
+++ b/jscomp/melstd/list.ml
@@ -24,6 +24,9 @@
 
 include StdLabels.List
 
+let[@inline] append left right =
+  match right with [] -> left | _ -> StdLabels.List.append left right
+
 let rec map_combine l1 l2 ~f =
   match (l1, l2) with
   | [], [] -> []

--- a/test/unit-tests/test_list.ml
+++ b/test/unit-tests/test_list.ml
@@ -55,6 +55,12 @@ let test_map () =
     (List.map ~f:(fun x -> string_of_int x) [ 0; 1; 2 ] @ [ "1"; "2"; "3" ])
     [ "0"; "1"; "2"; "1"; "2"; "3" ]
 
+let test_append () =
+  let left = [ 1; 2; 3 ] in
+  Alcotest.(check bool) __LOC__ true (List.append left [] == left);
+  Alcotest.(check (list int))
+    __LOC__ (List.append left [ 4 ]) [ 1; 2; 3; 4 ]
+
 let test_split_at () =
   let a, b = List.split_at [ 1; 2; 3; 4; 5; 6 ] 3 in
   Alcotest.(check (pair (list int) (list int)))
@@ -101,6 +107,7 @@ let suite =
     ("stable_group", `Quick, test_stable_group);
     ("map_last", `Quick, test_map_last);
     ("map", `Quick, test_map);
+    ("append", `Quick, test_append);
     ("split_at", `Quick, test_split_at);
     ("split_at_last", `Quick, test_split_at_last);
     ("length_larger_than_n", `Quick, test_length_larger_than_n);


### PR DESCRIPTION
Moves the empty-right-list fast path into `Melstd.List.append` and refactors `Js_output` to use it. Follow-up to #1771.