### PR TITLE
refactor(runtime): share float array initialization

### DIFF
--- a/jscomp/runtime/caml_array.ml
+++ b/jscomp/runtime/caml_array.ml
@@ -79,12 +79,7 @@ let make len init =
   done;
   b
 
-let make_float len =
-  let b = Caml_array_extern.new_uninitialized len in
-  for i = 0 to len - 1 do
-    b.!(i) <- 0.
-  done;
-  b
+let make_float len = make len 0.
 
 let blit a1 i1 a2 i2 len =
   if i2 <= i1 then

--- a/node_modules/melange.js/caml_array.js
+++ b/node_modules/melange.js/caml_array.js
@@ -86,11 +86,7 @@ function make(len, init) {
 }
 
 function make_float(len) {
-  const b = new Array(len);
-  for (let i = 0; i < len; ++i) {
-    b[i] = 0;
-  }
-  return b;
+  return make(len, 0);
 }
 
 function blit(a1, i1, a2, i2, len) {

--- a/node_modules/melange.js/caml_array.mjs
+++ b/node_modules/melange.js/caml_array.mjs
@@ -85,11 +85,7 @@ function make(len, init) {
 }
 
 function make_float(len) {
-  const b = new Array(len);
-  for (let i = 0; i < len; ++i) {
-    b[i] = 0;
-  }
-  return b;
+  return make(len, 0);
 }
 
 function blit(a1, i1, a2, i2, len) {


### PR DESCRIPTION
Reuses the generic array fill loop for float array initialization.

No related issue.