### PR TITLE
refactor(core): share lambda identifier traversal

### DIFF
--- a/jscomp/core/lam_hit.ml
+++ b/jscomp/core/lam_hit.ml
@@ -24,80 +24,8 @@
 
 open Import
 
-let hit_variables =
-  let rec hit_opt fv (x : Lam.t option) =
-    match x with None -> false | Some a -> hit fv a
-  and hit_var fv (id : Ident.t) = Ident.Set.mem id fv
-  and hit_list_snd : 'a. Ident.Set.t -> ('a * Lam.t) list -> bool =
-   fun fv x -> List.exists ~f:(fun (_, x) -> hit fv x) x
-  and hit_list fv xs = List.exists ~f:(hit fv) xs
-  and hit fv l =
-    match l with
-    | Lam.Lvar id | Lmutvar id -> hit_var fv id
-    | Lassign (id, e) -> hit_var fv id || hit fv e
-    | Lstaticcatch (e1, (_, _vars), e2) -> hit fv e1 || hit fv e2
-    | Ltrywith (e1, _exn, e2) -> hit fv e1 || hit fv e2
-    | Lfunction { body; params = _; _ } -> hit fv body
-    | Llet (_, _id, arg, body) | Lmutlet (_id, arg, body) ->
-        hit fv arg || hit fv body
-    | Lletrec (decl, body) -> hit fv body || hit_list_snd fv decl
-    | Lfor (_v, e1, e2, _dir, e3) -> hit fv e1 || hit fv e2 || hit fv e3
-    | Lconst _ -> false
-    | Lapply { ap_func; ap_args; _ } -> hit fv ap_func || hit_list fv ap_args
-    | Lglobal_module _ (* global persistent module, play safe *) -> false
-    | Lprim { args; _ } -> hit_list fv args
-    | Lswitch (arg, sw) ->
-        hit fv arg
-        || hit_list_snd fv sw.sw_consts
-        || hit_list_snd fv sw.sw_blocks
-        || hit_opt fv sw.sw_failaction
-    | Lstringswitch (arg, cases, default) ->
-        hit fv arg || hit_list_snd fv cases || hit_opt fv default
-    | Lstaticraise (_, args) -> hit_list fv args
-    | Lifthenelse (e1, e2, e3) -> hit fv e1 || hit fv e2 || hit fv e3
-    | Lsequence (e1, e2) -> hit fv e1 || hit fv e2
-    | Lwhile (e1, e2) -> hit fv e1 || hit fv e2
-    | Lsend (_k, met, obj, args, _) ->
-        hit fv met || hit fv obj || hit_list fv args
-    | Lifused (_v, e) -> hit fv e
-  in
-  fun (fv : Ident.Set.t) l -> hit fv l
+let hit_variables variables lam =
+  Lam_iter.exists_ident lam ~f:(fun id -> Ident.Set.mem id variables)
 
-let hit_variable =
-  let rec hit_opt fv (x : Lam.t option) =
-    match x with None -> false | Some a -> hit fv a
-  and hit_var fv (id : Ident.t) = Ident.same id fv
-  and hit_list_snd : 'a. Ident.t -> ('a * Lam.t) list -> bool =
-   fun fv x -> List.exists ~f:(fun (_, x) -> hit fv x) x
-  and hit_list fv xs = List.exists ~f:(hit fv) xs
-  and hit fv (l : Lam.t) =
-    match l with
-    | Lvar id | Lmutvar id -> hit_var fv id
-    | Lassign (id, e) -> hit_var fv id || hit fv e
-    | Lstaticcatch (e1, (_, _vars), e2) -> hit fv e1 || hit fv e2
-    | Ltrywith (e1, _exn, e2) -> hit fv e1 || hit fv e2
-    | Lfunction { body; params = _; _ } -> hit fv body
-    | Llet (_, _id, arg, body) | Lmutlet (_id, arg, body) ->
-        hit fv arg || hit fv body
-    | Lletrec (decl, body) -> hit fv body || hit_list_snd fv decl
-    | Lfor (_v, e1, e2, _dir, e3) -> hit fv e1 || hit fv e2 || hit fv e3
-    | Lconst _ -> false
-    | Lapply { ap_func; ap_args; _ } -> hit fv ap_func || hit_list fv ap_args
-    | Lglobal_module _ (* global persistent module, play safe *) -> false
-    | Lprim { args; _ } -> hit_list fv args
-    | Lswitch (arg, sw) ->
-        hit fv arg
-        || hit_list_snd fv sw.sw_consts
-        || hit_list_snd fv sw.sw_blocks
-        || hit_opt fv sw.sw_failaction
-    | Lstringswitch (arg, cases, default) ->
-        hit fv arg || hit_list_snd fv cases || hit_opt fv default
-    | Lstaticraise (_, args) -> hit_list fv args
-    | Lifthenelse (e1, e2, e3) -> hit fv e1 || hit fv e2 || hit fv e3
-    | Lsequence (e1, e2) -> hit fv e1 || hit fv e2
-    | Lwhile (e1, e2) -> hit fv e1 || hit fv e2
-    | Lsend (_k, met, obj, args, _) ->
-        hit fv met || hit fv obj || hit_list fv args
-    | Lifused (_v, e) -> hit fv e
-  in
-  fun (fv : Ident.t) (l : Lam.t) -> hit fv l
+let hit_variable variable lam =
+  Lam_iter.exists_ident lam ~f:(fun id -> Ident.same id variable)

