### PR TITLE
test: show compiler crash on negative block field access

### DIFF
--- a/test/blackbox-tests/negative-block-field-access.t
+++ b/test/blackbox-tests/negative-block-field-access.t
@@ -9,3 +9,7 @@ Negative constant field access on an immutable block does not crash the compiler
   > let field = Obj.field (Obj.repr block) (-1)
   > EOF
   $ melc x.ml -o x.js
+  melc: internal error, uncaught exception:
+        Invalid_argument("List.nth")
+        
+  [125]

--- a/test/blackbox-tests/negative-block-field-access.t
+++ b/test/blackbox-tests/negative-block-field-access.t
@@ -1,0 +1,11 @@
+Negative constant field access on an immutable block does not crash the compiler
+
+  $ . ./setup.sh
+  $ cat > x.ml <<'EOF'
+  > let block =
+  >   ( Sys.opaque_identity 1,
+  >     Sys.opaque_identity 2,
+  >     Sys.opaque_identity 3 )
+  > let field = Obj.field (Obj.repr block) (-1)
+  > EOF
+  $ melc x.ml -o x.js


### PR DESCRIPTION
Adds a Cram regression for negative immutable-block field access crashing the compiler.

Expected to fail until combined with #1770.