### PR TITLE
Backport melobjinfo to v7-55

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+Unreleased
+----------
+
+- CLI: add `melobjinfo` to inspect implementation, runtime and JavaScript
+  dependencies stored in `.cmj` files
+  ([#1859](https://github.com/melange-re/melange/pull/1859))
+
+
 7.0.1-55 2026-07-12
 ---------------
 
@@ -740,4 +748,3 @@
 - Initial public release
 
 This is the only release of Melange that supports OCaml 4.12.
-

--- a/bin/dune
+++ b/bin/dune
@@ -17,3 +17,9 @@
  (package melange)
  (modules melppx)
  (libraries melange.ppx ppxlib))
+
+(executable
+ (public_name melobjinfo)
+ (package melange)
+ (modules melobjinfo)
+ (libraries cmdliner melangelib))

--- a/bin/melobjinfo.ml
+++ b/bin/melobjinfo.ml
@@ -1,0 +1,60 @@
+open Cmdliner
+open Melangelib
+
+type dependencies = {
+  ml : string list;
+  runtime : string list;
+  external_ : string list;
+}
+
+let dependencies (cmj : Js_cmj_format.t) =
+  List.fold_right
+    (fun (module_id : J.module_id) dependencies ->
+      let name = Lam_module_ident.name module_id in
+      match module_id.kind with
+      | Ml -> { dependencies with ml = name :: dependencies.ml }
+      | Runtime -> { dependencies with runtime = name :: dependencies.runtime }
+      | External _ ->
+          { dependencies with external_ = name :: dependencies.external_ })
+    cmj.delayed_program.modules
+    { ml = []; runtime = []; external_ = [] }
+
+let print_names heading names =
+  match names with
+  | [] -> ()
+  | _ ->
+      Printf.printf "%s:\n" heading;
+      List.iter (Printf.printf "  %s\n") names
+
+(* CMJs do not store dependency digests. Dashes keep this compatible with the
+   implementation-import rows printed by ocamlobjinfo. *)
+let print_implementation name =
+  Printf.printf "  --------------------------------  %s\n" name
+
+let print_file file =
+  let cmj = Js_cmj_format.from_file file in
+  let { ml; runtime; external_ } = dependencies cmj in
+  Printf.printf "File %s\n" file;
+  print_names "Runtime modules imported" runtime;
+  print_names "JavaScript modules imported" external_;
+  Printf.printf "Implementations imported:\n";
+  List.iter print_implementation ml
+
+let run files =
+  match files with
+  | [] -> `Error (true, "at least one CMJ file is required")
+  | _ -> (
+      try
+        List.iter print_file files;
+        `Ok ()
+      with exn -> `Error (false, Printexc.to_string exn))
+
+let files =
+  let doc = "CMJ files to inspect." in
+  Arg.(value & pos_all file [] & info [] ~doc ~docv:"CMJ")
+
+let cmd =
+  let doc = "print information about Melange CMJ files" in
+  Cmd.v (Cmd.info "melobjinfo" ~doc) Term.(ret (const run $ files))
+
+let () = exit (Cmd.eval cmd)

--- a/bin/melobjinfo.ml
+++ b/bin/melobjinfo.ml
@@ -7,13 +7,14 @@ type dependencies = {
   external_ : string list;
 }
 
-let sort_uniq_dependencies { ml; runtime; external_ } =
+let sort_uniq_dependencies =
   let sort_uniq = List.sort_uniq String.compare in
-  {
-    ml = sort_uniq ml;
-    runtime = sort_uniq runtime;
-    external_ = sort_uniq external_;
-  }
+  fun { ml; runtime; external_ } ->
+    {
+      ml = sort_uniq ml;
+      runtime = sort_uniq runtime;
+      external_ = sort_uniq external_;
+    }
 
 let dependencies (cmj : Js_cmj_format.t) =
   List.fold_right

--- a/bin/melobjinfo.ml
+++ b/bin/melobjinfo.ml
@@ -7,6 +7,14 @@ type dependencies = {
   external_ : string list;
 }
 
+let sort_uniq_dependencies { ml; runtime; external_ } =
+  let sort_uniq = List.sort_uniq String.compare in
+  {
+    ml = sort_uniq ml;
+    runtime = sort_uniq runtime;
+    external_ = sort_uniq external_;
+  }
+
 let dependencies (cmj : Js_cmj_format.t) =
   List.fold_right
     (fun (module_id : J.module_id) dependencies ->
@@ -18,6 +26,7 @@ let dependencies (cmj : Js_cmj_format.t) =
           { dependencies with external_ = name :: dependencies.external_ })
     cmj.delayed_program.modules
     { ml = []; runtime = []; external_ = [] }
+  |> sort_uniq_dependencies
 
 let print_names heading names =
   match names with
@@ -32,22 +41,30 @@ let print_implementation name =
   Printf.printf "  --------------------------------  %s\n" name
 
 let print_file file =
-  let cmj = Js_cmj_format.from_file file in
-  let { ml; runtime; external_ } = dependencies cmj in
-  Printf.printf "File %s\n" file;
-  print_names "Runtime modules imported" runtime;
-  print_names "JavaScript modules imported" external_;
-  Printf.printf "Implementations imported:\n";
-  List.iter print_implementation ml
+  try
+    let cmj = Js_cmj_format.from_file file in
+    let { ml; runtime; external_ } = dependencies cmj in
+    Printf.printf "File %s\n" file;
+    print_names "Runtime modules imported" runtime;
+    print_names "JavaScript modules imported" external_;
+    (* Keep this section unconditional and last: ocamlobjinfo-compatible parsers
+       use it to delimit the implementation imports for each file. *)
+    Printf.printf "Implementations imported:\n";
+    List.iter print_implementation ml;
+    Ok ()
+  with exn -> Error (Printf.sprintf "%s: %s" file (Printexc.to_string exn))
+
+let rec print_files = function
+  | [] -> `Ok ()
+  | file :: files -> (
+      match print_file file with
+      | Ok () -> print_files files
+      | Error message -> `Error (false, message))
 
 let run files =
   match files with
   | [] -> `Error (true, "at least one CMJ file is required")
-  | _ -> (
-      try
-        List.iter print_file files;
-        `Ok ()
-      with exn -> `Error (false, Printexc.to_string exn))
+  | _ -> print_files files
 
 let files =
   let doc = "CMJ files to inspect." in

--- a/test/blackbox-tests/melobjinfo.t
+++ b/test/blackbox-tests/melobjinfo.t
@@ -1,0 +1,22 @@
+`melobjinfo` reports the implementation dependencies serialized in CMJ files.
+
+  $ . ./setup.sh
+
+  $ cat > dep.ml <<'EOF'
+  > let value = 1
+  > EOF
+  $ melc --bs-no-bin-annot --mel-stop-after-cmj dep.ml -o dep.cmj
+
+  $ cat > main.ml <<'EOF'
+  > let value = Dep.value
+  > EOF
+  $ melc -I . --bs-no-bin-annot --mel-stop-after-cmj main.ml -o main.cmj
+  $ test ! -e dep.cmt
+  $ test ! -e main.cmt
+
+  $ melobjinfo dep.cmj main.cmj
+  File dep.cmj
+  Implementations imported:
+  File main.cmj
+  Implementations imported:
+    --------------------------------  Dep

--- a/test/blackbox-tests/melobjinfo.t
+++ b/test/blackbox-tests/melobjinfo.t
@@ -1,22 +1,133 @@
-`melobjinfo` reports the implementation dependencies serialized in CMJ files.
+`melobjinfo` reports the dependencies serialized in CMJ files.
 
   $ . ./setup.sh
 
-  $ cat > dep.ml <<'EOF'
+CMJs with no dependencies are valid. Binary annotations are deliberately
+disabled throughout this test: `melobjinfo` reads only the CMJ.
+
+  $ cat > standalone.ml <<'EOF'
   > let value = 1
   > EOF
-  $ melc --bs-no-bin-annot --mel-stop-after-cmj dep.ml -o dep.cmj
-
-  $ cat > main.ml <<'EOF'
-  > let value = Dep.value
-  > EOF
-  $ melc -I . --bs-no-bin-annot --mel-stop-after-cmj main.ml -o main.cmj
-  $ test ! -e dep.cmt
-  $ test ! -e main.cmt
-
-  $ melobjinfo dep.cmj main.cmj
-  File dep.cmj
+  $ melc --bs-no-bin-annot --mel-stop-after-cmj standalone.ml \
+  >   -o standalone.cmj
+  $ test ! -e standalone.cmt
+  $ melobjinfo standalone.cmj
+  File standalone.cmj
   Implementations imported:
-  File main.cmj
+
+Melange implementation dependencies retain their compilation-unit names,
+including the names generated for wrapped libraries.
+
+  $ cat > leaf.ml <<'EOF'
+  > let value = 1
+  > EOF
+  $ melc --bs-no-bin-annot --mel-stop-after-cmj leaf.ml -o leaf.cmj
+
+  $ cat > dep.ml <<'EOF'
+  > let value = Leaf.value
+  > EOF
+  $ melc -I . --bs-no-bin-annot --mel-stop-after-cmj dep.ml -o dep.cmj
+
+  $ cat > namespace__Dep.ml <<'EOF'
+  > let value = 2
+  > EOF
+  $ melc --bs-no-bin-annot --mel-stop-after-cmj namespace__Dep.ml \
+  >   -o namespace__Dep.cmj
+
+A virtual module has an interface but no CMJ. It is still an implementation
+dependency of a CMJ that refers to it.
+
+  $ cat > virtual_dep.mli <<'EOF'
+  > val value : int
+  > EOF
+  $ melc --bs-no-bin-annot --mel-cmi-only virtual_dep.mli
+  $ test ! -e virtual_dep.cmj
+
+  $ cat > implementation_imports.ml <<'EOF'
+  > let ordinary = Dep.value
+  > let namespaced = Namespace__Dep.value
+  > let virtual_ = Virtual_dep.value
+  > EOF
+  $ melc -I . --bs-no-bin-annot --mel-stop-after-cmj \
+  >   implementation_imports.ml -o implementation_imports.cmj
+  $ test ! -e implementation_imports.cmt
+  $ melobjinfo implementation_imports.cmj
+  File implementation_imports.cmj
   Implementations imported:
     --------------------------------  Dep
+    --------------------------------  Namespace__Dep
+    --------------------------------  Virtual_dep
+
+Dependency rows are immediate, rather than the transitive closure. Leaf is
+reported by Dep, but not by Implementation_imports above.
+
+  $ melobjinfo dep.cmj
+  File dep.cmj
+  Implementations imported:
+    --------------------------------  Leaf
+
+Multiple inputs are reported in argument order, including files with no
+dependencies.
+
+  $ melobjinfo standalone.cmj dep.cmj
+  File standalone.cmj
+  Implementations imported:
+  File dep.cmj
+  Implementations imported:
+    --------------------------------  Leaf
+
+Runtime dependencies are reported separately from implementation imports.
+
+  $ cat > runtime_imports.ml <<'EOF'
+  > let to_option value = Js.Nullable.toOption value
+  > EOF
+  $ melc --bs-no-bin-annot --mel-stop-after-cmj runtime_imports.ml \
+  >   -o runtime_imports.cmj
+  $ melobjinfo runtime_imports.cmj
+  File runtime_imports.cmj
+  Runtime modules imported:
+    Caml_option
+  Implementations imported:
+
+JavaScript dependencies include package and relative module specifiers. Named
+and default exports, whether statically or dynamically imported, are retained.
+
+  $ cat > javascript_imports.ml <<'EOF'
+  > external named_export : int = "named" [@@mel.module "package-name"]
+  > external relative : int = "value" [@@mel.module "./relative.js"]
+  > external default_export : int = "default"
+  >   [@@mel.module "default-package"]
+  > external dynamic_default : int = "default"
+  >   [@@mel.module "dynamic-package"]
+  > external dynamic_named : int = "named"
+  >   [@@mel.module "dynamic-named-package"]
+  > let named_export = named_export
+  > let relative = relative
+  > let default_export = default_export
+  > let dynamic_default : int Js.promise = Js.import dynamic_default
+  > let dynamic_named : int Js.promise = Js.import dynamic_named
+  > EOF
+  $ melc --ppx melppx --bs-no-bin-annot --mel-stop-after-cmj \
+  >   javascript_imports.ml -o javascript_imports.cmj
+  $ melobjinfo javascript_imports.cmj
+  File javascript_imports.cmj
+  JavaScript modules imported:
+    ./relative.js
+    default-package
+    dynamic-named-package
+    dynamic-package
+    package-name
+  Implementations imported:
+
+Dynamic imports of Melange modules remain implementation dependencies.
+
+  $ cat > dynamic_import.ml <<'EOF'
+  > module type Dependency = module type of Namespace__Dep
+  > let dependency = Js.import (module Namespace__Dep : Dependency)
+  > EOF
+  $ melc -I . --bs-no-bin-annot --mel-stop-after-cmj dynamic_import.ml \
+  >   -o dynamic_import.cmj
+  $ melobjinfo dynamic_import.cmj
+  File dynamic_import.cmj
+  Implementations imported:
+    --------------------------------  Namespace__Dep

--- a/test/blackbox-tests/melobjinfo.t
+++ b/test/blackbox-tests/melobjinfo.t
@@ -58,6 +58,23 @@ dependency of a CMJ that refers to it.
     --------------------------------  Namespace__Dep
     --------------------------------  Virtual_dep
 
+Dependencies used only by erased type declarations are not implementation
+dependencies in the CMJ.
+
+  $ cat > type_dependency.ml <<'EOF'
+  > type t = int
+  > EOF
+  $ melc --bs-no-bin-annot --mel-stop-after-cmj type_dependency.ml \
+  >   -o type_dependency.cmj
+  $ cat > type_only_import.ml <<'EOF'
+  > type t = Type_dependency.t
+  > EOF
+  $ melc -I . --bs-no-bin-annot --mel-stop-after-cmj type_only_import.ml \
+  >   -o type_only_import.cmj
+  $ melobjinfo type_only_import.cmj
+  File type_only_import.cmj
+  Implementations imported:
+
 Dependency rows are immediate, rather than the transitive closure. Leaf is
 reported by Dep, but not by Implementation_imports above.
 
@@ -65,6 +82,19 @@ reported by Dep, but not by Implementation_imports above.
   File dep.cmj
   Implementations imported:
     --------------------------------  Leaf
+
+Cross-module optimization preserves the implementation dependencies needed to
+build the resulting CMJ.
+
+  $ cat > optimized_import.ml <<'EOF'
+  > let value = Dep.value
+  > EOF
+  $ melc -I . --mel-cross-module-opt --bs-no-bin-annot \
+  >   --mel-stop-after-cmj optimized_import.ml -o optimized_import.cmj
+  $ melobjinfo optimized_import.cmj
+  File optimized_import.cmj
+  Implementations imported:
+    --------------------------------  Dep
 
 Multiple inputs are reported in argument order, including files with no
 dependencies.
@@ -75,6 +105,18 @@ dependencies.
   File dep.cmj
   Implementations imported:
     --------------------------------  Leaf
+
+If one input is malformed, the diagnostic identifies it without discarding
+the output for preceding inputs.
+
+  $ touch malformed.cmj
+  $ melobjinfo standalone.cmj malformed.cmj >output 2>error
+  [124]
+  $ cat output
+  File standalone.cmj
+  Implementations imported:
+  $ sed 's/malformed.cmj:.*/malformed.cmj: <error>/' error
+  melobjinfo: malformed.cmj: <error>
 
 Runtime dependencies are reported separately from implementation imports.
 
@@ -91,6 +133,7 @@ Runtime dependencies are reported separately from implementation imports.
 
 JavaScript dependencies include package and relative module specifiers. Named
 and default exports, whether statically or dynamically imported, are retained.
+Module specifiers are sorted and deduplicated.
 
   $ cat > javascript_imports.ml <<'EOF'
   > external named_export : int = "named" [@@mel.module "package-name"]
@@ -101,11 +144,16 @@ and default exports, whether statically or dynamically imported, are retained.
   >   [@@mel.module "dynamic-package"]
   > external dynamic_named : int = "named"
   >   [@@mel.module "dynamic-named-package"]
+  > external duplicate_named : int = "named" [@@mel.module "same-package"]
+  > external duplicate_default : int = "default"
+  >   [@@mel.module "same-package"]
   > let named_export = named_export
   > let relative = relative
   > let default_export = default_export
   > let dynamic_default : int Js.promise = Js.import dynamic_default
   > let dynamic_named : int Js.promise = Js.import dynamic_named
+  > let duplicate_named = duplicate_named
+  > let duplicate_default = duplicate_default
   > EOF
   $ melc --ppx melppx --bs-no-bin-annot --mel-stop-after-cmj \
   >   javascript_imports.ml -o javascript_imports.cmj
@@ -117,6 +165,7 @@ and default exports, whether statically or dynamically imported, are retained.
     dynamic-named-package
     dynamic-package
     package-name
+    same-package
   Implementations imported:
 
 Dynamic imports of Melange modules remain implementation dependencies.


### PR DESCRIPTION
Backport #1858 to the v7-55 maintenance branch so Dune can inspect dependencies stored in CMJ files.

Supports ocaml/dune#16271.