### PR TITLE
fix: warn when cross-module CMJ is missing

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+Unreleased
+----------
+
+- compiler: warn when `--mel-cross-module-opt` cannot find a dependency's
+  `.cmj` file ([#1857](https://github.com/melange-re/melange/pull/1857))
+
+
 7.0.1-55 2026-07-12
 ---------------
 

--- a/jscomp/core/lam_compile_env.ml
+++ b/jscomp/core/lam_compile_env.ml
@@ -43,6 +43,10 @@ type external_id_info = { is_relative : bool }
 
 let external_id_tbl : external_id_info Ident.Hashtbl.t = Ident.Hashtbl.create 31
 
+(* Several optimization passes can query the same module. *)
+let missing_cmj_warnings : unit Lam_module_ident.Hashtbl.t =
+  Lam_module_ident.Hashtbl.create 7
+
 (* For each compilation we need reset to make it re-entrant *)
 let reset () =
   Translmod.reset ();
@@ -50,6 +54,7 @@ let reset () =
   (* This is needed in the playground since one no_export can make it true
      In the payground, it seems we need reset more states *)
   Lam_module_ident.Hashtbl.clear cached_tbl;
+  Lam_module_ident.Hashtbl.clear missing_cmj_warnings;
   Ident.Hashtbl.clear external_id_tbl
 
 let register_external_id id module_name =
@@ -106,7 +111,20 @@ let query_external_id_info_exn ~dynamic_import (module_id : Ident.t)
 
 let query_external_id_info ~dynamic_import module_id name =
   try Some (query_external_id_info_exn ~dynamic_import module_id name)
-  with Mel_exception.Error (Cmj_not_found _) -> None
+  with Mel_exception.Error (Cmj_not_found unit_name) ->
+    let oid = Lam_module_ident.of_ml ~dynamic_import module_id in
+    if
+      !Js_config.cross_module_inline
+      && not (Lam_module_ident.Hashtbl.mem missing_cmj_warnings oid)
+    then (
+      Lam_module_ident.Hashtbl.replace missing_cmj_warnings ~key:oid ~data:();
+      Location.prerr_warning Location.none
+        (Warnings.Inlining_impossible
+           (Printf.sprintf
+              "missing CMJ file for module %s; continuing without cross-module \
+               optimization"
+              unit_name)));
+    None
 
 let external_id_is_relative id =
   match Ident.Hashtbl.find external_id_tbl id with

--- a/jscomp/core/lam_compile_env.mli
+++ b/jscomp/core/lam_compile_env.mli
@@ -79,7 +79,8 @@ val query_external_id_info :
     2. there's no `.cmj` file available. This can happen if we're compiling a
     dune virtual library where one of the modules uses a binding from any of
     its virtual modules. Because we're programming against the interface file
-    at this point, we must emit the deoptimized expression too. *)
+    at this point, we must emit the deoptimized expression too. When
+    cross-module optimization is enabled, this case emits warning 55. *)
 
 val external_id_is_relative : Ident.t -> bool option
 (** Returns [None] when the identifier is not a registered JS external module. *)

--- a/test/blackbox-tests/missing-cmj-cross-module-opt.t
+++ b/test/blackbox-tests/missing-cmj-cross-module-opt.t
@@ -20,5 +20,8 @@ missing installed CMJ dependency.
 
   $ melc -I installed --mel-cross-module-opt --mel-stop-after-cmj \
   >   src/errors.ml -o app/errors.cmj
+  File "src/errors.ml", line 1:
+  Warning 55 [inlining-impossible]: Cannot inline:
+    missing CMJ file for module Classify; continuing without cross-module optimization
   $ ls app/errors.cmj
   app/errors.cmj


### PR DESCRIPTION
Emits warning 55 when cross-module optimization cannot find a dependency `.cmj`.

Follows #1856. Related to ocaml/dune#15900.