### PR TITLE
refactor(js_parser): share match case parsing

### DIFF
--- a/jscomp/js_parser/expression_parser.ml
+++ b/jscomp/js_parser/expression_parser.ml
@@ -1499,60 +1499,20 @@ module Expression
 
   and match_expression env ~match_keyword_loc ~leading ~arg =
     let case env =
-      let leading = Peek.comments env in
-      let case_match_root_loc = Peek.loc env |> Loc.start_loc in
-      let invalid_prefix_case =
-        if Peek.token env = T_CASE then (
-          let loc = Peek.loc env in
-          Eat.token env;
-          Some loc
-        ) else
-          None
-      in
-      let pattern = Parse.match_pattern env in
-      let guard =
-        if Eat.maybe env T_IF then (
-          Expect.token env T_LPAREN;
-          let test = Parse.expression env in
-          Expect.token env T_RPAREN;
-          Some test
-        ) else
-          None
-      in
-      let invalid_infix_colon =
-        if Peek.token env = T_COLON then (
-          let loc = Peek.loc env in
-          Eat.token env;
-          Some loc
-        ) else (
-          Expect.token env T_ARROW;
-          None
-        )
-      in
-      let body = assignment env in
-      let invalid_suffix_semicolon =
-        match Peek.token env with
-        | T_EOF
-        | T_RCURLY ->
-          None
-        | T_SEMICOLON ->
-          let loc = Peek.loc env in
-          Eat.token env;
-          Some loc
-        | _ ->
-          Expect.token env T_COMMA;
-          None
-      in
-      let trailing = Eat.trailing_comments env in
-      let comments = Flow_ast_utils.mk_comments_opt ~leading ~trailing () in
-      let invalid_syntax =
-        {
-          Match.Case.InvalidSyntax.invalid_prefix_case;
-          invalid_infix_colon;
-          invalid_suffix_semicolon;
-        }
-      in
-      { Match.Case.pattern; body; guard; comments; invalid_syntax; case_match_root_loc }
+      Parser_common.match_case env ~parse_pattern:Parse.match_pattern
+        ~parse_expression:Parse.expression ~parse_body:assignment
+        ~parse_suffix:(fun env ->
+          match Peek.token env with
+          | T_EOF
+          | T_RCURLY ->
+            None
+          | T_SEMICOLON ->
+            let loc = Peek.loc env in
+            Eat.token env;
+            Some loc
+          | _ ->
+            Expect.token env T_COMMA;
+            None)
     in
     let rec case_list env acc =
       match Peek.token env with

--- a/jscomp/js_parser/parser_common.ml
+++ b/jscomp/js_parser/parser_common.ml
@@ -328,6 +328,50 @@ module type MATCH_PATTERN = sig
   val match_pattern : env -> (Loc.t, Loc.t) MatchPattern.t
 end
 
+let match_case env ~parse_pattern ~parse_expression ~parse_body ~parse_suffix =
+  let leading = Peek.comments env in
+  let case_match_root_loc = Peek.loc env |> Loc.start_loc in
+  let invalid_prefix_case =
+    if Peek.token env = Token.T_CASE then (
+      let loc = Peek.loc env in
+      Eat.token env;
+      Some loc
+    ) else
+      None
+  in
+  let pattern = parse_pattern env in
+  let guard =
+    if Eat.maybe env Token.T_IF then (
+      Expect.token env Token.T_LPAREN;
+      let test = parse_expression env in
+      Expect.token env Token.T_RPAREN;
+      Some test
+    ) else
+      None
+  in
+  let invalid_infix_colon =
+    if Peek.token env = Token.T_COLON then (
+      let loc = Peek.loc env in
+      Eat.token env;
+      Some loc
+    ) else (
+      Expect.token env Token.T_ARROW;
+      None
+    )
+  in
+  let body = parse_body env in
+  let invalid_suffix_semicolon = parse_suffix env in
+  let trailing = Eat.trailing_comments env in
+  let comments = Flow_ast_utils.mk_comments_opt ~leading ~trailing () in
+  let invalid_syntax =
+    {
+      Match.Case.InvalidSyntax.invalid_prefix_case;
+      invalid_infix_colon;
+      invalid_suffix_semicolon;
+    }
+  in
+  { Match.Case.pattern; body; guard; comments; invalid_syntax; case_match_root_loc }
+
 let identifier_name_raw env =
   let open Token in
   let name =

--- a/jscomp/js_parser/statement_parser.ml
+++ b/jscomp/js_parser/statement_parser.ml
@@ -593,48 +593,14 @@ module Statement
   and match_statement env =
     let open Match in
     let case env =
-      let leading = Peek.comments env in
-      let case_match_root_loc = Peek.loc env |> Loc.start_loc in
-      let invalid_prefix_case =
-        if Peek.token env = T_CASE then (
-          let loc = Peek.loc env in
-          Eat.token env;
-          Some loc
-        ) else
-          None
-      in
-      let pattern = Parse.match_pattern env in
-      let guard =
-        if Eat.maybe env T_IF then (
-          Expect.token env T_LPAREN;
-          let test = Parse.expression env in
-          Expect.token env T_RPAREN;
-          Some test
-        ) else
-          None
-      in
-      let invalid_infix_colon =
-        if Peek.token env = T_COLON then (
-          let loc = Peek.loc env in
-          Eat.token env;
-          Some loc
-        ) else (
-          Expect.token env T_ARROW;
-          None
-        )
-      in
-      let body = Parse.statement ~allow_sequence:false (env |> with_in_match_statement true) in
-      ignore @@ Eat.maybe env T_COMMA;
-      let trailing = Eat.trailing_comments env in
-      let comments = Flow_ast_utils.mk_comments_opt ~leading ~trailing () in
-      let invalid_syntax =
-        {
-          Case.InvalidSyntax.invalid_prefix_case;
-          invalid_infix_colon;
-          invalid_suffix_semicolon = None;
-        }
-      in
-      { Case.pattern; body; guard; comments; invalid_syntax; case_match_root_loc }
+      Parser_common.match_case env ~parse_pattern:Parse.match_pattern
+        ~parse_expression:Parse.expression
+        ~parse_body:(fun env ->
+          Parse.statement ~allow_sequence:false
+            (env |> with_in_match_statement true))
+        ~parse_suffix:(fun env ->
+          ignore @@ Eat.maybe env T_COMMA;
+          None)
     in
     let rec case_list env acc =
       match Peek.token env with


### PR DESCRIPTION
Shares match-case prefix, guard, delimiter, and comment parsing between match expressions and statements. No related issue.