### PR TITLE
refactor: share external call summary resolution

### DIFF
--- a/jscomp/core/lam_compile_env.ml
+++ b/jscomp/core/lam_compile_env.ml
@@ -131,6 +131,28 @@ let external_id_is_relative id =
   | { is_relative } -> Some is_relative
   | exception Not_found -> None
 
+let resolve_external_call_summary ~dynamic_import ident name
+    ~arity:direct_arity =
+  let direct_external arity ~relocatable =
+    Lam_call_summary.Direct_external
+      { dynamic_import; id = ident; name; arity; relocatable }
+  in
+  match external_id_is_relative ident with
+  | Some is_relative -> (
+      match direct_arity with
+      | Some arity -> direct_external arity ~relocatable:(not is_relative)
+      | None -> Lam_call_summary.Unknown)
+  | None -> (
+      match query_external_id_info ~dynamic_import ident name with
+      | Some { arity; call_summary; _ } -> (
+          if not (Lam_call_summary.is_unknown call_summary) then call_summary
+          else
+            match arity with
+            | Single arity when not (Lam_arity.first_arity_na arity) ->
+                direct_external arity ~relocatable:true
+            | Single _ | Submodule _ -> Lam_call_summary.Unknown)
+      | None -> Lam_call_summary.Unknown)
+
 let is_relative_external_id id =
   match external_id_is_relative id with
   | Some true -> true

--- a/jscomp/core/lam_compile_env.mli
+++ b/jscomp/core/lam_compile_env.mli
@@ -85,6 +85,13 @@ val query_external_id_info :
 val external_id_is_relative : Ident.t -> bool option
 (** Returns [None] when the identifier is not a registered JS external module. *)
 
+val resolve_external_call_summary :
+  dynamic_import:bool ->
+  Ident.t ->
+  string ->
+  arity:Lam_arity.t option ->
+  Lam_call_summary.t
+
 val lambda_is_relocatable : Lam.t -> bool
 val is_pure_module : Lam_module_ident.t -> bool
 

--- a/jscomp/core/lam_pass_collect.ml
+++ b/jscomp/core/lam_pass_collect.ml
@@ -58,39 +58,14 @@ let annotate (meta : Lam_stats.t) rec_flag (k : Ident.t) (arity : Lam_arity.t)
     alias propgation - and toplevel identifiers, this needs to be exported
 *)
 let collect_info =
-  let direct_external ~dynamic_import id name arity ~relocatable =
-    Lam_call_summary.Direct_external
-      { dynamic_import; id; name; arity; relocatable }
-  in
-  let find_external ~dynamic_import ident name ~arity:direct_arity =
-    match Lam_compile_env.external_id_is_relative ident with
-    | Some is_relative -> (
-        match direct_arity with
-        | Some arity ->
-            direct_external ~dynamic_import ident name arity
-              ~relocatable:(not is_relative)
-        | None -> Lam_call_summary.Unknown)
-    | None -> (
-        match
-          Lam_compile_env.query_external_id_info ~dynamic_import ident name
-        with
-        | Some ({ arity; call_summary; _ } as _info) -> (
-            if not (Lam_call_summary.is_unknown call_summary) then call_summary
-            else
-              match arity with
-              | Single arity when not (Lam_arity.first_arity_na arity) ->
-                  direct_external ~dynamic_import ident name arity
-                    ~relocatable:true
-              | Single _ | Submodule _ -> Lam_call_summary.Unknown)
-        | None -> Lam_call_summary.Unknown)
-  in
   let find_ident (meta : Lam_stats.t) ident =
     match Ident.Hashtbl.find meta.ident_tbl ident with
     | FunctionId { call_summary; _ } -> call_summary
     | _ | (exception Not_found) -> Lam_call_summary.Unknown
   in
   let summarize meta lam =
-    Lam_call_summary.of_lambda lam ~find_ident:(find_ident meta) ~find_external
+    Lam_call_summary.of_lambda lam ~find_ident:(find_ident meta)
+      ~find_external:Lam_compile_env.resolve_external_call_summary
   in
   let rec collect_bind (meta : Lam_stats.t) rec_flag (ident : Ident.t)
       (lam : Lam.t) =
@@ -155,7 +130,8 @@ let collect_info =
           if Lam_arity.first_arity_na arity then None else Some arity
         in
         let call_summary =
-          find_external ~dynamic_import module_id field_name ~arity:direct_arity
+          Lam_compile_env.resolve_external_call_summary ~dynamic_import
+            module_id field_name ~arity:direct_arity
         in
         if Lam_call_summary.is_unknown call_summary then (
           collect meta lam;

--- a/jscomp/core/lam_stats_export.ml
+++ b/jscomp/core/lam_stats_export.ml
@@ -37,10 +37,6 @@ let values_of_export =
         param_map
     | _ -> Ident.Map.empty
   in
-  let direct_external ~dynamic_import id name arity ~relocatable =
-    Lam_call_summary.Direct_external
-      { dynamic_import; id; name; arity; relocatable }
-  in
   (* Preserve sharing in the lambda graph when building recursive CMJ data. *)
   let memoize cache key f =
     match Ident.Hashtbl.find cache key with
@@ -76,28 +72,6 @@ let values_of_export =
           (Array.map elems ~f:(arity_of_element meta seen))
     | SimpleForm lam -> arity_of_lambda meta seen lam
   in
-  let find_external_summary ~dynamic_import ident name ~arity:direct_arity =
-    match Lam_compile_env.external_id_is_relative ident with
-    | Some is_relative -> (
-        match direct_arity with
-        | Some arity ->
-            direct_external ~dynamic_import ident name arity
-              ~relocatable:(not is_relative)
-        | None -> Lam_call_summary.Unknown)
-    | None -> (
-        match
-          Lam_compile_env.query_external_id_info ~dynamic_import ident name
-        with
-        | Some { arity; call_summary; _ } -> (
-            if not (Lam_call_summary.is_unknown call_summary) then call_summary
-            else
-              match arity with
-              | Single arity when not (Lam_arity.first_arity_na arity) ->
-                  direct_external ~dynamic_import ident name arity
-                    ~relocatable:true
-              | Single _ | Submodule _ -> Lam_call_summary.Unknown)
-        | None -> Lam_call_summary.Unknown)
-  in
   let find_ident_summary (meta : Lam_stats.t) ident =
     match Ident.Hashtbl.find meta.ident_tbl ident with
     | FunctionId { call_summary; _ } -> call_summary
@@ -106,7 +80,7 @@ let values_of_export =
   let summarize meta lambda =
     let call_summary =
       Lam_call_summary.of_lambda lambda ~find_ident:(find_ident_summary meta)
-        ~find_external:find_external_summary
+        ~find_external:Lam_compile_env.resolve_external_call_summary
     in
     if Lam_call_summary.is_relocatable call_summary then call_summary
     else Lam_call_summary.Unknown


### PR DESCRIPTION
Centralizes external-call summary resolution shared by collection and CMJ export. No related issue.