### PR TITLE
refactor(ppx): share inline literal conversion

### DIFF
--- a/ppx/melange_ppx.cppo.ml
+++ b/ppx/melange_ppx.cppo.ml
@@ -328,6 +328,59 @@ module Obj = struct
 end
 
 module Mapper = struct
+  let inline_literal ~loc (expression : expression) =
+    let make typ ffi = Some (typ, ffi) in
+    let string ~loc value delimiter =
+      make [%type: string]
+        (Melange_ffi.External_ffi_types.inline_string_primitive value
+           ?op:delimiter)
+    in
+    match expression.pexp_desc with
+    | Pexp_constant (Pconst_string (s, _, None)) ->
+        string ~loc s None
+    | Pexp_constant (Pconst_string (s, string_loc, Some delim)) -> (
+        match
+          Melange_ffi.Utf8_string.transform ~loc:string_loc ~delim
+            (Ocaml_common.Ast_helper.Exp.constant
+#if OCAML_VERSION >= (5, 3, 0)
+               {
+                 pconst_desc = Pconst_string (s, string_loc, Some delim);
+                 pconst_loc = string_loc;
+               }
+#else
+               (Pconst_string (s, string_loc, Some delim))
+#endif
+                 )
+            s
+        with
+        | {
+         pexp_desc =
+#if OCAML_VERSION >= (5, 3, 0)
+           Pexp_constant { pconst_desc = Pconst_string (s, _, delim); _ };
+#else
+           Pexp_constant (Pconst_string (s, _, delim));
+#endif
+         _;
+        } ->
+            string ~loc:string_loc s delim
+        | _ -> None)
+    | Pexp_constant (Pconst_integer (s, None)) ->
+        make [%type: int]
+          (Melange_ffi.External_ffi_types.inline_int_primitive
+             (Int32.of_string s))
+    | Pexp_constant (Pconst_integer (s, Some 'L')) ->
+        make [%type: int64]
+          (Melange_ffi.External_ffi_types.inline_int64_primitive
+             (Int64.of_string s))
+    | Pexp_constant (Pconst_float (s, None)) ->
+        make [%type: float]
+          (Melange_ffi.External_ffi_types.inline_float_primitive s)
+    | Pexp_construct ({ txt = Lident (("true" | "false") as value); _ }, None)
+      ->
+        make [%type: bool]
+          (Melange_ffi.External_ffi_types.inline_bool_primitive (value = "true"))
+    | _ -> None
+
   let mapper =
     let pval_ffi ~pval_name ~pval_type ~pval_loc ffi =
       {
@@ -590,125 +643,37 @@ module Mapper = struct
             in
             let pvb_expr = self#expression pvb_expr in
             let pvb_attributes = self#attributes attrs in
-            match
-              ( Ast_attributes.has_inline_payload pvb_attributes,
-                pvb_expr.pexp_desc )
-            with
-            | Some attr, Pexp_constant (Pconst_string (s, _, None)) ->
-                succeed attr pvb_attributes;
-                let loc = pvb_loc in
-                {
-                  str with
-                  pstr_desc =
-                    Pstr_primitive
-                      (pval_ffi
-                        ~pval_name
-                        ~pval_type:[%type: string]
-                        ~pval_loc:loc
-                        (Melange_ffi.External_ffi_types.inline_string_primitive s));
-                }
-            | Some attr, Pexp_constant (Pconst_string (s, loc, Some dec)) -> (
-                match
-                  Melange_ffi.Utf8_string.transform ~loc ~delim:dec
-                    (Ocaml_common.Ast_helper.Exp.constant
-#if OCAML_VERSION >= (5, 3, 0)
-                       {
-                         pconst_desc = Pconst_string (s, loc, Some dec);
-                         pconst_loc = loc;
-                       }
-#else
-                       (Pconst_string (s, loc, Some dec))
-#endif
-                         )
-                    s
-                with
-                | {
-                 pexp_desc =
-#if OCAML_VERSION >= (5, 3, 0)
-                   Pexp_constant { pconst_desc = Pconst_string (s, _, dec); _ };
-#else
-                   Pexp_constant (Pconst_string (s, _, dec));
-#endif
-                 _;
-                } ->
+            let value_item () =
+              {
+                str with
+                pstr_desc =
+                  Pstr_value
+                    ( Nonrecursive,
+                      Ast_tuple_pattern_flatten.value_bindings_mapper self
+                        [
+                          {
+                            pvb_pat;
+                            pvb_expr;
+                            pvb_attributes;
+                            pvb_loc;
+                            pvb_constraint;
+                          };
+                        ] );
+              }
+            in
+            match Ast_attributes.has_inline_payload pvb_attributes with
+            | Some attr -> (
+                match inline_literal ~loc:pvb_loc pvb_expr with
+                | Some (pval_type, ffi) ->
                     succeed attr pvb_attributes;
                     {
                       str with
                       pstr_desc =
                         Pstr_primitive
-                          (pval_ffi
-                            ~pval_name
-                            ~pval_type:[%type: string]
-                            ~pval_loc:pvb_loc
-                            (Melange_ffi.External_ffi_types.inline_string_primitive s ?op:dec)
-                   );
+                          (pval_ffi ~pval_name ~pval_type ~pval_loc:pvb_loc ffi);
                     }
-                | _ -> str)
-            | Some attr, Pexp_constant (Pconst_integer (s, None)) ->
-                let s = Int32.of_string s in
-                succeed attr pvb_attributes;
-                let loc = pvb_loc in
-                {
-                  str with
-                  pstr_desc =
-                    Pstr_primitive
-                      (pval_ffi
-                       ~pval_name
-                       ~pval_type:[%type: int]
-                       ~pval_loc:loc
-                       (Melange_ffi.External_ffi_types.inline_int_primitive s))
-                }
-            | Some attr, Pexp_constant (Pconst_integer (s, Some 'L')) ->
-                let s = Int64.of_string s in
-                succeed attr pvb_attributes;
-                let loc = pvb_loc in
-                {
-                  str with
-                  pstr_desc =
-                    Pstr_primitive
-                      (pval_ffi
-                        ~pval_name
-                        ~pval_type:[%type: int64]
-                        ~pval_loc:loc
-                        (Melange_ffi.External_ffi_types.inline_int64_primitive s))
-                }
-            | Some attr, Pexp_constant (Pconst_float (s, None)) ->
-                succeed attr pvb_attributes;
-                let loc = pvb_loc in
-                {
-                  str with
-                  pstr_desc =
-                    Pstr_primitive
-                      (pval_ffi
-                        ~pval_name
-                        ~pval_type:[%type: float]
-                        ~pval_loc:loc
-                        (Melange_ffi.External_ffi_types.inline_float_primitive s));
-                }
-            | ( Some attr,
-                Pexp_construct
-                  ({ txt = Lident (("true" | "false") as bool); _ }, None) ) ->
-                succeed attr pvb_attributes;
-                let loc = pvb_loc in
-                {
-                  str with
-                  pstr_desc =
-                    Pstr_primitive
-                      (pval_ffi
-                        ~pval_name
-                        ~pval_type:[%type: bool]
-                        ~pval_loc:loc
-                        (Melange_ffi.External_ffi_types.inline_bool_primitive (bool = "true")));
-                }
-            | _ ->
-                {
-                  str with
-                  pstr_desc =
-                    Pstr_value
-                      ( Nonrecursive,
-                        Ast_tuple_pattern_flatten.value_bindings_mapper self
-                          [ { pvb_pat; pvb_expr; pvb_attributes; pvb_loc; pvb_constraint } ] );
-                })
+                | None -> value_item ())
+            | None -> value_item ())
         | Pstr_value (r, vbs) ->
             {
               str with
@@ -816,162 +781,43 @@ module Mapper = struct
               | None -> value_desc_orig
             in
             let pval_attributes = self#attributes attrs in
+            let value_item_with_unboxable () =
+              super#signature_item
+                {
+                  sigi with
+                  psig_desc =
+                    Psig_value
+                      {
+                        value_desc with
+                        pval_attributes =
+                          Ast_attributes.unboxable_type_in_prim_decl
+                          :: pval_attributes;
+                      };
+                }
+            in
             match Ast_attributes.rs_externals pval_attributes pval_prim with
             | true -> Ast_external.handleExternalInSig self value_desc sigi
-            | false ->
-              (match Ast_attributes.has_inline_payload pval_attributes with
-              | Some
-                  ({
-                     attr_payload =
-                       PStr
-                         [ { pstr_desc = Pstr_eval ({ pexp_desc; _ }, _); _ } ];
-                     _;
-                   } as attr) -> (
-                  match pexp_desc with
-                  | Pexp_constant (Pconst_string (s, _, None)) ->
-                      succeed attr pval_attributes;
-                      {
-                        sigi with
-                        psig_desc =
-                          Psig_value
-                            {
-                              value_desc with
-                              pval_prim = Ast_external.pval_prim_default;
-                              pval_attributes = [
-                                Ast_attributes.mel_ffi
-                                  (Melange_ffi.External_ffi_types.inline_string_primitive s);
-                              ]
-                            };
-                      }
-                  | Pexp_constant (Pconst_string (s, loc, Some dec)) -> (
-                      match
-                        Melange_ffi.Utf8_string.transform ~loc ~delim:dec
-                          (Ocaml_common.Ast_helper.Exp.constant
-#if OCAML_VERSION >= (5, 3, 0)
-                             {
-                               pconst_desc = Pconst_string (s, loc, Some dec);
-                               pconst_loc = loc;
-                             }
-#else
-                             (Pconst_string (s, loc, Some dec))
-#endif
-                               )
-                          s
-                      with
-                      | {
-                       pexp_desc =
-                         Pexp_constant
-#if OCAML_VERSION >= (5, 3, 0)
-                           { pconst_desc = Pconst_string (s, _, dec); _ };
-#else
-                           (Pconst_string (s, _, dec));
-#endif
-                       _;
-                      } ->
-                          succeed attr pval_attributes;
-                          {
-                            sigi with
-                            psig_desc =
-                              Psig_value
-                                {
-                                  value_desc with
-                                  pval_attributes = [
-                                    Ast_attributes.mel_ffi
-                                      (Melange_ffi.External_ffi_types.inline_string_primitive s ?op:dec)
-                                  ];
-                                  pval_prim = Ast_external.pval_prim_default;
-                                };
-                          }
-                      | _ -> sigi)
-                  | Pexp_constant (Pconst_integer (s, None)) ->
-                      succeed attr pval_attributes;
-                      let s = Int32.of_string s in
-                      {
-                        sigi with
-                        psig_desc =
-                          Psig_value
-                            {
-                              value_desc with
-                              pval_attributes = [
-                                Ast_attributes.mel_ffi
-                                  (Melange_ffi.External_ffi_types.inline_int_primitive s)
-                              ];
-                              pval_prim = Ast_external.pval_prim_default;
-                            };
-                      }
-                  | Pexp_constant (Pconst_integer (s, Some 'L')) ->
-                      let s = Int64.of_string s in
-                      succeed attr pval_attributes;
-                      {
-                        sigi with
-                        psig_desc =
-                          Psig_value
-                            {
-                              value_desc with
-                              pval_attributes = [
-                                Ast_attributes.mel_ffi
-                                  (Melange_ffi.External_ffi_types.inline_int64_primitive s)
-                              ];
-                              pval_prim = Ast_external.pval_prim_default;
-                            };
-                      }
-                  | Pexp_constant (Pconst_float (s, None)) ->
-                      succeed attr pval_attributes;
-                      {
-                        sigi with
-                        psig_desc =
-                          Psig_value
-                            {
-                              value_desc with
-                              pval_attributes = [
-                                  Ast_attributes.mel_ffi
-                                    (Melange_ffi.External_ffi_types.inline_float_primitive s)
-                              ];
-                              pval_prim = Ast_external.pval_prim_default;
-                            };
-                      }
-                  | Pexp_construct
-                      ({ txt = Lident (("true" | "false") as txt); _ }, None) ->
-                      succeed attr pval_attributes;
-                      {
-                        sigi with
-                        psig_desc =
-                          Psig_value
-                            {
-                              value_desc with
-                              pval_attributes = [
-                                Ast_attributes.mel_ffi
-                                  (Melange_ffi.External_ffi_types.inline_bool_primitive
-                                    (txt = "true"))];
-                              pval_prim = Ast_external.pval_prim_default;
-                            };
-                      }
-                  | _ ->
-                      super#signature_item
+            | false -> (
+                match Ast_attributes.has_inline_payload pval_attributes with
+                | Some ({ attr_payload; _ } as attr) -> (
+                    match
+                      Ast_payload.as_expression attr_payload
+                      |> Option.bind ~f:(inline_literal ~loc:pval_loc)
+                    with
+                    | Some (_, ffi) ->
+                        succeed attr pval_attributes;
                         {
                           sigi with
                           psig_desc =
                             Psig_value
                               {
                                 value_desc with
-                                pval_attributes =
-                                  Ast_attributes.unboxable_type_in_prim_decl
-                                  :: pval_attributes;
+                                pval_prim = Ast_external.pval_prim_default;
+                                pval_attributes = [ Ast_attributes.mel_ffi ffi ];
                               };
-                        })
-              | Some _ | None ->
-                  super#signature_item
-                    {
-                      sigi with
-                      psig_desc =
-                        Psig_value
-                          {
-                            value_desc with
-                            pval_attributes =
-                              Ast_attributes.unboxable_type_in_prim_decl
-                              :: pval_attributes;
-                          };
-                    }))
+                        }
+                    | None -> value_item_with_unboxable ())
+                | None -> value_item_with_unboxable ()))
         | Psig_attribute
             ({
                attr_name =


### PR DESCRIPTION
Shares mel.inline literal conversion and validation between structure and signature rewriting.

Independent of #1872.