### PR TITLE
test: preserve out-of-range numeric property access

### DIFF
--- a/test/blackbox-tests/property-access-key.t
+++ b/test/blackbox-tests/property-access-key.t
@@ -1,0 +1,17 @@
+Out-of-range integer-like property names are accessed as strings
+
+The key is `min_int` with a trailing zero on 64-bit hosts.
+
+  $ . ./setup.sh
+  $ cat > x.ml <<'EOF'
+  > type t
+  > external get : t -> int = "-46116860184273879040" [@@mel.get]
+  > let get_property x = get x
+  > EOF
+  $ melc -ppx melppx x.ml -o x.js
+  $ node <<'EOF'
+  > const { get_property } = require("./x.js");
+  > const key = "-46116860184273879040";
+  > console.log(get_property({ [key]: 42 }));
+  > EOF
+  42


### PR DESCRIPTION
Adds a regression test ensuring out-of-range integer-like property names are accessed as strings.

Precedes #1777.