### PR TITLE
feat: add melc spans to Dune action traces

### DIFF
--- a/bin/melc.ml
+++ b/bin/melc.ml
@@ -231,6 +231,7 @@ let main: Melc_cli.t -> _ Cmdliner.Term.ret
       bs_cmi_only;
       bs_no_version_header;
       bs_cross_module_opt;
+      action_trace;
       bs_diagnose;
       where;
       verbose;
@@ -293,6 +294,7 @@ let main: Melc_cli.t -> _ Cmdliner.Term.ret
 
     Option.iter bs_cross_module_opt ~f:(fun bs_cross_module_opt ->
         Js_config.cross_module_inline := bs_cross_module_opt);
+    if action_trace then Js_config.action_trace := true;
     if bs_syntax_only then Js_config.syntax_only := true;
 
     Option.iter ~f:Js_packages_state.set_package_name bs_package_name;

--- a/bin/melc_cli.ml
+++ b/bin/melc_cli.ml
@@ -50,6 +50,7 @@ type t = {
   bs_cmi_only : bool;
   bs_no_version_header : bool;
   bs_cross_module_opt : bool option;
+  action_trace : bool;
   bs_diagnose : bool;
   where : bool;
   verbose : bool;
@@ -340,6 +341,10 @@ module Internal = struct
               [ "bs-no-cross-module-opt"; "mel-no-cross-module-opt" ] );
         ])
 
+  let action_trace =
+    let doc = "*internal* Emit compiler spans into Dune's action trace" in
+    repeatable_flag (Arg.info [ "mel-action-trace" ] ~doc)
+
   let bs_diagnose =
     let doc = "*internal* More verbose output" in
     repeatable_flag (Arg.info [ "bs-diagnose"; "mel-diagnose" ] ~doc)
@@ -469,12 +474,13 @@ let parse include_dirs hidden_include_dirs alerts warnings output_name ppx
     open_modules bs_package_output mel_module_system bs_syntax_only
     bs_package_name bs_module_name as_ppx as_pp no_alias_deps bs_gentype
     unboxed_types bs_unsafe_empty_array nostdlib color bs_eval bs_cmi_only
-    bs_no_version_header bs_cross_module_opt bs_diagnose where verbose keep_locs
-    bs_no_check_div_by_zero bs_noassertfalse noassert bs_loc impl intf
-    intf_suffix cmi_file g opaque preamble strict_sequence strict_formats
-    dtypedtree dparsetree drawlambda dsource version pp absname bin_annot i
-    nopervasives nolabels principal rectypes short_paths unsafe warn_help
-    warn_error bs_stop_after_cmj runtime filenames _c store_occurrences =
+    bs_no_version_header bs_cross_module_opt action_trace bs_diagnose where
+    verbose keep_locs bs_no_check_div_by_zero bs_noassertfalse noassert bs_loc
+    impl intf intf_suffix cmi_file g opaque preamble strict_sequence
+    strict_formats dtypedtree dparsetree drawlambda dsource version pp absname
+    bin_annot i nopervasives nolabels principal rectypes short_paths unsafe
+    warn_help warn_error bs_stop_after_cmj runtime filenames _c
+    store_occurrences =
   {
     include_dirs;
     hidden_include_dirs;
@@ -500,6 +506,7 @@ let parse include_dirs hidden_include_dirs alerts warnings output_name ppx
     bs_cmi_only;
     bs_no_version_header;
     bs_cross_module_opt;
+    action_trace;
     bs_diagnose;
     where;
     verbose;
@@ -549,7 +556,7 @@ let cmd =
     $ Internal.bs_gentype $ unboxed_types $ Internal.bs_unsafe_empty_array
     $ Internal.nostdlib $ color $ Internal.bs_eval $ Internal.bs_cmi_only
     $ Internal.bs_no_version_header $ Internal.bs_cross_module_opt
-    $ Internal.bs_diagnose $ where $ verbose $ keep_locs
+    $ Internal.action_trace $ Internal.bs_diagnose $ where $ verbose $ keep_locs
     $ Internal.bs_no_check_div_by_zero $ Internal.bs_noassertfalse
     $ Internal.noassert $ Internal.bs_loc $ Internal.impl $ Internal.intf
     $ Internal.intf_suffix $ Internal.cmi_file $ Internal.g $ Internal.opaque

--- a/bin/melc_cli.mli
+++ b/bin/melc_cli.mli
@@ -49,6 +49,7 @@ type t = {
   bs_cmi_only : bool;
   bs_no_version_header : bool;
   bs_cross_module_opt : bool option;
+  action_trace : bool;
   bs_diagnose : bool;
   where : bool;
   verbose : bool;

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.21)
+(lang dune 3.24)
 
 (maintenance_intent "(latest)")
 
@@ -7,8 +7,6 @@
 (using menhir 3.0)
 
 (using melange 1.0)
-
-(using directory-targets 0.1)
 
 (generate_opam_files true)
 
@@ -35,6 +33,9 @@
    (and (>= "5.5") (< "5.6")))
   (cmdliner
    (>= "1.1.0"))
