### PR TITLE
fix(melstd): preserve Nonempty_list.map order

### DIFF
--- a/jscomp/melstd/nonempty_list.ml
+++ b/jscomp/melstd/nonempty_list.ml
@@ -29,4 +29,7 @@ let tl (_ :: xs) = xs
 let of_list = function [] -> None | x :: xs -> Some (x :: xs)
 let of_list_exn = function [] -> assert false | x :: xs -> x :: xs
 let to_list (x :: xs) = List.cons x xs
-let map (x :: xs) ~f = f x :: List.map xs ~f
+
+let map (x :: xs) ~f =
+  let x = f x in
+  x :: List.map xs ~f

--- a/test/unit-tests/melange_tests.ml
+++ b/test/unit-tests/melange_tests.ml
@@ -6,6 +6,7 @@ let () =
       ("vec", Test_vec.suite);
       ("path", Test_path.suite);
       ("list", Test_list.suite);
+      ("nonempty list", Test_nonempty_list.suite);
       ("string", Test_string.suite);
       ("filename", Test_filename.suite);
       ("modulename", Test_modulename.suite);

--- a/test/unit-tests/test_nonempty_list.ml
+++ b/test/unit-tests/test_nonempty_list.ml
@@ -1,0 +1,23 @@
+let nonempty = Nonempty_list.of_list_exn
+
+let check_int_list message expected actual =
+  Alcotest.(check (list int)) message expected actual
+
+let check_nonempty_int message expected actual =
+  check_int_list message expected (Nonempty_list.to_list actual)
+
+let test_map () =
+  let visited = ref [] in
+  let result =
+    Nonempty_list.map
+      (nonempty [ 1; 2; 3 ])
+      ~f:(fun x ->
+        visited := x :: !visited;
+        x * 2)
+  in
+  check_nonempty_int "values" [ 2; 4; 6 ] result;
+  check_int_list "callback order" [ 1; 2; 3 ] (List.rev !visited);
+  check_nonempty_int "singleton" [ 8 ]
+    (Nonempty_list.map (nonempty [ 4 ]) ~f:(fun x -> x * 2))
+
+let suite = [ ("map", `Quick, test_map) ]


### PR DESCRIPTION
Ensures Nonempty_list.map evaluates its callback from head to tail.

Split from #1885.