### PR TITLE
refactor(js_parser): share trailing comment parsing

### DIFF
--- a/jscomp/js_parser/enum_parser.ml
+++ b/jscomp/js_parser/enum_parser.ml
@@ -259,14 +259,7 @@ end = struct
         in
         let internal = internal @ Peek.comments env in
         Expect.token env T_RCURLY;
-        let trailing =
-          match Peek.token env with
-          | T_EOF
-          | T_RCURLY ->
-            Eat.trailing_comments env
-          | _ when Peek.is_line_terminator env -> Eat.comments_until_next_line env
-          | _ -> []
-        in
+        let trailing = Parser_common.trailing_comments_after_delimiter env in
         let comments =
           Flow_ast_utils.mk_comments_with_internal_opt ~leading ~trailing ~internal ()
         in

--- a/jscomp/js_parser/object_parser.ml
+++ b/jscomp/js_parser/object_parser.ml
@@ -941,14 +941,7 @@ module Object
         (key, annot, value, [])
       | T_SEMICOLON ->
         Eat.token env;
-        let trailing =
-          match Peek.token env with
-          | T_EOF
-          | T_RCURLY ->
-            Eat.trailing_comments env
-          | _ when Peek.is_line_terminator env -> Eat.comments_until_next_line env
-          | _ -> []
-        in
+        let trailing = Parser_common.trailing_comments_after_delimiter env in
         (key, annot, value, trailing)
       | _ ->
         let remover =
@@ -1856,12 +1849,8 @@ module Object
             exit_class env;
             Expect.token env T_RCURLY;
             let trailing =
-              match (expression, Peek.token env) with
-              | (true, _)
-              | (_, (T_RCURLY | T_EOF)) ->
-                Eat.trailing_comments env
-              | _ when Peek.is_line_terminator env -> Eat.comments_until_next_line env
-              | _ -> []
+              Parser_common.trailing_comments_after_delimiter
+                ~consume_all:expression env
             in
             { Ast.Class.Body.body; comments = Flow_ast_utils.mk_comments_opt ~leading ~trailing () }
           ) else (
@@ -2113,14 +2102,7 @@ module Object
         let leading = Peek.comments env in
         if Eat.maybe env T_LCURLY then (
           let body = elements env [] in
-          let trailing =
-            match Peek.token env with
-            | T_RCURLY
-            | T_EOF ->
-              Eat.trailing_comments env
-            | _ when Peek.is_line_terminator env -> Eat.comments_until_next_line env
-            | _ -> []
-          in
+          let trailing = Parser_common.trailing_comments_after_delimiter env in
           Expect.token env T_RCURLY;
           { Body.body; comments = Flow_ast_utils.mk_comments_opt ~leading ~trailing () }
         ) else (

--- a/jscomp/js_parser/parser_common.ml
+++ b/jscomp/js_parser/parser_common.ml
@@ -328,6 +328,23 @@ module type MATCH_PATTERN = sig
   val match_pattern : env -> (Loc.t, Loc.t) MatchPattern.t
 end
 
+let trailing_comments_after_delimiter ?(consume_all = false) env =
+  let consume_all =
+    consume_all
+    ||
+    match Peek.token env with
+    | Token.T_EOF
+    | Token.T_RCURLY ->
+      true
+    | _ -> false
+  in
+  if consume_all then
+    Eat.trailing_comments env
+  else if Peek.is_line_terminator env then
+    Eat.comments_until_next_line env
+  else
+    []
+
 let identifier_name_raw env =
   let open Token in
   let name =

--- a/jscomp/js_parser/parser_flow.ml
+++ b/jscomp/js_parser/parser_flow.ml
@@ -560,12 +560,8 @@ module rec Parse : PARSER = struct
         in
         Expect.token env T_RCURLY;
         let trailing =
-          match (expression, Peek.token env) with
-          | (true, _)
-          | (_, (T_RCURLY | T_EOF)) ->
-            Eat.trailing_comments env
-          | _ when Peek.is_line_terminator env -> Eat.comments_until_next_line env
-          | _ -> []
+          Parser_common.trailing_comments_after_delimiter
+            ~consume_all:expression env
         in
         let comments =
           Flow_ast_utils.mk_comments_with_internal_opt ~leading ~trailing ~internal ()

--- a/jscomp/js_parser/statement_parser.ml
+++ b/jscomp/js_parser/statement_parser.ml
@@ -67,12 +67,8 @@ module Statement
       Implicit { trailing = Eat.trailing_comments env; remove_trailing = (fun x _ -> x) }
     | T_SEMICOLON ->
       Eat.token env;
-      (match Peek.token env with
-      | T_EOF
-      | T_RCURLY ->
-        Explicit (Eat.trailing_comments env)
-      | _ when Peek.is_line_terminator env -> Explicit (Eat.comments_until_next_line env)
-      | _ -> Explicit [])
+      Explicit
+        (Parser_common.trailing_comments_after_delimiter env)
     | _ when Peek.is_line_terminator env ->
       Implicit (Comment_attachment.trailing_and_remover_after_last_line env)
     | _ ->


### PR DESCRIPTION
Shares end-of-block and same-line trailing-comment handling across parser paths. No related issue.