### PR TITLE
refactor(melstd): share power-of-two sizing

### DIFF
--- a/jscomp/melstd/hash_set_ident_mask.ml
+++ b/jscomp/melstd/hash_set_ident_mask.ml
@@ -38,17 +38,8 @@ type t = {
 let key_index_by_ident (h : t) (key : Ident.t) =
   Mel_ident.hash key land (Array.length h.data - 1)
 
-(** {[
-     (power_2_above 16 63 = 64)
-       (power_2_above 16 76 = 128)
-   ]} *)
-let rec power_2_above x n =
-  if x >= n then x
-  else if x * 2 > Sys.max_array_length then x
-  else power_2_above (x * 2) n
-
 let create initial_size =
-  let s = power_2_above 8 initial_size in
+  let s = Int.power_2_above 8 initial_size in
   { size = 0; data = Array.make s Empty; mask_size = 0 }
 
 let iter_and_unmask h ~f =

--- a/jscomp/melstd/int.ml
+++ b/jscomp/melstd/int.ml
@@ -29,6 +29,16 @@ module T = struct
 end
 
 include T
+
+(** {[
+     (power_2_above 16 63 = 64)
+       (power_2_above 16 76 = 128)
+   ]} *)
+let rec power_2_above x n =
+  if x >= n then x
+  else if x * 2 > Sys.max_array_length then x
+  else power_2_above (x * 2) n
+
 module Map = MoreLabels.Map.Make (T)
 module Set = MoreLabels.Set.Make (T)
 module Hashtbl = MoreLabels.Hashtbl.Make (T)

--- a/jscomp/melstd/ordered_hash_map_local_ident.ml
+++ b/jscomp/melstd/ordered_hash_map_local_ident.ml
@@ -39,17 +39,8 @@ type 'value t = {
   initial_size : int; (* initial array size *)
 }
 
-(** {[
-     (power_2_above 16 63 = 64)
-       (power_2_above 16 76 = 128)
-   ]} *)
-let rec power_2_above x n =
-  if x >= n then x
-  else if x * 2 > Sys.max_array_length then x
-  else power_2_above (x * 2) n
-
 let create initial_size =
-  let s = power_2_above 16 initial_size in
+  let s = Int.power_2_above 16 initial_size in
   { initial_size = s; size = 0; data = Array.make s Empty }
 
 let clear h =


### PR DESCRIPTION
Centralizes power-of-two capacity sizing shared by the identifier hash structures. No related issue.