### PR TITLE
fix(nix): make playground overlay evaluable

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -6,16 +6,13 @@ final: prev:
   ocamlPackages = prev.ocamlPackages.overrideScope (
     oself: osuper:
 
-    with oself;
-
     {
       melange = prev.callPackage ./. {
         inherit melange-compiler-libs-vendor-dir;
         doCheck = false;
       };
-      melange-playground = prev.lib.callPackageWith oself ./melange-playground.nix {
+      melange-playground = oself.callPackage ./melange-playground.nix {
         inherit melange-compiler-libs-vendor-dir;
-        inherit (prev) nodejs;
       };
     }
   );


### PR DESCRIPTION
Use the OCaml scope's `callPackage` for `melange-playground` so the exported overlay evaluates correctly.

Related work: none.