### PR TITLE
refactor(melstd): add Nonempty_list operations

### DIFF
--- a/jscomp/melstd/nonempty_list.ml
+++ b/jscomp/melstd/nonempty_list.ml
@@ -33,3 +33,25 @@ let to_list (x :: xs) = List.cons x xs
 let map (x :: xs) ~f =
   let x = f x in
   x :: List.map xs ~f
+
+let iter (x :: xs) ~f =
+  f x;
+  List.iter xs ~f
+
+let to_list_rev_map (x :: xs) ~f =
+  let x = f x in
+  let init = List.cons x [] in
+  List.fold_left xs ~init ~f:(fun acc x ->
+      let x = f x in
+      List.cons x acc)
+
+let mapi (x :: xs) ~f =
+  let x = f 0 x in
+  x :: List.mapi xs ~f:(fun i x -> f (i + 1) x)
+
+let map_last (x :: xs) ~f =
+  match xs with
+  | [] -> f true x :: []
+  | _ ->
+      let x = f false x in
+      x :: List.map_last xs ~f

--- a/jscomp/melstd/nonempty_list.mli
+++ b/jscomp/melstd/nonempty_list.mli
@@ -30,3 +30,10 @@ val of_list : 'a list -> 'a t option
 val of_list_exn : 'a list -> 'a t
 val to_list : 'a t -> 'a list
 val map : 'a t -> f:('a -> 'b) -> 'b t
+val iter : 'a t -> f:('a -> unit) -> unit
+val to_list_rev_map : 'a t -> f:('a -> 'b) -> 'b list
+val mapi : 'a t -> f:(int -> 'a -> 'b) -> 'b t
+
+val map_last : 'a t -> f:(bool -> 'a -> 'b) -> 'b t
+(** [map_last xs ~f] passes [true] to [f] for the last element and [false] for
+    every other element. *)

--- a/test/unit-tests/test_nonempty_list.ml
+++ b/test/unit-tests/test_nonempty_list.ml
@@ -20,4 +20,78 @@ let test_map () =
   check_nonempty_int "singleton" [ 8 ]
     (Nonempty_list.map (nonempty [ 4 ]) ~f:(fun x -> x * 2))
 
-let suite = [ ("map", `Quick, test_map) ]
+let test_iter () =
+  let visited = ref [] in
+  Nonempty_list.iter
+    (nonempty [ 1; 2; 3 ])
+    ~f:(fun x -> visited := x :: !visited);
+  check_int_list "callback order" [ 1; 2; 3 ] (List.rev !visited);
+  visited := [];
+  Nonempty_list.iter (nonempty [ 4 ]) ~f:(fun x -> visited := x :: !visited);
+  check_int_list "singleton" [ 4 ] (List.rev !visited)
+
+let test_to_list_rev_map () =
+  let visited = ref [] in
+  let result =
+    Nonempty_list.to_list_rev_map
+      (nonempty [ 1; 2; 3 ])
+      ~f:(fun x ->
+        visited := x :: !visited;
+        x * 2)
+  in
+  check_int_list "values" [ 6; 4; 2 ] result;
+  check_int_list "callback order" [ 1; 2; 3 ] (List.rev !visited);
+  check_int_list "singleton" [ 8 ]
+    (Nonempty_list.to_list_rev_map (nonempty [ 4 ]) ~f:(fun x -> x * 2))
+
+let test_mapi () =
+  let visited = ref [] in
+  let result =
+    Nonempty_list.mapi
+      (nonempty [ 1; 2; 3 ])
+      ~f:(fun i x ->
+        visited := (i, x) :: !visited;
+        (i * 10) + x)
+  in
+  check_nonempty_int "values" [ 1; 12; 23 ] result;
+  Alcotest.(check (list (pair int int)))
+    "callback order"
+    [ (0, 1); (1, 2); (2, 3) ]
+    (List.rev !visited);
+  check_nonempty_int "singleton" [ 4 ]
+    (Nonempty_list.mapi (nonempty [ 4 ]) ~f:(fun i x -> i + x))
+
+let test_map_last () =
+  let visited = ref [] in
+  let result =
+    Nonempty_list.map_last
+      (nonempty [ 1; 2; 3 ])
+      ~f:(fun is_last x ->
+        visited := (is_last, x) :: !visited;
+        if is_last then x * 10 else x)
+  in
+  check_nonempty_int "values" [ 1; 2; 30 ] result;
+  Alcotest.(check (list (pair bool int)))
+    "callback order"
+    [ (false, 1); (false, 2); (true, 3) ]
+    (List.rev !visited);
+  visited := [];
+  let result =
+    Nonempty_list.map_last (nonempty [ 4 ]) ~f:(fun is_last x ->
+        visited := (is_last, x) :: !visited;
+        if is_last then x * 10 else x)
+  in
+  check_nonempty_int "singleton value" [ 40 ] result;
+  Alcotest.(check (list (pair bool int)))
+    "singleton callback"
+    [ (true, 4) ]
+    (List.rev !visited)
+
+let suite =
+  [
+    ("map", `Quick, test_map);
+    ("iter", `Quick, test_iter);
+    ("to_list_rev_map", `Quick, test_to_list_rev_map);
+    ("mapi", `Quick, test_mapi);
+    ("map_last", `Quick, test_map_last);
+  ]


### PR DESCRIPTION
Adds the Nonempty_list operations used by the follow-up refactors.

Follows #1892. Required by #1887, #1889, #1890, and #1891.