### PR TITLE
refactor(stdlib): share queue removal transition

### DIFF
--- a/jscomp/stdlib/queue.ml
+++ b/jscomp/stdlib/queue.ml
@@ -68,26 +68,25 @@ let peek_opt q =
 let top =
   peek
 
+let[@inline] remove_first q next =
+  match next with
+  | Nil -> clear q
+  | Cons _ ->
+    q.length <- q.length - 1;
+    q.first <- next
+
 let take q =
   match q.first with
   | Nil -> raise Empty
-  | Cons { content; next = Nil } ->
-    clear q;
-    content
   | Cons { content; next } ->
-    q.length <- q.length - 1;
-    q.first <- next;
+    remove_first q next;
     content
 
 let take_opt q =
   match q.first with
   | Nil -> None
-  | Cons { content; next = Nil } ->
-    clear q;
-    Some content
   | Cons { content; next } ->
-    q.length <- q.length - 1;
-    q.first <- next;
+    remove_first q next;
     Some content
 
 let pop =
@@ -96,11 +95,7 @@ let pop =
 let drop q =
   match q.first with
   | Nil -> raise Empty
-  | Cons { content = _; next = Nil } ->
-    clear q
-  | Cons { content = _; next } ->
-    q.length <- q.length - 1;
-    q.first <- next
+  | Cons { content = _; next } -> remove_first q next
 
 let copy =
   let rec copy q_res prev cell =

--- a/node_modules/melange/queue.js
+++ b/node_modules/melange/queue.js
@@ -67,16 +67,14 @@ function take(q) {
         MEL_EXN_ID: Empty
       });
   }
-  const content = match.content;
-  const match$1 = match.next;
-  if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
-    clear(q);
-    return content;
-  }
   const next = match.next;
-  q.length = q.length - 1 | 0;
-  q.first = next;
-  return content;
+  if (/* tag */ typeof next !== "object" && typeof next !== "function") {
+    clear(q);
+  } else {
+    q.length = q.length - 1 | 0;
+    q.first = next;
+  }
+  return match.content;
 }
 
 function take_opt(q) {
@@ -84,16 +82,14 @@ function take_opt(q) {
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     return;
   }
-  const content = match.content;
-  const match$1 = match.next;
-  if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
-    clear(q);
-    return Caml_option.some(content);
-  }
   const next = match.next;
-  q.length = q.length - 1 | 0;
-  q.first = next;
-  return Caml_option.some(content);
+  if (/* tag */ typeof next !== "object" && typeof next !== "function") {
+    clear(q);
+  } else {
+    q.length = q.length - 1 | 0;
+    q.first = next;
+  }
+  return Caml_option.some(match.content);
 }
 
 function drop(q) {
@@ -103,11 +99,10 @@ function drop(q) {
         MEL_EXN_ID: Empty
       });
   }
-  const match$1 = match.next;
-  if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
+  const next = match.next;
+  if (/* tag */ typeof next !== "object" && typeof next !== "function") {
     return clear(q);
   }
-  const next = match.next;
   q.length = q.length - 1 | 0;
   q.first = next;
 }

--- a/node_modules/melange/queue.mjs
+++ b/node_modules/melange/queue.mjs
@@ -66,16 +66,14 @@ function take(q) {
         MEL_EXN_ID: Empty
       });
   }
-  const content = match.content;
-  const match$1 = match.next;
-  if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
-    clear(q);
-    return content;
-  }
   const next = match.next;
-  q.length = q.length - 1 | 0;
-  q.first = next;
-  return content;
+  if (/* tag */ typeof next !== "object" && typeof next !== "function") {
+    clear(q);
+  } else {
+    q.length = q.length - 1 | 0;
+    q.first = next;
+  }
+  return match.content;
 }
 
 function take_opt(q) {
@@ -83,16 +81,14 @@ function take_opt(q) {
   if (/* tag */ typeof match !== "object" && typeof match !== "function") {
     return;
   }
-  const content = match.content;
-  const match$1 = match.next;
-  if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
-    clear(q);
-    return Caml_option.some(content);
-  }
   const next = match.next;
-  q.length = q.length - 1 | 0;
-  q.first = next;
-  return Caml_option.some(content);
+  if (/* tag */ typeof next !== "object" && typeof next !== "function") {
+    clear(q);
+  } else {
+    q.length = q.length - 1 | 0;
+    q.first = next;
+  }
+  return Caml_option.some(match.content);
 }
 
 function drop(q) {
@@ -102,11 +98,10 @@ function drop(q) {
         MEL_EXN_ID: Empty
       });
   }
-  const match$1 = match.next;
-  if (/* tag */ typeof match$1 !== "object" && typeof match$1 !== "function") {
+  const next = match.next;
+  if (/* tag */ typeof next !== "object" && typeof next !== "function") {
     return clear(q);
   }
-  const next = match.next;
   q.length = q.length - 1 | 0;
   q.first = next;
 }


### PR DESCRIPTION
Centralizes the nonempty queue removal transition shared by `take`, `take_opt`, and `drop`.

No related issue.