### PR TITLE
refactor(belt): share mutable queue pop mutation

### DIFF
--- a/belt/belt_MutableQueue.ml
+++ b/belt/belt_MutableQueue.ml
@@ -59,48 +59,23 @@ let peekUndefined q =
 let peekExn q =
   match q.first with None -> raise Not_found | Some v -> v.content
 
-let pop q =
-  match q.first with
-  | None -> None
-  | Some x ->
-      let next = x.next in
-      if next = None then (
-        (* only one element*)
-        clear q;
-        Some x.content)
-      else (
-        q.length <- q.length - 1;
-        q.first <- next;
-        Some x.content)
+let popAux q x =
+  let next = x.next in
+  if next = None then clear q
+  else (
+    q.length <- q.length - 1;
+    q.first <- next);
+  x.content
+
+let pop q = match q.first with None -> None | Some x -> Some (popAux q x)
 
 let popExn q =
-  (* TO fix *)
-  match q.first with
-  | None -> raise Not_found
-  | Some x ->
-      let next = x.next in
-      if next = None then (
-        (* only one element*)
-        clear q;
-        x.content)
-      else (
-        q.length <- q.length - 1;
-        q.first <- next;
-        x.content)
+  match q.first with None -> raise Not_found | Some x -> popAux q x
 
 let popUndefined q =
   match q.first with
   | None -> Js.undefined
-  | Some x ->
-      let next = x.next in
-      if next = None then (
-        (* only one element*)
-        clear q;
-        Js.Undefined.return x.content)
-      else (
-        q.length <- q.length - 1;
-        q.first <- next;
-        Js.Undefined.return x.content)
+  | Some x -> Js.Undefined.return (popAux q x)
 
 let rec copyAux qRes prev cell =
   match cell with

--- a/node_modules/melange.belt/belt_MutableQueue.js
+++ b/node_modules/melange.belt/belt_MutableQueue.js
@@ -63,36 +63,29 @@ function peekExn(q) {
     });
 }
 
-function pop(q) {
-  const x = q.first;
-  if (x === undefined) {
-    return;
-  }
-  const x$1 = Caml_option.valFromOption(x);
-  const next = x$1.next;
+function popAux(q, x) {
+  const next = x.next;
   if (next === undefined) {
     clear(q);
-    return Caml_option.some(x$1.content);
   } else {
     q.length = q.length - 1 | 0;
     q.first = next;
-    return Caml_option.some(x$1.content);
   }
+  return x.content;
+}
+
+function pop(q) {
+  const x = q.first;
+  if (x !== undefined) {
+    return Caml_option.some(popAux(q, Caml_option.valFromOption(x)));
+  }
+
 }
 
 function popExn(q) {
   const x = q.first;
   if (x !== undefined) {
-    const x$1 = Caml_option.valFromOption(x);
-    const next = x$1.next;
-    if (next === undefined) {
-      clear(q);
-      return x$1.content;
-    } else {
-      q.length = q.length - 1 | 0;
-      q.first = next;
-      return x$1.content;
-    }
+    return popAux(q, Caml_option.valFromOption(x));
   }
   throw new Caml_js_exceptions.MelangeError(Stdlib.Not_found, {
       MEL_EXN_ID: Stdlib.Not_found
@@ -101,19 +94,10 @@ function popExn(q) {
 
 function popUndefined(q) {
   const x = q.first;
-  if (x === undefined) {
-    return;
+  if (x !== undefined) {
+    return popAux(q, Caml_option.valFromOption(x));
   }
-  const x$1 = Caml_option.valFromOption(x);
-  const next = x$1.next;
-  if (next === undefined) {
-    clear(q);
-    return x$1.content;
-  } else {
-    q.length = q.length - 1 | 0;
-    q.first = next;
-    return x$1.content;
-  }
+
 }
 
 function copy(q) {


### PR DESCRIPTION
Shares the non-empty state transition used by Belt.MutableQueue pop variants.

No related issue.