+  csexp
+  (dune-action-trace
+   (>= "3.24"))
   dune-build-info
   (cppo :build)
   (alcotest :with-test)

--- a/jscomp/core/compiler_trace.ml
+++ b/jscomp/core/compiler_trace.ml
@@ -1,0 +1,48 @@
+module Trace = Dune_action_trace
+
+type args = (string * string) list
+
+let context = lazy (Trace.Context.create ~name:"melc")
+
+let enabled () =
+  !Js_config.action_trace && Trace.Context.is_enabled (Lazy.force context)
+
+let now_in_nanoseconds () = int_of_float (Unix.gettimeofday () *. 1_000_000_000.)
+
+let encode_args args =
+  List.map (fun (name, value) -> (name, Csexp.Atom value)) args
+
+let emit event = Trace.Context.emit (Lazy.force context) event
+
+let instant ?(args = []) ~category ~name () =
+  if enabled () then
+    emit
+      (Trace.Event.instant ~args:(encode_args args) ~category ~name
+         ~time_in_nanoseconds:(now_in_nanoseconds ()) ())
+
+let with_span ?(args = []) ~category ~name f =
+  if not (enabled ()) then f ()
+  else
+    let start_in_nanoseconds = now_in_nanoseconds () in
+    match f () with
+    | result ->
+        let duration_in_nanoseconds =
+          now_in_nanoseconds () - start_in_nanoseconds
+        in
+        emit
+          (Trace.Event.span ~args:(encode_args args) ~category ~name
+             ~start_in_nanoseconds ~duration_in_nanoseconds ());
+        result
+    | exception exn ->
+        let duration_in_nanoseconds =
+          now_in_nanoseconds () - start_in_nanoseconds
+        in
+        emit
+          (Trace.Event.span
+             ~args:(encode_args (("status", "error") :: args))
+             ~category ~name ~start_in_nanoseconds ~duration_in_nanoseconds ());
+        raise exn
+
+let () =
+  at_exit (fun () ->
+      if Lazy.is_val context then Trace.Context.close (Lazy.force context))

