### PR TITLE
fix: handle negative block field access

### DIFF
--- a/jscomp/core/js_pass_flatten_and_mark_dead.ml
+++ b/jscomp/core/js_pass_flatten_and_mark_dead.ml
@@ -294,7 +294,8 @@ let subst_map (substitution : J.expression Ident.Hashtbl.t) =
                     _;
                   } as x ->
                     x
-                | _ | (exception Failure _) -> super.expression self x)
+                | _ | (exception (Failure _ | Invalid_argument _)) ->
+                    super.expression self x)
             | _ | (exception Not_found) -> super.expression self x)
         | _ -> super.expression self x);
   }

--- a/test/blackbox-tests/negative-block-field-access.t
+++ b/test/blackbox-tests/negative-block-field-access.t
@@ -9,7 +9,3 @@ Negative constant field access on an immutable block does not crash the compiler
   > let field = Obj.field (Obj.repr block) (-1)
   > EOF
   $ melc x.ml -o x.js
-  melc: internal error, uncaught exception:
-        Invalid_argument("List.nth")
-        
-  [125]


### PR DESCRIPTION
Handles negative immutable-block field indices without crashing the compiler.

Fixes the behavior characterized in #1838 and precedes #1770.