### PR TITLE
refactor(core): rename Lam_iter.inner_exists

### DIFF
--- a/jscomp/core/lam_compile_env.ml
+++ b/jscomp/core/lam_compile_env.ml
@@ -166,7 +166,7 @@ let rec lambda_is_relocatable (lam : Lam.t) =
       false
   | _ ->
       not
-        (Lam_iter.inner_exists lam ~f:(fun lam ->
+        (Lam_iter.exists lam ~f:(fun lam ->
              not (lambda_is_relocatable lam)))
 
 let get_dependency_info_from_cmj (module_id : Lam_module_ident.t) :

--- a/jscomp/core/lam_exit_code.ml
+++ b/jscomp/core/lam_exit_code.ml
@@ -26,6 +26,6 @@ let rec has_exit_code lam ~exits =
   match lam with
   | Lam.Lfunction _ -> false (* static exit can not cross function boundary *)
   | Lstaticraise (p, _) when exits p -> true
-  | lam -> Lam_iter.inner_exists lam ~f:(has_exit_code ~exits)
+  | lam -> Lam_iter.exists lam ~f:(has_exit_code ~exits)
 
 let has_exit lam = has_exit_code lam ~exits:(Fun.const true)

--- a/jscomp/core/lam_iter.ml
+++ b/jscomp/core/lam_iter.ml
@@ -24,7 +24,7 @@
 
 open Import
 
-let inner_exists (l : Lam.t) ~(f : Lam.t -> bool) =
+let exists (l : Lam.t) ~(f : Lam.t -> bool) =
   match l with
   | Lvar _ | Lmutvar _ | Lglobal_module _ | Lconst _ -> false
   | Lapply { ap_func; ap_args; ap_info = _ } ->
@@ -67,6 +67,6 @@ let exists_ident (lam : Lam.t) ~(f : Ident.t -> bool) =
     match lam with
     | Lvar id | Lmutvar id -> f id
     | Lassign (id, expression) -> f id || loop expression
-    | lam -> inner_exists lam ~f:loop
+    | lam -> exists lam ~f:loop
   in
   loop lam

--- a/jscomp/core/lam_iter.mli
+++ b/jscomp/core/lam_iter.mli
@@ -22,5 +22,5 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-val inner_exists : Lam.t -> f:(Lam.t -> bool) -> bool
+val exists : Lam.t -> f:(Lam.t -> bool) -> bool
 val exists_ident : Lam.t -> f:(Ident.t -> bool) -> bool


### PR DESCRIPTION
Renames `Lam_iter.inner_exists` to `Lam_iter.exists` and updates every caller.

Follow-up to #1865.