### PR TITLE
refactor(melstd): make stable groups nonempty

### DIFF
--- a/jscomp/core/lam_compile.ml
+++ b/jscomp/core/lam_compile.ml
@@ -538,8 +538,9 @@ and compile_general_cases :
     J.block =
   let group_apply cases ~f:callback =
     List.concat_map
-      ~f:(fun group -> List.map_last group ~f:callback)
-      (List.stable_group cases ~equal:(fun (_, lam) (_, lam1) ->
+      ~f:(fun group ->
+        Nonempty_list.map_last group ~f:callback |> Nonempty_list.to_list)
+      (Nonempty_list.stable_group cases ~equal:(fun (_, lam) (_, lam1) ->
            Lam.eq_approx lam lam1))
   in
   let morph_declare_to_assign (cxt : Lam_compile_context.t) k =

--- a/jscomp/melstd/list.ml
+++ b/jscomp/melstd/list.ml
@@ -359,19 +359,6 @@ let rec length_larger_than_n xs ys n =
   | _ :: xs, _ :: ys -> length_larger_than_n xs ys n
   | [], _ -> false
 
-let stable_group =
-  let rec group (eq : 'a -> 'a -> bool) lst =
-    match lst with [] -> [] | x :: xs -> aux eq x (group eq xs)
-  and aux eq (x : 'a) (xss : 'a list list) : 'a list list =
-    match xss with
-    | [] -> [ [ x ] ]
-    | (y0 :: _ as y) :: ys ->
-        (* cannot be empty *)
-        if eq x y0 then (x :: y) :: ys else y :: aux eq x ys
-    | _ :: _ -> assert false
-  in
-  fun lst ~equal -> group equal lst |> rev
-
 let rec rev_iter l ~f =
   match l with
   | [] -> ()

--- a/jscomp/melstd/list.mli
+++ b/jscomp/melstd/list.mli
@@ -54,22 +54,6 @@ val length_ge : 'a list -> int -> bool
    TODO: input checking *)
 
 val length_larger_than_n : 'a list -> 'a list -> int -> bool
-
-val stable_group : 'a list -> equal:('a -> 'a -> bool) -> 'a list list
-(**
-    [stable_group eq lst]
-    Example:
-    Input:
-   {[
-     stable_group (=) [1;2;3;4;3]
-   ]}
-    Output:
-   {[
-     [[1];[2];[4];[3;3]]
-   ]}
-    TODO: this is O(n^2) behavior
-    which could be improved later *)
-
 val rev_iter : 'a list -> f:('a -> unit) -> unit
 
 val for_all2_no_exn : 'a list -> 'b list -> f:('a -> 'b -> bool) -> bool

--- a/jscomp/melstd/nonempty_list.ml
+++ b/jscomp/melstd/nonempty_list.ml
@@ -55,3 +55,20 @@ let map_last (x :: xs) ~f =
   | _ ->
       let x = f false x in
       x :: List.map_last xs ~f
+
+let stable_group =
+  let rec group (equal : 'a -> 'a -> bool) = function
+    | [] -> []
+    | x :: xs -> aux equal x (group equal xs)
+  and aux equal (x : 'a) (groups : 'a t list) : 'a t list =
+    match groups with
+    | [] ->
+        let group = x :: [] in
+        List.cons group []
+    | (y0 :: yrest as group) :: groups ->
+        if equal x y0 then
+          let group = x :: List.cons y0 yrest in
+          List.cons group groups
+        else List.cons group (aux equal x groups)
+  in
+  fun xs ~equal -> List.rev (group equal xs)

--- a/jscomp/melstd/nonempty_list.mli
+++ b/jscomp/melstd/nonempty_list.mli
@@ -37,3 +37,7 @@ val mapi : 'a t -> f:(int -> 'a -> 'b) -> 'b t
 val map_last : 'a t -> f:(bool -> 'a -> 'b) -> 'b t
 (** [map_last xs ~f] passes [true] to [f] for the last element and [false] for
     every other element. *)
+
+val stable_group : 'a list -> equal:('a -> 'a -> bool) -> 'a t list
+(** [stable_group xs ~equal] groups equal elements into nonempty lists while
+    preserving their order within each group. *)

--- a/test/unit-tests/test_list.ml
+++ b/test/unit-tests/test_list.ml
@@ -20,12 +20,6 @@ let test_concat_map () =
     (List.concat_map ~f:(fun x -> [ x; succ x ]) [ 1; 2; 3 ])
     [ 1; 2; 2; 3; 3; 4 ]
 
-let test_stable_group () =
-  Alcotest.(check (list (list int)))
-    __LOC__
-    (List.stable_group [ 1; 2; 3; 4; 3 ] ~equal:( = ))
-    [ [ 1 ]; [ 2 ]; [ 4 ]; [ 3; 3 ] ]
-
 let test_map_last () =
   let f b _v = if b then 1 else 0 in
   Alcotest.(check (list int)) __LOC__ (List.map_last [] ~f) [];
@@ -104,7 +98,6 @@ let test_length_ge () =
 let suite =
   [
     ("concat_map", `Quick, test_concat_map);
-    ("stable_group", `Quick, test_stable_group);
     ("map_last", `Quick, test_map_last);
     ("map", `Quick, test_map);
     ("append", `Quick, test_append);

--- a/test/unit-tests/test_nonempty_list.ml
+++ b/test/unit-tests/test_nonempty_list.ml
@@ -87,6 +87,30 @@ let test_map_last () =
     [ (true, 4) ]
     (List.rev !visited)
 
+let test_stable_group () =
+  let stable_group xs =
+    Nonempty_list.stable_group xs ~equal:( = )
+    |> List.map ~f:Nonempty_list.to_list
+  in
+  let check input expected =
+    Alcotest.(check (list (list int))) __LOC__ expected (stable_group input)
+  in
+  check [] [];
+  check [ 1 ] [ [ 1 ] ];
+  check [ 1; 1; 1 ] [ [ 1; 1; 1 ] ];
+  check [ 1; 2; 3 ] [ [ 1 ]; [ 2 ]; [ 3 ] ];
+  check [ 1; 2; 3; 4; 3 ] [ [ 1 ]; [ 2 ]; [ 4 ]; [ 3; 3 ] ];
+  let grouped =
+    Nonempty_list.stable_group
+      [ (1, "first"); (2, "middle"); (1, "last") ]
+      ~equal:(fun (x, _) (y, _) -> x = y)
+    |> List.map ~f:Nonempty_list.to_list
+  in
+  Alcotest.(check (list (list (pair int string))))
+    "preserves order within groups"
+    [ [ (2, "middle") ]; [ (1, "first"); (1, "last") ] ]
+    grouped
+
 let suite =
   [
     ("map", `Quick, test_map);
@@ -94,4 +118,5 @@ let suite =
     ("to_list_rev_map", `Quick, test_to_list_rev_map);
     ("mapi", `Quick, test_mapi);
     ("map_last", `Quick, test_map_last);
+    ("stable_group", `Quick, test_stable_group);
   ]


### PR DESCRIPTION
Moves stable_group from List to Nonempty_list, representing every result group as Nonempty_list.t, and updates its compiler consumer.

Follows #1885.
