### PR TITLE
refactor(core): share binary AST encoding

### DIFF
--- a/jscomp/core/cmd_ppx_apply.ml
+++ b/jscomp/core/cmd_ppx_apply.ml
@@ -2,11 +2,7 @@ open Import
 
 let write_ast (type a) (kind : a Ml_binary.kind) fn (ast : a) =
   Io.write_filev_exn fn
-    [
-      Ml_binary.magic_of_kind kind;
-      Marshal.to_string (!Location.input_name : string) [];
-      Marshal.to_string (ast : a) [];
-    ]
+    (Ml_binary.to_strings kind ~input_name:!Location.input_name ast)
 
 let temp_ppx_file () =
   Filename.temp_file "ppx" (Filename.basename !Location.input_name)

--- a/jscomp/core/js_implementation.cppo.ml
+++ b/jscomp/core/js_implementation.cppo.ml
@@ -69,10 +69,8 @@ let output_prefix ?(f = Filename.remove_extension) name =
 
 let after_parsing_sig ppf fname ast =
   let outputprefix = output_prefix fname in
-  if !Js_config.as_pp then (
-    output_string stdout Config.ast_intf_magic_number;
-    output_value stdout (!Location.input_name : string);
-    output_value stdout ast);
+  if !Js_config.as_pp then
+    Ml_binary.output Mli stdout ~input_name:!Location.input_name ast;
   if !Js_config.syntax_only then Warnings.check_fatal ()
   else (
     Lam_compile_env.reset ();
@@ -174,10 +172,8 @@ let after_parsing_impl ppf fname (ast : Parsetree.structure) =
   Js_config.all_module_aliases :=
     (not (Sys.file_exists sourceintf)) && all_module_alias ast;
   let ast = if !Js_config.no_export then no_export ast else ast in
-  if !Js_config.as_pp then (
-    output_string stdout Config.ast_impl_magic_number;
-    output_value stdout (!Location.input_name : string);
-    output_value stdout ast);
+  if !Js_config.as_pp then
+    Ml_binary.output Ml stdout ~input_name:!Location.input_name ast;
   if !Js_config.syntax_only then Warnings.check_fatal ()
   else (
     let modulename = module_name outputprefix in

--- a/jscomp/core/ml_binary.ml
+++ b/jscomp/core/ml_binary.ml
@@ -29,3 +29,13 @@ type _ kind = Ml : Parsetree.structure kind | Mli : Parsetree.signature kind
 let magic_of_kind : type a. a kind -> string = function
   | Ml -> Config.ast_impl_magic_number
   | Mli -> Config.ast_intf_magic_number
+
+let to_strings (type a) (kind : a kind) ~input_name (ast : a) =
+  [
+    magic_of_kind kind;
+    Marshal.to_string (input_name : string) [];
+    Marshal.to_string ast [];
+  ]
+
+let output kind channel ~input_name ast =
+  List.iter ~f:(output_string channel) (to_strings kind ~input_name ast)

--- a/jscomp/core/ml_binary.mli
+++ b/jscomp/core/ml_binary.mli
@@ -25,3 +25,5 @@
 type _ kind = Ml : Parsetree.structure kind | Mli : Parsetree.signature kind
 
 val magic_of_kind : 'a kind -> string
+val to_strings : 'a kind -> input_name:string -> 'a -> string list
+val output : 'a kind -> out_channel -> input_name:string -> 'a -> unit


### PR DESCRIPTION
Centralizes the compiler binary-AST wire format used for PPX files and --as-pp output. This is independent of the other helper extractions; the emitted implementation and interface bytes remain unchanged.