--- a/jscomp/core/compiler_trace.mli
+++ b/jscomp/core/compiler_trace.mli
@@ -1,0 +1,8 @@
+type args = (string * string) list
+
+val enabled : unit -> bool
+
+val with_span :
+  ?args:args -> category:string -> name:string -> (unit -> 'a) -> 'a
+
+val instant : ?args:args -> category:string -> name:string -> unit -> unit

--- a/jscomp/core/dune
+++ b/jscomp/core/dune
@@ -6,6 +6,8 @@
   melange_compiler_libs
   melange_ffi
   ppxlib.ast
+  csexp
+  dune-action-trace
   dune-build-info))
 
 (rule

--- a/jscomp/core/js_config.ml
+++ b/jscomp/core/js_config.ml
@@ -62,6 +62,7 @@ let stdlib_paths =
 let no_version_header = ref false
 let cross_module_inline = ref false
 let diagnose = ref false
+let action_trace = ref false
 let tool_name = "Melange"
 let check_div_by_zero = ref true
 let syntax_only = ref false

--- a/jscomp/core/js_config.mli
+++ b/jscomp/core/js_config.mli
@@ -33,6 +33,9 @@ val cross_module_inline : bool ref
 val diagnose : bool ref
 (** diagnose option *)
 
+val action_trace : bool ref
+(** Emit compiler phase spans into Dune's action trace. *)
+
 val check_div_by_zero : bool ref
 (** check-div-by-zero option *)
 

--- a/jscomp/core/js_implementation.cppo.ml
+++ b/jscomp/core/js_implementation.cppo.ml
@@ -91,7 +91,11 @@ let after_parsing_sig ppf fname ast =
     let modulename = module_name outputprefix in
     Env.set_unit_name modulename;
 #endif
-    let tsg = Typemod.type_interface initial_env ast in
+    let tsg =
+      Compiler_trace.with_span ~category:"melange.frontend" ~name:"typecheck"
+        ~args:[ "input", fname ] (fun () ->
+          Typemod.type_interface initial_env ast)
+    in
     if !Clflags.dump_typedtree then
       Format.fprintf ppf "%a@." Printtyped.interface tsg;
     let sg = tsg.sig_type in
@@ -134,10 +138,22 @@ let after_parsing_sig ppf fname ast =
 
 let interface ~parser ppf fname =
   Initialization.Perfile.init_path ();
-  parser fname
-  |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name
-       Mli
-  |> Builtin_ast_mapper.rewrite_signature
+  let ast =
+    Compiler_trace.with_span ~category:"melange.frontend" ~name:"parse"
+      ~args:[ "input", fname ] (fun () -> parser fname)
+  in
+  let ast =
+    Compiler_trace.with_span ~category:"melange.frontend" ~name:"ppx"
+      ~args:[ "input", fname ] (fun () ->
+        Cmd_ppx_apply.apply_rewriters ~restore:false
+          ~tool_name:Js_config.tool_name Mli ast)
+  in
+  let ast =
+    Compiler_trace.with_span ~category:"melange.frontend" ~name:"builtin-ppx"
+      ~args:[ "input", fname ] (fun () ->
+        Builtin_ast_mapper.rewrite_signature ast)
+  in
+  ast
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.interface
   |> print_if_pipe ppf Clflags.dump_source Pprintast.signature
   |> after_parsing_sig ppf fname
@@ -197,11 +213,14 @@ let after_parsing_impl ppf fname (ast : Parsetree.structure) =
     Env.set_unit_name modulename;
 #endif
     let ({ Typedtree.structure = typedtree; coercion; _ } as implementation) =
+      Compiler_trace.with_span ~category:"melange.frontend" ~name:"typecheck"
+        ~args:[ "input", fname ] (fun () ->
 #if OCAML_VERSION >= (5,2,0)
-      Typemod.type_implementation unit_info env ast
+          Typemod.type_implementation unit_info env ast
 #else
-      Typemod.type_implementation fname outputprefix modulename env ast
+          Typemod.type_implementation fname outputprefix modulename env ast
 #endif
+        )
     in
     let typedtree_coercion = (typedtree, coercion) in
     print_if ppf Clflags.dump_typedtree Printtyped.implementation_with_coercion
@@ -214,11 +233,13 @@ let after_parsing_impl ppf fname (ast : Parsetree.structure) =
       let package_info = Js_packages_state.get_packages_info () in
       let js_program =
         let lambda =
-          let program =
-            Translmod.transl_implementation modulename typedtree_coercion
-          in
-          Lambda_simplif.simplify_lambda program.code
-          |> print_if_pipe ppf Clflags.dump_rawlambda Printlambda.lambda
+          Compiler_trace.with_span ~category:"melange.lambda"
+            ~name:"translate" ~args:[ "input", fname ] (fun () ->
+              let program =
+                Translmod.transl_implementation modulename typedtree_coercion
+              in
+              Lambda_simplif.simplify_lambda program.code
+              |> print_if_pipe ppf Clflags.dump_rawlambda Printlambda.lambda)
         in
         Lam_compile_main.compile ~package_info outputprefix lambda
       in
@@ -229,10 +250,22 @@ let after_parsing_impl ppf fname (ast : Parsetree.structure) =
 
 let implementation ~parser ppf fname =
   Initialization.Perfile.init_path ();
-  parser fname
-  |> Cmd_ppx_apply.apply_rewriters ~restore:false ~tool_name:Js_config.tool_name
-       Ml
-  |> Builtin_ast_mapper.rewrite_structure
+  let ast =
+    Compiler_trace.with_span ~category:"melange.frontend" ~name:"parse"
+      ~args:[ "input", fname ] (fun () -> parser fname)
+  in
+  let ast =
+    Compiler_trace.with_span ~category:"melange.frontend" ~name:"ppx"
+      ~args:[ "input", fname ] (fun () ->
+        Cmd_ppx_apply.apply_rewriters ~restore:false
+          ~tool_name:Js_config.tool_name Ml ast)
+  in
+  let ast =
+    Compiler_trace.with_span ~category:"melange.frontend" ~name:"builtin-ppx"
+      ~args:[ "input", fname ] (fun () ->
+        Builtin_ast_mapper.rewrite_structure ast)
+  in
+  ast
   |> print_if_pipe ppf Clflags.dump_parsetree Printast.implementation
   |> print_if_pipe ppf Clflags.dump_source Pprintast.structure
   |> after_parsing_impl ppf fname
@@ -240,7 +273,10 @@ let implementation ~parser ppf fname =
 let implementation_cmj _ppf fname =
   (* this is needed because the path is used to find other modules path *)
   Initialization.Perfile.init_path ();
-  let cmj = Js_cmj_format.from_file fname in
+  let cmj =
+    Compiler_trace.with_span ~category:"melange.io" ~name:"cmj-read"
+      ~args:[ "input", fname ] (fun () -> Js_cmj_format.from_file fname)
+  in
   (* NOTE(anmonteiro): If we're generating JS from a `.cmj`, we take the
      resulting JS extension from the `-o FILENAME.EXT1.EXT2` argument. In this
      case, we need to make sure we're removing all the extensions from the

--- a/jscomp/core/lam_compile_main.cppo.ml
+++ b/jscomp/core/lam_compile_main.cppo.ml
@@ -107,12 +107,28 @@ let _d s lam =
 
 (* Actually simplify_lets is kind of global optimization since it requires you
    to know whether it's used or not *)
+let trace_args output_prefix =
+  [ "module", Filename.basename output_prefix ]
+
+let emit_artifact ~name ~output ~output_prefix =
+  if Compiler_trace.enabled () then
+    Compiler_trace.instant ~category:"melange.artifact" ~name
+      ~args:
+        (("bytes", string_of_int (Unix.stat output).st_size)
+        :: ("output", output)
+        :: trace_args output_prefix)
+      ()
+
 let compile ~package_info (output_prefix: string) (lam: Lambda.lambda) =
   let _j =
     Js_pass_debug.dump
       ~output_dir:(Filename.dirname output_prefix)
       ~package_info
       ~output_info:(Js_packages_state.get_output_info () |> List.hd)
+  in
+  let pass name f program =
+    Compiler_trace.with_span ~category:"melange.js" ~name
+      ~args:(trace_args output_prefix) (fun () -> f program)
   in
 
   let export_idents = Translmod.get_export_identifiers() in
@@ -127,8 +143,15 @@ let compile ~package_info (output_prefix: string) (lam: Lambda.lambda) =
 #endif
     Lam_compile_env.reset ();
   in
-  let lam, may_required_modules = Lam_convert.convert export_ident_sets lam in
+  let lam, may_required_modules =
+    Compiler_trace.with_span ~category:"melange.lambda" ~name:"convert"
+      ~args:(trace_args output_prefix) (fun () ->
+        Lam_convert.convert export_ident_sets lam)
+  in
 
+  let coerced_input, meta =
+    Compiler_trace.with_span ~category:"melange.lambda" ~name:"optimize"
+      ~args:(trace_args output_prefix) (fun () ->
   let lam = _d "initial"  lam in
   let lam  = Lam_pass_deep_flatten.deep_flatten lam in
   let lam = _d  "flatten0" lam in
@@ -198,8 +221,7 @@ let compile ~package_info (output_prefix: string) (lam: Lambda.lambda) =
 #endif
   in
 
-  let (coerced_input, meta) =
-    Lam_coercion.coerce_and_group_big_lambda  meta lam
+        Lam_coercion.coerce_and_group_big_lambda meta lam)
   in
   let groups = Lam_coercion.groups coerced_input in
 
@@ -230,11 +252,13 @@ let compile ~package_info (output_prefix: string) (lam: Lambda.lambda) =
       (Pp.textf "[TIME:] Pre-compile: %f" (Sys.time () *. 1000.))
   in
 #endif
-  let body  =
-    groups
-    |> List.map ~f:(fun group -> compile_group meta group)
-    |> Js_output.concat
-    |> Js_output.output_as_block
+  let body =
+    Compiler_trace.with_span ~category:"melange.lambda" ~name:"to-js"
+      ~args:(trace_args output_prefix) (fun () ->
+        groups
+        |> List.map ~f:(fun group -> compile_group meta group)
+        |> Js_output.concat
+        |> Js_output.output_as_block)
   in
 #ifndef MELANGE_RELEASE_BUILD
   let () =
@@ -248,38 +272,43 @@ let compile ~package_info (output_prefix: string) (lam: Lambda.lambda) =
     ; block = body
     }
   in
-  js
-  |> _j "initial"
-  |> Js_pass_flatten.program
-  |> _j "flatten"
-  |> Js_pass_tailcall_inline.tailcall_inline
-  |> _j "inline_and_shake"
-  |> Js_pass_flatten_and_mark_dead.program
-  |> _j "flatten_and_mark_dead"
-  |> Js_pass_scope.program
-  |> Js_shake.shake_program
-  |> _j "shake"
+  Compiler_trace.with_span ~category:"melange.js" ~name:"optimize"
+    ~args:(trace_args output_prefix) (fun () ->
+      js
+      |> _j "initial"
+      |> pass "flatten" Js_pass_flatten.program
+      |> _j "flatten"
+      |> pass "tailcall-inline" Js_pass_tailcall_inline.tailcall_inline
+      |> _j "inline_and_shake"
+      |> pass "flatten-and-mark-dead" Js_pass_flatten_and_mark_dead.program
+      |> _j "flatten_and_mark_dead"
+      |> pass "scope" Js_pass_scope.program
+      |> pass "shake" Js_shake.shake_program
+      |> _j "shake")
   |> (fun (program:  J.program) ->
       let external_module_ids : Lam_module_ident.t list =
-        if !Js_config.all_module_aliases then []
-        else
-          let hard_dependencies =
-            Js_fold_basic.calculate_hard_dependencies program.block
-          in
-          Lam_compile_env.populate_required_modules
-            may_required_modules hard_dependencies;
-          let module_ids =
-            let arr =
-              Lam_module_ident.Hash_set.to_list hard_dependencies
-              |> Array.of_list
-            in
-            Array.sort
-              ~cmp:(fun id1 id2 ->
-                String.compare (Lam_module_ident.name id1) (Lam_module_ident.name id2))
-              arr;
-            Array.to_list arr
-          in
-          module_ids
+        Compiler_trace.with_span ~category:"melange.js" ~name:"dependencies"
+          ~args:(trace_args output_prefix) (fun () ->
+            if !Js_config.all_module_aliases then []
+            else
+              let hard_dependencies =
+                Js_fold_basic.calculate_hard_dependencies program.block
+              in
+              Lam_compile_env.populate_required_modules
+                may_required_modules hard_dependencies;
+              let module_ids =
+                let arr =
+                  Lam_module_ident.Hash_set.to_list hard_dependencies
+                  |> Array.of_list
+                in
+                Array.sort
+                  ~cmp:(fun id1 id2 ->
+                    String.compare (Lam_module_ident.name id1)
+                      (Lam_module_ident.name id2))
+                  arr;
+                Array.to_list arr
+              in
+              module_ids)
       in
       Warnings.check_fatal();
       let effect_ =
@@ -306,21 +335,22 @@ let compile ~package_info (output_prefix: string) (lam: Lambda.lambda) =
           ~effect_
           (Lam_coercion.export_map coerced_input)
       in
-      (if not !Clflags.dont_write_files then
-         Js_cmj_format.to_file
-           (Artifact_extension.append_extension output_prefix Cmj) 
-           cmj);
+      (if not !Clflags.dont_write_files then (
+         let file = Artifact_extension.append_extension output_prefix Cmj in
+         Compiler_trace.with_span ~category:"melange.io" ~name:"cmj-write"
+           ~args:(trace_args output_prefix) (fun () ->
+             Js_cmj_format.to_file file cmj);
+         emit_artifact ~name:"cmj" ~output:file ~output_prefix));
       delayed_program)
 ;;
 
 let write_to_file ~package_info ~output_info ~output_prefix lambda_output file  =
-  Io.with_file_out_fd file ~f:(fun fd ->
-    Js_dump_program.dump_deps_program
-      ~package_info
-      ~output_info
-      ~output_prefix
-      lambda_output
-      fd)
+  Compiler_trace.with_span ~category:"melange.io" ~name:"js-print"
+    ~args:(trace_args output_prefix) (fun () ->
+      Io.with_file_out_fd file ~f:(fun fd ->
+        Js_dump_program.dump_deps_program ~package_info ~output_info
+          ~output_prefix lambda_output fd));
+  emit_artifact ~name:"javascript" ~output:file ~output_prefix
 
 let lambda_as_module =
   let (//) = Paths.(//) in
@@ -330,11 +360,11 @@ let lambda_as_module =
     in
     match (!Js_config.js_stdout, !Clflags.output_name) with
     | (true, None) ->
-      Js_dump_program.dump_deps_program
-        ~package_info
-        ~output_info:Js_packages_info.default_output_info
-        ~output_prefix
-        lambda_output Unix.stdout
+      Compiler_trace.with_span ~category:"melange.io" ~name:"js-print"
+        ~args:(trace_args output_prefix) (fun () ->
+          Js_dump_program.dump_deps_program ~package_info
+            ~output_info:Js_packages_info.default_output_info ~output_prefix
+            lambda_output Unix.stdout)
     | false, None ->
       raise (Arg.Bad ("no output specified (use -o <filename>.js)"))
     | (_, Some _) ->

--- a/melange-playground.opam
+++ b/melange-playground.opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-or-later"
 homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
-  "dune" {>= "3.21"}
+  "dune" {>= "3.24"}
   "ocaml"
   "js_of_ocaml" {dev}
   "reason" {dev}

--- a/melange.opam
+++ b/melange.opam
@@ -7,9 +7,11 @@ license: "LGPL-2.1-or-later"
 homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
-  "dune" {>= "3.21"}
+  "dune" {>= "3.24"}
   "ocaml" {>= "5.5" & < "5.6"}
   "cmdliner" {>= "1.1.0"}
+  "csexp"
+  "dune-action-trace" {>= "3.24"}
   "dune-build-info"
   "cppo" {build}
   "alcotest" {with-test}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -82,6 +82,8 @@ buildDunePackage {
     makeWrapper
   ];
   propagatedBuildInputs = [
+    csexp
+    dune-action-trace
     dune-build-info
     cmdliner
     ppxlib_gt_0_37

--- a/test/blackbox-tests/compiler-action-trace.t
+++ b/test/blackbox-tests/compiler-action-trace.t
@@ -1,0 +1,113 @@
+Melange can add compiler phases and artifact sizes to Dune's action trace.
+Tracing is opt-in, so normal compiler invocations do not emit events or read
+artifact sizes for tracing.
+
+  $ . ./setup.sh
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.24)
+  > (using melange 1.0)
+  > EOF
+  $ cat > dune <<'EOF'
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (module_systems (commonjs cjs) (esm mjs))
+  >  (compile_flags :standard --mel-action-trace))
+  > EOF
+  $ cat > main.ml <<'EOF'
+  > let identity x = x
+  > let answer = identity 42
+  > EOF
+  $ cat > main.mli <<'EOF'
+  > val identity : 'a -> 'a
+  > val answer : int
+  > EOF
+
+  $ dune build --trace-file=trace.csexp @melange
+  $ dune trace cat --trace-file=trace.csexp --chrome-trace > trace.json
+  $ cp _build/default/output/main.cjs traced-main.cjs
+  $ cp _build/default/output/main.mjs traced-main.mjs
+
+The event names are deliberately stable; timestamps and durations are not.
+
+  $ jq -r '
+  >   [(if type == "array" then . else .traceEvents end)[]
+  >    | select(.cat | startswith("melange."))
+  >    | [.cat, .name]
+  >    | @tsv]
+  >   | unique | sort | .[]' trace.json
+  melange.artifact	cmj
+  melange.artifact	javascript
+  melange.frontend	builtin-ppx
+  melange.frontend	parse
+  melange.frontend	ppx
+  melange.frontend	typecheck
+  melange.io	cmj-read
+  melange.io	cmj-write
+  melange.io	js-print
+  melange.js	dependencies
+  melange.js	flatten
+  melange.js	flatten-and-mark-dead
+  melange.js	optimize
+  melange.js	scope
+  melange.js	shake
+  melange.js	tailcall-inline
+  melange.lambda	convert
+  melange.lambda	optimize
+  melange.lambda	to-js
+  melange.lambda	translate
+
+Both implementation and interface compilation emit frontend spans.
+
+  $ jq '[(if type == "array" then . else .traceEvents end)[] | select(.cat == "melange.frontend" and .name == "typecheck")] | length' trace.json
+  2
+
+The JavaScript optimizer runs once while producing the CMJ, even when the
+project requests two JavaScript module systems.
+
+  $ jq '[(if type == "array" then . else .traceEvents end)[] | select(.cat == "melange.js" and .name == "optimize")] | length' trace.json
+  1
+
+The Dune-provided rule digest lets consumers attribute the optimizer span to
+the CMJ action.
+
+  $ jq -e '
+  >   (if type == "array" then . else .traceEvents end) as $events
+  >   | [$events[]
+  >      | select(.cat == "melange.artifact" and .name == "cmj")
+  >      | .args.digest] as $cmj_rules
+  >   | [$events[]
+  >      | select(.cat == "melange.js" and .name == "optimize")
+  >      | .args.digest] as $optimizer_rules
+  >   | all($optimizer_rules[]; . as $digest
+  >       | $cmj_rules | index($digest) != null)' trace.json >/dev/null
+
+Artifact events expose machine-readable byte counts and all spans are complete.
+
+  $ jq -e '
+  >   ([(if type == "array" then . else .traceEvents end)[]
+  >     | select(.cat == "melange.artifact")
+  >     | .args.bytes
+  >     | tonumber] | length == 3)
+  >   and
+  >   ([(if type == "array" then . else .traceEvents end)[]
+  >     | select(.cat | startswith("melange."))
+  >     | select(.ph == "X")
+  >     | .dur >= 0] | all)' trace.json >/dev/null
+
+Without the compiler flag, the same traced Dune build contains no Melange
+custom events.
+
+  $ cat > dune <<'EOF'
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (module_systems (commonjs cjs) (esm mjs)))
+  > EOF
+  $ dune clean
+  $ dune build --trace-file=unannotated.csexp @melange
+  $ dune trace cat --trace-file=unannotated.csexp --chrome-trace > unannotated.json
+  $ jq '[(if type == "array" then . else .traceEvents end)[] | select(.cat | startswith("melange."))] | length' unannotated.json
+  0
+  $ cmp traced-main.cjs _build/default/output/main.cjs
+  $ cmp traced-main.mjs _build/default/output/main.mjs


### PR DESCRIPTION
Adds opt-in `melc` phase spans and artifact metadata to Dune action traces.

Extracted from #1849 so tracing can land independently of delayed JavaScript optimization.