### PR TITLE
refactor(core): share polyvariant constant switch builder

### DIFF
--- a/jscomp/core/polyvar_pattern_match.cppo.ml
+++ b/jscomp/core/polyvar_pattern_match.cppo.ml
@@ -106,7 +106,7 @@ let or_list (arg : lam) (hash_names : (int * string) list) =
               Loc_unknown ))
   | _ -> assert false
 
-let make_test_sequence_variant_constant (fail : lam option) (arg : lam)
+let build_variant_constant_switch (fail : lam option) (arg : lam)
     (int_lambda_list : (int * (string * lam)) list) : lam =
   let int_lambda_list : ((int * string) list * lam) list =
     convert int_lambda_list
@@ -119,18 +119,13 @@ let make_test_sequence_variant_constant (fail : lam option) (arg : lam)
         Lifthenelse (predicate, act1, acc))
   | [], None -> assert false
 
+let make_test_sequence_variant_constant = build_variant_constant_switch
+
 let call_switcher_variant_constant (_loc : Debuginfo.Scoped_location.t)
     (fail : lam option) (arg : lam)
     (int_lambda_list : (int * (string * lam)) list)
     (_names : Lambda.switch_names option) =
-  let int_lambda_list = convert int_lambda_list in
-  match (int_lambda_list, fail) with
-  | (_, act) :: rest, None | rest, Some act ->
-      List.fold_right rest ~init:act
-        ~f:(fun (hash_names, act1) (acc : lam) ->
-          let predicate = or_list arg hash_names in
-          Lifthenelse (predicate, act1, acc))
-  | [], None -> assert false
+  build_variant_constant_switch fail arg int_lambda_list
 
 let call_switcher_variant_constr (loc : Lambda.scoped_location)
     (fail : lam option) (arg : lam) int_lambda_list


### PR DESCRIPTION
Shares polymorphic-variant constant switch construction between matching adapters.

No related issue.