--- a/jscomp/core/lam_iter.ml
+++ b/jscomp/core/lam_iter.ml
@@ -61,3 +61,9 @@ let inner_exists (l : Lam.t) ~(f : Lam.t -> bool) =
   | Lassign (_id, e) -> f e
   | Lsend (_k, met, obj, args, _loc) -> f met || f obj || List.exists ~f args
   | Lifused (_v, e) -> f e
+
+let rec exists_ident (lam : Lam.t) ~(f : Ident.t -> bool) =
+  match lam with
+  | Lvar id | Lmutvar id -> f id
+  | Lassign (id, expression) -> f id || exists_ident expression ~f
+  | _ -> inner_exists lam ~f:(exists_ident ~f)

--- a/jscomp/core/lam_iter.ml
+++ b/jscomp/core/lam_iter.ml
@@ -62,8 +62,11 @@ let inner_exists (l : Lam.t) ~(f : Lam.t -> bool) =
   | Lsend (_k, met, obj, args, _loc) -> f met || f obj || List.exists ~f args
   | Lifused (_v, e) -> f e
 
-let rec exists_ident (lam : Lam.t) ~(f : Ident.t -> bool) =
-  match lam with
-  | Lvar id | Lmutvar id -> f id
-  | Lassign (id, expression) -> f id || exists_ident expression ~f
-  | _ -> inner_exists lam ~f:(exists_ident ~f)
+let exists_ident (lam : Lam.t) ~(f : Ident.t -> bool) =
+  let rec loop (lam : Lam.t) =
+    match lam with
+    | Lvar id | Lmutvar id -> f id
+    | Lassign (id, expression) -> f id || loop expression
+    | lam -> inner_exists lam ~f:loop
+  in
+  loop lam

--- a/jscomp/core/lam_iter.mli
+++ b/jscomp/core/lam_iter.mli
@@ -23,3 +23,4 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 val inner_exists : Lam.t -> f:(Lam.t -> bool) -> bool
+val exists_ident : Lam.t -> f:(Ident.t -> bool) -> bool

--- a/jscomp/core/lam_scc.ml
+++ b/jscomp/core/lam_scc.ml
@@ -29,46 +29,8 @@ open Import
     set the bit of corresponding [id] if [id] is hit.
     As an optimization step if [mask_and_check_all_hit],
     there is no need to iter such lambda any more *)
-let hit_mask : Hash_set_ident_mask.t -> Lam.t -> bool =
-  let rec hit_opt mask (x : Lam.t option) =
-    match x with None -> false | Some a -> hit mask a
-  and hit_var mask (id : Ident.t) =
-    Hash_set_ident_mask.mask_and_check_all_hit mask id
-  and hit_list_snd : 'a. Hash_set_ident_mask.t -> ('a * Lam.t) list -> bool =
-   fun mask x -> List.exists ~f:(fun (_, x) -> hit mask x) x
-  and hit_list mask xs = List.exists ~f:(hit mask) xs
-  and hit mask (l : Lam.t) =
-    match l with
-    | Lvar id | Lmutvar id -> hit_var mask id
-    | Lassign (id, e) -> hit_var mask id || hit mask e
-    | Lstaticcatch (e1, (_, _), e2) -> hit mask e1 || hit mask e2
-    | Ltrywith (e1, _exn, e2) -> hit mask e1 || hit mask e2
-    | Lfunction { body; params = _; _ } -> hit mask body
-    | Llet (_, _id, arg, body) | Lmutlet (_id, arg, body) ->
-        hit mask arg || hit mask body
-    | Lletrec (decl, body) -> hit mask body || hit_list_snd mask decl
-    | Lfor (_v, e1, e2, _dir, e3) -> hit mask e1 || hit mask e2 || hit mask e3
-    | Lconst _ -> false
-    | Lapply { ap_func; ap_args; _ } ->
-        hit mask ap_func || hit_list mask ap_args
-    | Lglobal_module _ (* playsafe *) -> false
-    | Lprim { args; _ } -> hit_list mask args
-    | Lswitch (arg, sw) ->
-        hit mask arg
-        || hit_list_snd mask sw.sw_consts
-        || hit_list_snd mask sw.sw_blocks
-        || hit_opt mask sw.sw_failaction
-    | Lstringswitch (arg, cases, default) ->
-        hit mask arg || hit_list_snd mask cases || hit_opt mask default
-    | Lstaticraise (_, args) -> hit_list mask args
-    | Lifthenelse (e1, e2, e3) -> hit mask e1 || hit mask e2 || hit mask e3
-    | Lsequence (e1, e2) -> hit mask e1 || hit mask e2
-    | Lwhile (e1, e2) -> hit mask e1 || hit mask e2
-    | Lsend (_k, met, obj, args, _) ->
-        hit mask met || hit mask obj || hit_list mask args
-    | Lifused (_v, e) -> hit mask e
-  in
-  fun mask l -> hit mask l
+let hit_mask mask lam =
+  Lam_iter.exists_ident lam ~f:(Hash_set_ident_mask.mask_and_check_all_hit mask)
 
 type bindings = (Ident.t * Lam.t) Nonempty_list.t
 


### PR DESCRIPTION
Reuses the common lambda child traversal for identifier queries and SCC dependency collection. No related issue.